### PR TITLE
Improved accessibility for ContactDetails view

### DIFF
--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -31,6 +31,8 @@ struct AddContactMenu: View {
     @State private var success = false
     @State private var newContact : MLContact?
     
+    @State private var isEditingJid = false
+    
     private let dismissWithNewContact: (MLContact) -> ()
     private let preauthToken: String?
 
@@ -181,12 +183,13 @@ struct AddContactMenu: View {
                         }
                         .pickerStyle(.menu)
                     }
-                    TextField(NSLocalizedString("Contact or Group/Channel Jid", comment: "placeholder when adding jid"), text: $toAdd)
+                    
+                    TextField(NSLocalizedString("Contact or Group/Channel Jid", comment: "placeholder when adding jid"), text: $toAdd, onEditingChanged: { isEditingJid = $0 })
                         //ios15: .textInputAutocapitalization(.never)
                         .autocapitalization(.none)
                         .autocorrectionDisabled()
                         .keyboardType(.emailAddress)
-                        .addClearButton(text:$toAdd)
+                        .addClearButton(isEditing: isEditingJid, text:$toAdd)
                         .disabled(scannedFingerprints != nil)
                         .foregroundColor(scannedFingerprints != nil ? .secondary : .primary)
                         .onChange(of: toAdd) { _ in

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -30,7 +30,7 @@ struct ContactDetails: View {
                 
             // info/nondestructive buttons
             Section {
-                Button(action: {
+                Button {
                     if(contact.isGroup) {
                         if(!contact.isMuted && !contact.isMentionOnly) {
                             contact.obj.toggleMentionOnly(true)
@@ -44,45 +44,52 @@ struct ContactDetails: View {
                     } else {
                         contact.obj.toggleMute(!contact.isMuted)
                     }
-                }) {
-                    HStack {
-                        if(contact.isMuted) {
+                } label: {
+                    if(contact.isMuted) {
+                        Label {
+                            contact.isGroup ? Text("Notifications disabled") : Text("Contact is muted")
+                        } icon: {
                             Image(systemName: "bell.slash.fill")
                                 .foregroundColor(.red)
-                            contact.isGroup ? Text("Notifications disabled") : Text("Contact is muted")
-                        } else if(contact.isGroup && contact.isMentionOnly) {
-                            Image(systemName: "bell.badge")
-                                .foregroundColor(.accentColor)
+                        }
+                    } else if(contact.isGroup && contact.isMentionOnly) {
+                        Label {
                             Text("Notify only when mentioned")
-                        } else {
+                        } icon: {
+                            Image(systemName: "bell.badge")
+                        }
+                    } else {
+                        Label {
+                            contact.isGroup ? Text("Notify on all messages") : Text("Contact is not muted")
+                        } icon: {
                             Image(systemName: "bell.fill")
                                 .foregroundColor(.green)
-                            contact.isGroup ? Text("Notify on all messages") : Text("Contact is not muted")
                         }
                     }
                 }
-                //.buttonStyle(BorderlessButtonStyle())
                 
 #if !DISABLE_OMEMO
                 if((!contact.isGroup || (contact.isGroup && contact.mucType == "group")) && !HelperTools.isContactBlacklisted(forEncryption:contact.obj)) {
-                    Button(action: {
+                    Button {
                         if(contact.isEncrypted) {
                             showingShouldDisableEncryptionAlert = true
                         } else {
                             showingCannotEncryptAlert = !contact.obj.toggleEncryption(!contact.isEncrypted)
                         }
-                    }) {
-                        HStack {
-                            if contact.isEncrypted {
+                    } label: {
+                        if contact.isEncrypted {
+                            Label {
+                                Text("Messages are encrypted")
+                            } icon: {
                                 Image(systemName: "lock.fill")
                                     .foregroundColor(.green)
-                                Text("Messages are encrypted")
-                                    .foregroundColor(.accentColor)
-                            } else {
+                            }
+                        } else {
+                            Label {
+                                Text("Messages are NOT encrypted")
+                            } icon: {
                                 Image(systemName: "lock.open.fill")
                                     .foregroundColor(.red)
-                                Text("Messages are NOT encrypted")
-                                    .foregroundColor(.accentColor)
                             }
                         }
                     }
@@ -117,9 +124,14 @@ struct ContactDetails: View {
                         .addClearButton(text:$contact.nickNameView)
                 }
                 
-                Button(contact.isPinned ? "Unpin Chat" : "Pin Chat") {
-                    contact.obj.togglePinnedChat(!contact.isPinned);
-                }
+                Toggle("Pin Chat", isOn: Binding(get: {
+                    contact.isPinned
+                }, set: {
+                    contact.obj.togglePinnedChat($0)
+                }))
+//                Button(contact.isPinned ? "Unpin Chat" : "Pin Chat") {
+//                    contact.obj.togglePinnedChat(!contact.isPinned);
+//                }
 
                 if(contact.obj.isGroup && contact.obj.mucType == "group") {
                     NavigationLink(destination: LazyClosureView(MemberList(mucContact: contact))) {

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -21,6 +21,7 @@ struct ContactDetails: View {
     @State private var showingResetOmemoSessionConfirmation = false
     @State private var showingCannotEncryptAlert = false
     @State private var showingShouldDisableEncryptionAlert = false
+    @State private var isEditingNickname = false
 
     var body: some View {
         Form {
@@ -119,9 +120,11 @@ struct ContactDetails: View {
 #endif
                 
                 if(!contact.isGroup && !contact.isSelfChat) {
-                    TextField(NSLocalizedString("Rename Contact", comment: "placeholder text in contact details"), text: $contact.nickNameView)
-                        .textFieldStyle(RoundedBorderTextFieldStyle())
-                        .addClearButton(text:$contact.nickNameView)
+                    TextField(NSLocalizedString("Rename Contact", comment: "placeholder text in contact details"), text: $contact.nickNameView, onEditingChanged: {
+                        isEditingNickname = $0
+                    })
+                    .accessibilityLabel("Nickname")
+                    .addClearButton(isEditing: isEditingNickname, text: $contact.nickNameView)
                 }
                 
                 Toggle("Pin Chat", isOn: Binding(get: {

--- a/Monal/Classes/ContactDetailsHeader.swift
+++ b/Monal/Classes/ContactDetailsHeader.swift
@@ -17,40 +17,37 @@ struct ContactDetailsHeader: View {
     @State private var navigationAction: String?
 
     var body: some View {
-        VStack(alignment: .center) {
-            HStack {
-                Spacer()
-                Image(uiImage: contact.avatar)
-                    .resizable()
-                    .frame(width: 150, height: 150, alignment: .center)
-                    .scaledToFit()
-                    .shadow(radius: 7)
-                Spacer()
-            }
+        VStack(spacing: 20) {
+            Image(uiImage: contact.avatar)
+                .resizable()
+                .scaledToFit()
+                .accessibilityLabel("Avatar")
+                .frame(width: 150, height: 150, alignment: .center)
+                .shadow(radius: 7)
             
-            Spacer()
-                .frame(height: 20)
-            HStack {
-                Text(contact.contactJid as String)
-                //for ios >= 15.0
-                //.textSelection(.enabled)
-                Spacer().frame(width: 10)
-                Button(action: {
-                    UIPasteboard.general.setValue(contact.contactJid as String, forPasteboardType:UTType.utf8PlainText.identifier as String)
-                }) {
+            
+            Button {
+                UIPasteboard.general.setValue(contact.contactJid as String, forPasteboardType:UTType.utf8PlainText.identifier as String)
+                UIAccessibility.post(notification: .announcement, argument: "JID Copied")
+            } label: {
+                HStack {
+                    Text(contact.contactJid as String)
+                    
                     Image(systemName: "doc.on.doc")
                         .foregroundColor(.primary)
+                        .accessibilityHidden(true)
                 }
-                .buttonStyle(BorderlessButtonStyle())
+                .accessibilityHint("Copies JID")
             }
+            .buttonStyle(.borderless)
+                
+            
             //only show account jid if more than one is configured
             if MLXMPPManager.sharedInstance().connectedXMPP.count > 1 && !contact.isSelfChat {
                 Text("Account: \(MLXMPPManager.sharedInstance().getConnectedAccount(forID:contact.accountId)!.connectionProperties.identity.jid)")
             }
             
             if !contact.isSelfChat && !contact.isGroup {
-                Spacer()
-                    .frame(height: 20)
                 if let lastInteractionTime = contact.lastInteractionTime as Date? {
                     if lastInteractionTime.timeIntervalSince1970 > 0 {
                         Text(String(format: NSLocalizedString("Last seen: %@", comment: ""),
@@ -64,27 +61,29 @@ struct ContactDetailsHeader: View {
             }
             
             if(!contact.isGroup && (contact.statusMessage as String).count > 0) {
-                Spacer()
-                    .frame(height: 20)
-                Text("Status message:")
-                Text(contact.statusMessage as String)
-                    .fixedSize(horizontal: false, vertical: true)
+                VStack {
+                    Text("Status message:")
+                    Text(contact.statusMessage as String)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
             }
             
             if(contact.isGroup && (contact.groupSubject as String).count > 0) {
-                Spacer()
-                    .frame(height: 20)
-                if(contact.obj.mucType == "group") {
-                    Text("Group subject:")
-                } else {
-                    Text("Channel subject:")
+                VStack {
+                    if(contact.obj.mucType == "group") {
+                        Text("Group subject:")
+                    } else {
+                        Text("Channel subject:")
+                    }
+                    
+                    Text(contact.groupSubject as String)
+                        .fixedSize(horizontal: false, vertical: true)
                 }
-                Text(contact.groupSubject as String)
-                    .fixedSize(horizontal: false, vertical: true)
             }
         }
         .foregroundColor(.primary)
         .padding([.top, .bottom])
+        .frame(maxWidth: .infinity)
     }
 }
 

--- a/Monal/Classes/CreateGroupMenu.swift
+++ b/Monal/Classes/CreateGroupMenu.swift
@@ -23,6 +23,8 @@ struct CreateGroupMenu: View {
     // note: dismissLabel is not accessed but defined at the .alert() section
     @State private var alertPrompt = AlertPrompt(dismissLabel: Text("Close"))
     @State private var selectedContacts : OrderedSet<MLContact> = []
+    
+    @State private var isEditingGroupName = false
 
     @ObservedObject private var overlay = LoadingOverlayState()
     
@@ -52,16 +54,17 @@ struct CreateGroupMenu: View {
             else
             {
                 Section() {
-                        Picker("Use account", selection: $selectedAccount) {
-                            ForEach(Array(self.connectedAccounts.enumerated()), id: \.element) { idx, account in
-                                Text(account.connectionProperties.identity.jid).tag(account as xmpp?)
-                            }
+                    Picker("Use account", selection: $selectedAccount) {
+                        ForEach(Array(self.connectedAccounts.enumerated()), id: \.element) { idx, account in
+                            Text(account.connectionProperties.identity.jid).tag(account as xmpp?)
                         }
-                        .pickerStyle(.menu)
-                    TextField(NSLocalizedString("Group Name (optional)", comment: "placeholder when creating new group"), text: $groupName)
+                    }
+                    .pickerStyle(.menu)
+                    
+                    TextField(NSLocalizedString("Group Name (optional)", comment: "placeholder when creating new group"), text: $groupName, onEditingChanged: { isEditingGroupName = $0 })
                         .autocorrectionDisabled()
                         .autocapitalization(.none)
-                        .addClearButton(text:$groupName)
+                        .addClearButton(isEditing: isEditingGroupName, text:$groupName)
 
                     NavigationLink(destination: LazyClosureView(ContactPicker(account: self.selectedAccount!, selectedContacts: $selectedContacts)), label: {
                             Text("Change Group Members")

--- a/Monal/Classes/PasswordMigration.swift
+++ b/Monal/Classes/PasswordMigration.swift
@@ -78,7 +78,7 @@ struct PasswordMigration: View {
                                     }
                                 }
                             ))
-                            .addClearButton(text:Binding(
+                            .addClearButton(isEditing: true, text:Binding(
                                 get: { self.needingMigration[id]?["password"] as? String ?? "" },
                                 set: { self.needingMigration[id]?["password"] = $0 as NSString }
                             ))

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -158,26 +158,33 @@ extension DocumentPickerViewController: UIDocumentPickerDelegate {
 
 // clear button for text fields, see https://stackoverflow.com/a/58896723/3528174
 struct ClearButton: ViewModifier {
+    let isEditing: Bool
     @Binding var text: String
+    
     public func body(content: Content) -> some View {
-        ZStack(alignment: .trailing) {
+        HStack {
             content
-            if(!text.isEmpty) {
-                Button(action: {
+                .accessibilitySortPriority(2)
+            
+            if isEditing, !text.isEmpty {
+                Button {
                     self.text = ""
-                }) {
-                    Image(systemName: "delete.left")
-                    .foregroundColor(Color(UIColor.opaqueSeparator))
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(Color(UIColor.tertiaryLabel))
+                        .accessibilityLabel("Clear text")
                 }
                 .padding(.trailing, 8)
+                .accessibilitySortPriority(1)
             }
         }
     }
 }
 //this extension contains the easy-access view modifier
 extension View {
-    func addClearButton(text: Binding<String>) -> some View {
-        modifier(ClearButton(text:text))
+    /// Puts the view in an HStack and adds a clear button to the right when the text is not empty.
+    func addClearButton(isEditing: Bool, text: Binding<String>) -> some View {
+        modifier(ClearButton(isEditing: isEditing, text:text))
     }
 }
 

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -319,42 +319,16 @@ struct AlertPrompt {
     var dismissLabel: Text = Text("Close")
 }
 
-//see https://www.avanderlee.com/swiftui/conditional-view-modifier/
 extension View {
-    /// Applies the given transform if the given condition evaluates to `true`.
+    /// Applies the given transform.
+    ///
+    /// Useful for availability branching on view modifiers. Do not branch with any properties that may change during runtime as this will cause errors.
     /// - Parameters:
-    ///   - condition: The condition to evaluate.
     ///   - transform: The transform to apply to the source `View`.
-    /// - Returns: Either the original `View` or the modified `View` if the condition is `true`.
-    @ViewBuilder func `if`<Content: View>(_ condition: @autoclosure () -> Bool, transform: (Self) -> Content) -> some View {
-        if condition() {
-            transform(self)
-        } else {
-            self
-        }
+    /// - Returns: The view transformed by the transform.
+    func ifAvailable<Content: View>(@ViewBuilder _ transform: (Self) -> Content) -> some View {
+        transform(self)
     }
-    
-    @ViewBuilder func `if`<Content: View>(closure condition: () -> Bool, transform: (Self) -> Content) -> some View {
-        if condition() {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
-func iOS15() -> Bool {
-    guard #available(iOS 15, *) else {
-        return true
-    }
-    return false
-}
-
-func iOS16() -> Bool {
-    guard #available(iOS 16, *) else {
-        return true
-    }
-    return false
 }
 
 // Interfaces between ObjectiveC/Storyboards and SwiftUI


### PR DESCRIPTION
- Standardized the look of mute and encryption buttons in ContactDetails. This also helps with accessibility by using the standard Label instead of HStack
- Changed Pin Chat to a Toggle.
- Changed the JID copy button to include the JID itself. Also ensured it was labelled for VoiceOver
- Replaced the unused conditional 'if' view modifiers with a more functional and safer ifAvailable version (not in use yet but helpful for the future)
- Improved the SwiftUI clear button added to several TextField views. It now hides when the field is not being edited and works better for VoiceOver.