### PR TITLE
6.4.1

### DIFF
--- a/.github/workflows/stable.build-push.yml
+++ b/.github/workflows/stable.build-push.yml
@@ -166,7 +166,7 @@ jobs:
         env:
           DELIVER_METADATA_PATH: ${{ steps.metadata.outputs.path_macos }}
         run: |
-          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" pkg:"./Monal/build/app/Monal.pkg" app_version:"${{ steps.releasenotes.outputs.version }}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:true skip_screenshots:true precheck:true precheck_include_in_app_purchases:false
+          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" pkg:"./Monal/build/app/Monal.pkg" app_version:"${{ steps.releasenotes.outputs.version }}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:true skip_screenshots:true run_precheck_before_submit:false
       # - name: Update xmpp.org client list with new timestamp
       #   run: ./scripts/push_xmpp.org.sh
       - name: Remove fastlane metadata directory


### PR DESCRIPTION
- Allow image cropping when setting a group/channel avatar
- Fix position of floating scroll-to-bottom button (thanks Matthew Fennell)
- Fix buttons in contact list not working sometimes (thanks Matthew Fennell)
- Implement setting to control the time used for auto-deletion of messages (thanks Noman Ashraf)
- Fix bug sometimes showing an empty list of omemo keys in groups
- Fix saving of group name when creating groups on ejabberd servers
- Fix message retraction in groups/channels
- Fixed dark mode display of chat placeholder image (park)
- New Onboarding flow introducing Monal, XMPP and Privacy Settings
- Accessibility fixes when using VoiceOver
- Merge and improve add contact menu and contact requests menu
- Show contact requests menu when tapping onto a contact request notification
- Fix several crashes and other bugs
- Updated translations
MACOS_ONLY - This is the last release that will support macOS 11 + 12.
IOS_ONLY - This is the last release that will support iOS 14 + 15.