### PR TITLE
Replace sheet dismisser with dismiss action (iOS 16+ changes)

### DIFF
--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -10,7 +10,6 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 
 struct AddContactMenu: View {
-    var delegate: SheetDismisserProtocol
     static private let jidFaultyPattern = "^([^@]+@)?.+(\\..{2,})?$"
 
     @State private var connectedAccounts: [xmpp]
@@ -33,11 +32,12 @@ struct AddContactMenu: View {
 
     @State private var isEditingJid = false
 
+    @Environment(\.dismiss) private var dismiss
+
     private let dismissWithNewContact: (MLContact) -> ()
     private let preauthToken: String?
 
-    init(delegate: SheetDismisserProtocol, dismissWithNewContact: @escaping (MLContact) -> (), prefillJid: String = "", preauthToken:String? = nil, prefillAccount:xmpp? = nil, omemoFingerprints: [NSNumber:Data]? = nil) {
-        self.delegate = delegate
+    init(dismissWithNewContact: @escaping (MLContact) -> (), prefillJid: String = "", preauthToken:String? = nil, prefillAccount:xmpp? = nil, omemoFingerprints: [NSNumber:Data]? = nil) {
         self.dismissWithNewContact = dismissWithNewContact
         //self.toAdd = State(wrappedValue: prefillJid)
         self.toAdd = prefillJid
@@ -258,7 +258,7 @@ struct AddContactMenu: View {
                     if self.newContact != nil {
                         self.dismissWithNewContact(newContact!)
                     } else {
-                        self.delegate.dismiss()
+                        dismiss()
                     }
                 }
             }))
@@ -347,9 +347,8 @@ struct AddContactMenu: View {
 }
 
 struct AddContactMenu_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        AddContactMenu(delegate: delegate, dismissWithNewContact: { c in
+        AddContactMenu(dismissWithNewContact: { c in
         })
     }
 }

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -7,7 +7,7 @@
 //
 
 struct ContactDetails: View {
-    var delegate: SheetDismisserProtocol
+    @Environment(\.dismiss) private var dismiss
     private var account: xmpp
     @State private var ownRole = "participant"
     @State private var ownAffiliation = "none"
@@ -32,8 +32,7 @@ struct ContactDetails: View {
     @State private var successCallback: monal_void_block_t?
     @StateObject private var overlay = LoadingOverlayState()
 
-    init(delegate: SheetDismisserProtocol, contact: ObservableKVOWrapper<MLContact>) {
-        self.delegate = delegate
+    init(contact: ObservableKVOWrapper<MLContact>) {
         _contact = StateObject(wrappedValue: contact)
         self.account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.accountId)!
     }
@@ -477,8 +476,7 @@ struct ContactDetails: View {
                                             action: {
                                                 contact.obj.removeFromRoster()      //this will dismiss the chatview via kMonalContactRemoved notification
                                                 //this will do nothing for contact details opened through group members list (which is fine!)
-                                                //NOTE: this holds for all delegate.dismiss() calls
-                                                self.delegate.dismiss()
+                                                dismiss()
                                             }
                                         )
                                     ]
@@ -678,12 +676,11 @@ struct ContactDetails: View {
 }
 
 struct ContactDetails_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(0)))
-        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(1)))
-        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(2)))
-        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(3)))
-        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(4)))
+        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(0)))
+        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(1)))
+        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(2)))
+        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(3)))
+        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(4)))
     }
 }

--- a/Monal/Classes/ImageViewer.swift
+++ b/Monal/Classes/ImageViewer.swift
@@ -46,12 +46,11 @@ struct SVGRepresentation: Transferable {
 }
 
 struct ImageViewer: View {
-    var delegate: SheetDismisserProtocol
     let info: [String:AnyObject]
     @State private var controlsVisible = false
-    
-    init(delegate: SheetDismisserProtocol, info:[String:AnyObject]) throws {
-        self.delegate = delegate
+    @Environment(\.dismiss) private var dismiss
+
+    init(info:[String:AnyObject]) throws {
         self.info = info
     }
     
@@ -143,7 +142,7 @@ struct ImageViewer: View {
                                 }
                                 
                                 Button(action: {
-                                    self.delegate.dismiss()
+                                    dismiss()
                                 }, label: {
                                     Image(systemName: "xmark")
                                         .foregroundColor(.primary)

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -278,7 +278,7 @@ struct MemberList: View {
                             .accessibilityLabel(Text("Open Profile of \(contact.contactDisplayName as String)"))
                             //invisible navigation link that can be triggered programmatically
                             .background(
-                                NavigationLink(destination: LazyClosureView(ContactDetails(delegate:SheetDismisserProtocol(), contact:contact)), tag:contact, selection:$navigationActive) { EmptyView() }
+                                NavigationLink(destination: LazyClosureView(ContactDetails(contact:contact)), tag:contact, selection:$navigationActive) { EmptyView() }
                                     .opacity(0)
                             )
                             

--- a/Monal/Classes/PasswordMigration.swift
+++ b/Monal/Classes/PasswordMigration.swift
@@ -7,7 +7,7 @@
 //
 
 struct PasswordMigration: View {
-    let delegate: SheetDismisserProtocol
+    @Environment(\.dismiss) private var dismiss
     @State var needingMigration: [Int:[String:NSObject]]
 #if IS_ALPHA
     let appLogoId = "AlphaAppLogo"
@@ -17,8 +17,7 @@ struct PasswordMigration: View {
     let appLogoId = "AppLogo"
 #endif
     
-    init(delegate:SheetDismisserProtocol, needingMigration:[[String:NSObject]]) {
-        self.delegate = delegate
+    init(needingMigration:[[String:NSObject]]) {
         var tmpState = [Int:[String:NSObject]]()
         for entry in needingMigration {
             let id = (entry["account_id"] as! NSNumber).intValue
@@ -113,7 +112,7 @@ struct PasswordMigration: View {
                             }
                         }
                         NotificationCenter.default.post(name:Notification.Name("kMonalRefresh"), object:nil);
-                        self.delegate.dismiss()
+                        dismiss()
                     }, label: {
                         Text("Done")
                     })
@@ -144,8 +143,7 @@ func previewMock() -> [[String:NSObject]] {
 }
 
 struct PasswordMigration_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        PasswordMigration(delegate:delegate, needingMigration:previewMock())
+        PasswordMigration(needingMigration:previewMock())
     }
 }

--- a/Monal/Classes/RegisterAccount.swift
+++ b/Monal/Classes/RegisterAccount.swift
@@ -26,8 +26,6 @@ struct WebView: UIViewRepresentable {
 }
 
 struct RegisterAccount: View {
-    var delegate: SheetDismisserProtocol
-
     static let XMPPServer: [Dictionary<String, String>] = [
         ["XMPPServer": "Input", "TermsSite_default": ""],
         ["XMPPServer": "conversations.im", "TermsSite_default": "https://account.conversations.im/privacy/"],
@@ -64,8 +62,10 @@ struct RegisterAccount: View {
     @State private var showWebView = false
     @State private var errorObserverEnabled = false
 
-    init(delegate:SheetDismisserProtocol, registerData:[String:AnyObject]? = nil) {
-        self.delegate = delegate
+    @Environment(\.dismiss) private var dismiss
+
+    init(registerData:[String:AnyObject]? = nil) {
+
         if let registerData = registerData {
             DDLogDebug("RegisterAccount created with data: \(registerData)");
             //for State stuff see https://forums.swift.org/t/assignment-to-state-var-in-init-doesnt-do-anything-but-the-compiler-gened-one-works/35235
@@ -392,7 +392,7 @@ struct RegisterAccount: View {
                     .alert(isPresented: $showAlert) {
                         Alert(title: alertPrompt.title, message: alertPrompt.message, dismissButton: .default(alertPrompt.dismissLabel, action: {
                             if(self.registerComplete == true) {
-                                self.delegate.dismiss()
+                                dismiss()
                                 
                                 if let completion = self.completionHandler {
                                     DDLogVerbose("Calling reg completion handler...")
@@ -476,8 +476,7 @@ struct RegisterAccount: View {
 }
 
 struct RegisterAccount_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        RegisterAccount(delegate:delegate)
+        RegisterAccount()
     }
 }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -672,10 +672,8 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makePasswordMigration(_ needingMigration: [[String:NSObject]]) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(needingMigration:needingMigration)))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -634,10 +634,8 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makeContactDetails(_ contact: MLContact) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
+        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(contact:ObservableKVOWrapper<MLContact>(contact))))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -698,9 +698,9 @@ class SwiftuiInterface : NSObject {
             case "DebugView":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(DebugView())))
             case "WelcomeLogIn":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn(delegate:delegate))))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn())))
             case "LogIn":
-                host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn(delegate:delegate))))
+                host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn())))
             case "CreateGroup":
                 host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: CreateGroupMenu(delegate: delegate))))
             case "ChatPlaceholder":

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -643,10 +643,8 @@ class SwiftuiInterface : NSObject {
     
     @objc(makeImageViewerForInfo:)
     func makeImageViewerFor(info:[String:AnyObject]) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
-        host.rootView = AnyView(try! ImageViewer(delegate:delegate, info:info))
+        host.rootView = AnyView(try! ImageViewer(info:info))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -511,10 +511,9 @@ struct LazyClosureView<Content: View>: View {
 // use this to wrap a view into NavigationView, if it should be the outermost swiftui view of a new view stack
 struct AddTopLevelNavigation<Content: View>: View {
     let build: () -> Content
-    let delegate: SheetDismisserProtocol
-    init(withDelegate delegate: SheetDismisserProtocol, to build: @autoclosure @escaping () -> Content) {
+    @Environment(\.dismiss) private var dismiss
+    init(to build: @autoclosure @escaping () -> Content) {
         self.build = build
-        self.delegate = delegate
     }
     var body: some View {
         NavigationView {
@@ -522,7 +521,7 @@ struct AddTopLevelNavigation<Content: View>: View {
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
             .navigationBarItems(leading: Button(action : {
-                self.delegate.dismiss()
+                dismiss()
             }){
                 Image(systemName: "arrow.backward")
             }.keyboardShortcut(.escape, modifiers: []))
@@ -620,7 +619,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
         return host
     }
     
@@ -638,7 +637,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
+        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
         return host
     }
     
@@ -670,7 +669,7 @@ class SwiftuiInterface : NSObject {
 #if IS_QUICKSY
         host.rootView = AnyView(Quicksy_RegisterAccount(delegate:delegate))
 #else
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:RegisterAccount(delegate:delegate, registerData:registerData)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(delegate:delegate, registerData:registerData)))
 #endif
         return host
     }
@@ -680,7 +679,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
         return host
     }
     
@@ -689,7 +688,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
         return host
     }
     
@@ -698,7 +697,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
         return host
     }
 
@@ -711,19 +710,19 @@ class SwiftuiInterface : NSObject {
             case "DebugView":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(DebugView())))
             case "WelcomeLogIn":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate:delegate, to:WelcomeLogIn(delegate:delegate))))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn(delegate:delegate))))
             case "LogIn":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn(delegate:delegate))))
             case "CreateGroup":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: CreateGroupMenu(delegate: delegate))))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: CreateGroupMenu(delegate: delegate))))
             case "ChatPlaceholder":
                 host = UIHostingController(rootView:AnyView(ChatPlaceholder()))
             case "GeneralSettings" :
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(GeneralSettings())))
             case "ActiveChatsGeneralSettings":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: GeneralSettings())))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: GeneralSettings())))
             case "ActiveChatsNotificationSettings":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: NotificationSettings())))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: NotificationSettings())))
             case "OnboardingView":
                 host = UIHostingController(rootView:AnyView(createOnboardingView(delegate:delegate)))
             

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -681,19 +681,15 @@ class SwiftuiInterface : NSObject {
     
     @objc(makeAddContactViewWithDismisser:)
     func makeAddContactView(dismisser: @escaping (MLContact) -> ()) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(dismissWithNewContact: dismisser)))
         return host
     }
     
     @objc
     func makeAddContactView(forJid jid:String, preauthToken: String?, prefillAccount: xmpp?, andOmemoFingerprints omemoFingerprints: [NSNumber:Data]?, withDismisser dismisser: @escaping (MLContact) -> ()) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
         return host
     }
 

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -616,9 +616,7 @@ public extension UIViewController {
 class SwiftuiInterface : NSObject {
     @objc(makeAccountPickerForContacts:andCallType:)
     func makeAccountPicker(for contacts: [MLContact], and callType: UInt) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
         host.rootView = AnyView(AddTopLevelNavigation(to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
         return host
     }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -661,13 +661,11 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makeAccountRegistration(_ registerData: [String:AnyObject]?) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
 #if IS_QUICKSY
         host.rootView = AnyView(Quicksy_RegisterAccount(delegate:delegate))
 #else
-        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(delegate:delegate, registerData:registerData)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(registerData:registerData)))
 #endif
         return host
     }

--- a/Monal/Classes/WelcomeLogIn.swift
+++ b/Monal/Classes/WelcomeLogIn.swift
@@ -208,7 +208,7 @@ struct WelcomeLogIn: View {
                         }
                     }
                     
-                    NavigationLink(destination: LazyClosureView(RegisterAccount(delegate: self.delegate))) {
+                    NavigationLink(destination: LazyClosureView(RegisterAccount())) {
                         Text("Register a new account")
                         .foregroundColor(monalDarkGreen)
                     }

--- a/Monal/Classes/WelcomeLogIn.swift
+++ b/Monal/Classes/WelcomeLogIn.swift
@@ -9,8 +9,8 @@
 struct WelcomeLogIn: View {
     static private let credFaultyPattern = "^.+@.+\\..{2,}$"
     
-    var delegate: SheetDismisserProtocol
-    
+    @Environment(\.dismiss) private var dismiss
+
     @State private var isEditingJid: Bool = false
     @State private var jid: String = ""
     @State private var isEditingPassword: Bool = false
@@ -176,7 +176,7 @@ struct WelcomeLogIn: View {
                         .alert(isPresented: $showAlert) {
                             Alert(title: alertPrompt.title, message: alertPrompt.message, dismissButton: .default(alertPrompt.dismissLabel, action: {
                                 if(self.loginComplete == true) {
-                                    self.delegate.dismiss()
+                                    dismiss()
                                 }
                             }))
                         }
@@ -215,7 +215,7 @@ struct WelcomeLogIn: View {
                     
                     if(DataLayer.sharedInstance().enabledAccountCnts() == 0) {
                         Button(action: {
-                            self.delegate.dismiss()
+                            dismiss()
                         }){
                             Text("Set up account later")
                                 .frame(maxWidth: .infinity)
@@ -296,8 +296,7 @@ struct WelcomeLogIn: View {
 }
 
 struct WelcomeLogIn_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        WelcomeLogIn(delegate:delegate)
+        WelcomeLogIn()
     }
 }


### PR DESCRIPTION
I've only made this change for the `ImageViewer` for now, to make sure I'm on the right track first :)

If this looks good, I can remove the other usages as well.

Also - just wanted to check - we still need to support iOS 14, right?

I ask as I saw `PresentationMode` is [deprecated](https://developer.apple.com/documentation/swiftui/presentationmode), but that its replacement `DismissAction` is [iOS 15+](https://developer.apple.com/documentation/swiftui/environmentvalues/dismiss) only.


https://github.com/monal-im/Monal/assets/148400980/4043baab-0a6b-4600-a91d-403e85b9d19f

#1055