### PR TITLE
custom chat backgrounds not showing even though its set, fixes #1043

### DIFF
--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -176,7 +176,6 @@ enum msgSentState {
 
     self.messageTable.rowHeight = UITableViewAutomaticDimension;
     self.messageTable.estimatedRowHeight = UITableViewAutomaticDimension;
-    self.messageTable.backgroundColor = [UIColor colorNamed:@"chatBackgroundColor"];
 
 #if TARGET_OS_MACCATALYST
     //does not become first responder like in iOS

--- a/Monal/localization/Base.lproj/Main.storyboard
+++ b/Monal/localization/Base.lproj/Main.storyboard
@@ -2268,7 +2268,7 @@
                             </tableView>
                         </subviews>
                         <viewLayoutGuide key="safeArea" id="ZKQ-3D-6NG"/>
-                        <color key="backgroundColor" systemColor="tertiarySystemBackgroundColor"/>
+                        <color key="backgroundColor" name="chatBackgroundColor"/>
                         <gestureRecognizers/>
                         <constraints>
                             <constraint firstItem="SEk-WZ-Rcm" firstAttribute="leading" secondItem="Riz-2Q-bcU" secondAttribute="leadingMargin" constant="-20" id="FL9-Tl-rIX"/>
@@ -2547,6 +2547,9 @@
         <image name="plus.square" catalog="system" width="128" height="114"/>
         <image name="text.bubble" catalog="system" width="128" height="110"/>
         <image name="xmark.circle.fill" catalog="system" width="128" height="123"/>
+        <namedColor name="chatBackgroundColor">
+            <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
         <systemColor name="darkTextColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
@@ -2567,9 +2570,6 @@
         </systemColor>
         <systemColor name="systemGrayColor">
             <color red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-        </systemColor>
-        <systemColor name="tertiarySystemBackgroundColor">
-            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>
         <systemColor name="tertiarySystemGroupedBackgroundColor">
             <color red="0.94901960780000005" green="0.94901960780000005" blue="0.96862745100000003" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Background Image:
![Simulator Screenshot - iPhone 15 - 2024-04-28 at 19 50 47](https://github.com/monal-im/Monal/assets/155921778/32d52bbb-2370-4301-8042-42a817d66637)

No Background Image:
![Simulator Screenshot - iPhone 15 - 2024-04-28 at 19 50 57](https://github.com/monal-im/Monal/assets/155921778/653d2cbe-0c23-42a5-a26f-822d75a0378a)
 
reference: https://github.com/monal-im/Monal/commit/68efd1702097bf8669f5df1391abc15f142c90ea