### PR TITLE
support both import paths that pycryptodome might use

### DIFF
--- a/UDPLogServer/server.py
+++ b/UDPLogServer/server.py
@@ -6,7 +6,11 @@ import ipaddress
 import json
 import zlib
 import hashlib
-from Cryptodome.Cipher import AES
+
+try:
+    from Cryptodome.Cipher import AES  # pycryptodomex
+except ImportError:
+    from Crypto.Cipher import AES  # pycryptodome
 
 def eprint(*args, **kwargs):
     print(*args, file=sys.stderr, **kwargs)


### PR DESCRIPTION
Two variants of pycryptodome exist, one installs to "Crypto" and the other installs to "Cryptodome". I guess the latter is probably used to avoid problems when coexisting with the old pycrypto library?

This change allows to use the script with the pycryptodome package in Arch Linux (_community/python-pycryptodome_) for example.