### PR TITLE
Add hide keyboard function in Log page.

### DIFF
--- a/Monal/Classes/LogViewController.h
+++ b/Monal/Classes/LogViewController.h
@@ -8,7 +8,7 @@
 
 #import <UIKit/UIKit.h>
 
-@interface LogViewController : UIViewController
+@interface LogViewController : UIViewController<UITextFieldDelegate>
 
 @property  (nonatomic,weak) IBOutlet UITextView *logView;
 

--- a/Monal/Classes/LogViewController.m
+++ b/Monal/Classes/LogViewController.m
@@ -37,6 +37,13 @@ DDLogFileInfo* _logInfo;
 {
     [super viewDidLoad];
     // Do any additional setup after loading the view from its nib.
+    
+    self.logUDPHostname.delegate = self;
+    self.logUDPPort.delegate = self;
+    self.logUDPAESKey.delegate = self;
+    
+    UITapGestureRecognizer *tapGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:@selector(hideKeyboard)];
+    [self.view addGestureRecognizer:tapGestureRecognizer];    
 }
 
 -(void) viewDidAppear:(BOOL)animated
@@ -115,4 +122,13 @@ DDLogFileInfo* _logInfo;
     // Dispose of any resources that can be recreated.
 }
 
+-(BOOL)textFieldShouldReturn:(UITextField *)textField
+{
+    [textField resignFirstResponder];
+    return YES;
+}
+
+-(void)hideKeyboard{
+    [self.view endEditing:YES];
+}
 @end


### PR DESCRIPTION
As title 

I found I can't hide keyboard in "Settings"-> "Log" page after I key in data.

Add hide keyboard function in Log page.