### PR TITLE
Implement dynamic UI updates for OMEMO device updates

### DIFF
--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -164,6 +164,7 @@ static inline NSString* _Nonnull LocalizationNotNeeded(NSString* _Nonnull s)
 #define kMLResourceBoundNotice @"kMLResourceBoundNotice"
 #define kMonalFinishedCatchup @"kMonalFinishedCatchup"
 #define kMonalFinishedOmemoBundleFetch @"kMonalFinishedOmemoBundleFetch"
+#define kMonalOmemoStateUpdated @"kMonalOmemoStateUpdated"
 #define kMonalUpdateBundleFetchStatus @"kMonalUpdateBundleFetchStatus"
 #define kMonalIdle @"kMonalIdle"
 #define kMonalFiletransfersIdle @"kMonalFiletransfersIdle"

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -134,8 +134,7 @@ struct OmemoKeysEntry: View {
         let trustLevelBinding = Binding<Bool>.init(get: {
             return (self.trustLevel.int32Value != MLOmemoNotTrusted)
         }, set: { keyEnabled in
-            self.account.omemo.updateTrust(keyEnabled, for: self.address)
-            self.trustLevel = self.account.omemo.getTrustLevel(self.address, identityKey: self.fingerprint)
+            setTrustLevel(keyEnabled)
         })
 
         let fingerprintString = HelperTools.signalHexKeyWithSpaces(with: fingerprint)

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -211,10 +211,14 @@ struct OmemoKeysForContact: View {
         self.contactJid = contact.obj.contactJid
         self.account = account
         self.deviceId = account.omemo.getDeviceId()
-        self.deviceIds = OrderedSet(self.account.omemo.knownDevices(forAddressName: self.contactJid))
+        self.deviceIds = OmemoKeysForContact.knownDevices(account: self.account, jid: self.contactJid)
         self.selectedDeviceForDeletion = -1
     }
     
+    private static func knownDevices(account: xmpp, jid: String) -> OrderedSet<NSNumber> {
+        return OrderedSet(account.omemo.knownDevices(forAddressName: jid).sorted { return $0.intValue < $1.intValue })
+    }
+
     func deleteButton(deviceId: NSNumber) -> some View {
         Button(action: {
             selectedDeviceForDeletion = deviceId // SwiftUI does not like to have deviceID nested in multiple functions, so safe this in the struct...


### PR DESCRIPTION
This PR only addresses new / removed devices, and is the first part of #1101

I show the group chat view, as this is the most complex case. The "own keys" view works similarly.

https://github.com/user-attachments/assets/3c631e27-a3c7-4e84-9cd5-36961d5ab071

I removed the explicit delete action, as this is now handled by refreshing the keys. To check it still works:

https://github.com/user-attachments/assets/16cd8aac-b755-467c-8d5b-7b46533c5ff8

Even after this change, I noticed some cases where the device list does not update after creating a device (on other accounts - not the user's own account). However, these all turned out to be differences between Monal's view and the server's view, instead of mismatches between the view and Monal's own DB.

Still to do (in future PR's, if it's ok to merge this as-is):
* show added / removed users
* show changes in trust
* investigate above cases where Monal and server are out of sync (probably because server did not send the update message to Monal?)
* add animation to delete button