### PR TITLE
Improvements in the menu that pops up after generating an invitation

### DIFF
--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -271,8 +271,12 @@ struct AddContactMenu: View {
                 UIPasteboard.general.setValue(data["landing"] as! String, forPasteboardType:UTType.utf8PlainText.identifier as String)
                 invitationResult = nil
             }) {
-                Text("Copy link to clipboard")
-                    .frame(maxWidth: .infinity)
+                if #available(iOS 16, *) {
+                    ShareLink("Share invitation link", item: URL(string: data["landing"] as! String)!)
+                } else {
+                    Text("Copy invitation link to clipboard")
+                        .frame(maxWidth: .infinity)
+                }
             }
             Button(action: {
                 invitationResult = nil

--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -245,14 +245,12 @@ struct AddContactMenu: View {
         }
         .richAlert(isPresented: $invitationResult, title:Text("Invitation for \(splitJid["host"]!) created")) { data in
             VStack {
-                Text("Direct your buddy to this webpage for instructions on how to setup an xmpp client. You will then automatically be added to their contact list.")
-                    .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                Link(data["landing"] as! String, destination:URL(string:data["landing"] as! String)!)
-                    .multilineTextAlignment(.leading)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.top, 10)
-                    .padding(.bottom, 10)
+                Image(uiImage: createQrCode(value: data["landing"] as! String))
+                    .interpolation(.none)
+                    .resizable()
+                    .scaledToFit()
+                    .aspectRatio(1, contentMode: .fit)
+
                 if let expires = data["expires"] as? Date {
                     HStack {
                         if #available(iOS 15, *) {


### PR DESCRIPTION
Display a QR code of newly-generated invitations, instead of a link
And use the built-in share functionality to share the invitation.

Note that I deleted the paragraph explaining what to do with the link, because:
1- A QR code is self-explanatory, especially if the invitation is web-based
2- with the current size of the QR code, the paragraph would be too long that small devices (iphone SE) won't display the action buttons unless the user scrolls down


Here's how the menu would look like after applying my changes: (some parts blurred)

![0AD450C3-357A-4D72-9FEA-6B7A05B2E5A3_1_201_a](https://github.com/monal-im/Monal/assets/138154076/d612f1eb-6846-41e1-8f8a-68e795a286f8)
