### PR TITLE
DOAP: Fix XML syntax (missing '>')

### DIFF
--- a/monal.doap
+++ b/monal.doap
@@ -3,7 +3,7 @@
 <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
         xmlns:xmpp="https://linkmauve.fr/ns/xmpp-doap#"
         xmlns="http://usefulinc.com/ns/doap#"
-        xmlns:schema="https://schema.org/" 
+        xmlns:schema="https://schema.org/">
   <Project>
 
     <name>Monal</name>


### PR DESCRIPTION
The XML was not well-formed, a '>' got lost in https://github.com/monal-im/Monal/commit/1eebcd3804e05892e69f88f540c346d7e32b919a added back here.