### PR TITLE
Update Supported XEPs links

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -45,7 +45,7 @@ Monal always supports the two latest MacOS and iOS major releases.
 
 ### Supported XEPs
 
-Take a look at this list to get information on [supported XEPs by Monal](https://github.com/monal-im/Monal/blob/develop/XEPsupport.md).
+Take a look at this list to get information on [supported XEPs by Monal](https://monal-im.org/install/#implemented-xeps).
 
 ### iOS Screenshots
 <p float="left">


### PR DESCRIPTION
The old linked file has been removed. Alternatively, link: “https://github.com/monal-im/Monal/blob/develop/monal.doap” can also be used.