### PR TITLE
Autofocus on textbox in chat window, fixes #704

### DIFF
--- a/Monal/Classes/MLResizingTextView.m
+++ b/Monal/Classes/MLResizingTextView.m
@@ -17,6 +17,7 @@
     if (!CGSizeEqualToSize(self.bounds.size, [self intrinsicContentSize])) {
         [self invalidateIntrinsicContentSize];
     }
+    [self becomeFirstResponder];
 }
 
 - (CGSize)intrinsicContentSize


### PR DESCRIPTION
Automatically pops up the keyboard when the user enters the chat interface