### PR TITLE
Removed empty chat bubble when sharing without comment

### DIFF
--- a/Monal/shareSheet-iOS/ShareViewController.m
+++ b/Monal/shareSheet-iOS/ShareViewController.m
@@ -111,7 +111,7 @@ const u_int32_t MagicMapKitItem = 1 << 2;
             MKMapItem* mapItem = [NSKeyedUnarchiver unarchivedObjectOfClass:[MKMapItem class] fromData:item error:&err];
             DDLogWarn(@"%@", err);
             [payload setObject:[NSString stringWithFormat:@"geo:%f,%f", mapItem.placemark.coordinate.latitude, mapItem.placemark.coordinate.longitude] forKey:@"url"];
-            if(self.contentText) [payload setObject:self.contentText forKey:@"comment"];
+            if(self.contentText.length) [payload setObject:self.contentText forKey:@"comment"];
             [self savePayloadMsgAndComplete:payload];
         }];
     }
@@ -120,13 +120,13 @@ const u_int32_t MagicMapKitItem = 1 << 2;
         NSItemProvider* provider = [magicIdentifyerDic objectForKey:[NSNumber numberWithUnsignedInt:MagicPublicUrl]];
         [provider loadItemForTypeIdentifier:@"public.url" options:NULL completionHandler:^(NSURL<NSSecureCoding>*  _Nullable item, NSError * _Null_unspecified error) {
             [payload setObject:item.absoluteString forKey:@"url"];
-            if(self.contentText) [payload setObject:self.contentText forKey:@"comment"];
+            if(self.contentText.length) [payload setObject:self.contentText forKey:@"comment"];
             [self savePayloadMsgAndComplete:payload];
         }];
     }
     else if((magicIdentifyer & MagicPlainTxt) > 0)
     {
-        if(self.contentText) [payload setObject:self.contentText forKey:@"comment"];
+        if(self.contentText.length) [payload setObject:self.contentText forKey:@"comment"];
         [self savePayloadMsgAndComplete:payload];
     }
 }


### PR DESCRIPTION
Sharing something via share sheet without writing some comment creates an empty chat bubble in the chat view, as the condition `if(self.contentText)` is true in this case. This can be fixed by using `self.contentText.length` instead.