### PR TITLE
Fix crash on alpha when disabling push

### DIFF
--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -4119,15 +4119,9 @@ NSString* const kStanza = @"stanza";
         DDLogInfo(@"DISABLING push: %@ < %@ (accountState: %ld, supportsPush: %@)", [[[UIDevice currentDevice] identifierForVendor] UUIDString], pushToken, (long)self.accountState, self.connectionProperties.supportsPush ? @"YES" : @"NO");
         if(self.connectionProperties.supportsPush)
         {
-#ifdef IS_ALPHA
-            XMPPIQ* disable = [[XMPPIQ alloc] initWithType:kiqSetType];
-            [disable setPushDisable:pushToken];
-            [self send:disable];
-#else
             XMPPIQ* disable = [[XMPPIQ alloc] initWithType:kiqSetType];
             [disable setPushDisable:[[[UIDevice currentDevice] identifierForVendor] UUIDString]];
             [self send:disable];
-#endif
         }
     }
     else


### PR DESCRIPTION
Not sure if this is the correct way to fix this, but the deleted code causes Monal Alpha to crash if pushToken is nil.