### PR TITLE
docs: update Homebrew beta install instructions

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -11,7 +11,7 @@ If you want to  use the latest stable versions, search for Monal in the iOS or O
 |        | iOS                                                           | macOS                                                    | macOS (homebrew)                                                          |
 |--------|---------------------------------------------------------------|----------------------------------------------------------|---------------------------------------------------------------------------|
 | Stable | [App Store](https://apps.apple.com/app/id317711500)           | [App Store](https://apps.apple.com/app/id1499227291)     | brew install --cask monal                                                 |
-| Beta   | [Testflight](https://testflight.apple.com/join/lLLlgHpB)      | [Testflight](https://testflight.apple.com/join/tGH2m5vf) |  brew tap homebrew/cask-versions<br>brew install --cask monal-beta                                                                         |
+| Beta   | [Testflight](https://testflight.apple.com/join/lLLlgHpB)      | [Testflight](https://testflight.apple.com/join/tGH2m5vf) | brew install --cask monal@beta                                            |
 | Alpha  | upon request to [info@monal-im.org](mailto:info@monal-im.org)<br>Then download from our [alpha download site](https://downloads.monal-im.org/monal-im/alpha/) |                                                          | brew tap monal-im/homebrew-monal-alpha<br>brew install --cask monal-alpha |
 
 


### PR DESCRIPTION
Hi - Homebrew maintainer here 👋 

Just a small doc update.  Noticed the install instructions for the beta version of Monal was outdated - we recently deprecated `homebrew/cask-versions` and moved the contents into the main Cask repository. 

Along with that, we renamed from -suffix to `@suffix` for alpha, beta, etc.