### PR TITLE
Remove sheet dismisser from classes where it is unused (iOS 14 changes)

### DIFF
--- a/Monal/Classes/AccountPicker.swift
+++ b/Monal/Classes/AccountPicker.swift
@@ -7,7 +7,6 @@
 //
 
 struct AccountPicker: View {
-    let delegate: SheetDismisserProtocol
     let contacts: [MLContact]
     let callType: MLCallType
 #if IS_ALPHA
@@ -18,8 +17,7 @@ struct AccountPicker: View {
     let appLogoId = "AppLogo"
 #endif
     
-    init(delegate:SheetDismisserProtocol, contacts:[MLContact], callType: MLCallType) {
-        self.delegate = delegate
+    init(contacts:[MLContact], callType: MLCallType) {
         self.contacts = contacts
         self.callType = callType
     }
@@ -63,8 +61,7 @@ struct AccountPicker: View {
 }
 
 struct AccountPicker_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        AccountPicker(delegate:delegate, contacts:[MLContact.makeDummyContact(0)], callType:.audio)
+        AccountPicker(contacts:[MLContact.makeDummyContact(0)], callType:.audio)
     }
 }

--- a/Monal/Classes/ContactRequestsMenu.swift
+++ b/Monal/Classes/ContactRequestsMenu.swift
@@ -63,7 +63,6 @@ struct ContactRequestsMenuEntry: View {
 }
 
 struct ContactRequestsMenu: View {
-    var delegate: SheetDismisserProtocol
     @State private var pendingRequests: [MLContact]
 
     var body: some View {
@@ -95,15 +94,13 @@ struct ContactRequestsMenu: View {
         }
     }
 
-    init(delegate: SheetDismisserProtocol) {
-        self.delegate = delegate
+    init() {
         self.pendingRequests = DataLayer.sharedInstance().allContactRequests() as! [MLContact]
     }
 }
 
 struct ContactRequestsMenu_Previews: PreviewProvider {
-    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        ContactRequestsMenu(delegate: delegate)
+        ContactRequestsMenu()
     }
 }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -673,7 +673,7 @@ class SwiftuiInterface : NSObject {
             case "LogIn":
                 host.rootView = AnyView(UIKitWorkaround(WelcomeLogIn(delegate:delegate)))
             case "ContactRequests":
-                host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: ContactRequestsMenu(delegate: delegate)))
+                host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: ContactRequestsMenu()))
             case "CreateGroup":
                 host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: CreateGroupMenu(delegate: delegate)))
             case "ChatPlaceholder":

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -582,7 +582,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:AccountPicker(delegate:delegate, contacts:contacts, callType:MLCallType(rawValue: callType)!)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -513,10 +513,6 @@ struct AddTopLevelNavigation<Content: View>: View {
         self.build = build
         self.delegate = delegate
     }
-    init(withDelegate delegate: SheetDismisserProtocol, andClosure build: @escaping () -> Content) {
-        self.build = build
-        self.delegate = delegate
-    }
     var body: some View {
         NavigationView {
             build()

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -615,9 +615,7 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makeOwnOmemoKeyView(_ ownContact: MLContact?) -> UIViewController {
-        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        delegate.host = host
         if(ownContact == nil) {
             host.rootView = AnyView(OmemoKeys(contact: nil))
         } else {


### PR DESCRIPTION
While working through replacing `SheetDismisserProtocol` usages with `DismissAction`s, I came across these cases where the sheet dismisser is created but not used.

Therefore, we can remove these usages without needing to bump the iOS version.

I couldn't find a way to trigger the `AccountPicker`, but here is a demo of the other two views:

https://github.com/monal-im/Monal/assets/148400980/ba8ec0ec-646e-420d-ae61-a3ab07713aa1

#1055 