### PR TITLE
Preparation for OmemoKeys ViewController

### DIFF
--- a/Monal/Classes/ChannelMemberList.swift
+++ b/Monal/Classes/ChannelMemberList.swift
@@ -15,7 +15,7 @@ struct ChannelMemberList: View {
     @State private var participants: OrderedDictionary<String, String>
 
     init(mucContact: ObservableKVOWrapper<MLContact>) {
-        account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: mucContact.accountId)! as xmpp
+        account = mucContact.obj.account! as xmpp
         _channel = StateObject(wrappedValue:mucContact)
         _ownAffiliation = State(wrappedValue:"none")
         _participants = State(wrappedValue:OrderedDictionary<String, String>())

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -381,7 +381,7 @@ struct ContactDetails: View {
                     }
                 }
                 
-                let accountJid = MLXMPPManager.sharedInstance().getConnectedAccount(forID:contact.accountId)!.connectionProperties.identity.jid
+                let accountJid = account.connectionProperties.identity.jid
                 let displayName = contact.contactDisplayName as String
                 let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -34,7 +34,7 @@ struct ContactDetails: View {
 
     init(contact: ObservableKVOWrapper<MLContact>) {
         _contact = StateObject(wrappedValue: contact)
-        self.account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.accountId)!
+        self.account = contact.obj.account!
     }
 
     private func updateRoleAndAffiliation() {

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -381,7 +381,9 @@ struct ContactDetails: View {
                     }
                 }
                 
-                let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[MLXMPPManager.sharedInstance().getConnectedAccount(forID:contact.accountId)!.connectionProperties.identity.jid, contact.contactDisplayName as String])
+                let accountJid = MLXMPPManager.sharedInstance().getConnectedAccount(forID:contact.accountId)!.connectionProperties.identity.jid
+                let displayName = contact.contactDisplayName as String
+                let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {
                     Button(action: {
                             UIApplication.shared.open(sharedUrl, options:[:])

--- a/Monal/Classes/EditGroupSubject.swift
+++ b/Monal/Classes/EditGroupSubject.swift
@@ -19,7 +19,7 @@ struct EditGroupSubject: View {
         
         _subject = State(wrappedValue: contact.obj.groupSubject)
         _contact = StateObject(wrappedValue: contact)
-        self.account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.accountId)! as xmpp
+        self.account = contact.obj.account! as xmpp
     }
 
     var body: some View {

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -288,7 +288,7 @@
 -(xmpp*) account
 {
     @synchronized(self) {
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.contact.accountId];
+        xmpp* account = self.contact.account;
         MLAssert(account != nil, @"Account of call must be listed in MLXMPPManager connected accounts!", (@{
             @"contact": nilWrapper(self.contact),
             @"call": nilWrapper(self),
@@ -1274,7 +1274,7 @@
     if(account != [[MLXMPPManager sharedInstance] getConnectedAccountForID:account.accountNo])
         return;
     //don't use self.account because that asserts on nil
-    if([[MLXMPPManager sharedInstance] getConnectedAccountForID:self.contact.accountId] == nil)
+    if(self.contact.account == nil)
         return;
     
     XMPPIQ* iqNode = userInfo[@"iqNode"];
@@ -1413,7 +1413,7 @@
     if(account != [[MLXMPPManager sharedInstance] getConnectedAccountForID:account.accountNo])
         return;
     //don't use self.account because that asserts on nil
-    if([[MLXMPPManager sharedInstance] getConnectedAccountForID:self.contact.accountId] == nil)
+    if(self.contact.account == nil)
         return;
     XMPPIQ* iqNode = userInfo[@"iqNode"];
     

--- a/Monal/Classes/MLContact.h
+++ b/Monal/Classes/MLContact.h
@@ -53,6 +53,7 @@ FOUNDATION_EXPORT NSString* const kAskSubscribe;
 @property (nonatomic, readonly, copy) UIImage* avatar;
 @property (nonatomic, readonly) BOOL hasAvatar;
 @property (nonatomic, readonly) NSString* fullName;
+@property (nonatomic, readonly) xmpp* _Nullable account;
 /**
  usually user assigned nick name
  */

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -377,7 +377,7 @@ static NSMutableDictionary* _singletonCache;
     }
     else
     {
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+        xmpp* account = self.account;
         if(hasSelfnotesPrefix)
         {
             //add "Note to self: " prefix for selfchats
@@ -436,7 +436,7 @@ static NSMutableDictionary* _singletonCache;
         _cancelNickChange();
     // delay changes because we don't want to update the roster on our server too often while typing
     _cancelNickChange = createTimer(2.0, (^{
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+        xmpp* account = self.account;
         [account updateRosterItem:self withName:self.nickName];
     }));
 }
@@ -457,7 +457,7 @@ static NSMutableDictionary* _singletonCache;
     if([self.fullName isEqualToString:name] || name == nil)
         return;             //no change at all
     self.fullName = name;
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+    xmpp* account = self.account;
     [[DataLayer sharedInstance] setFullName:self.fullName forContact:self.contactJid andAccount:account.accountNo];
     // abort old change timer and start a new one
     if(_cancelFullNameChange)
@@ -498,7 +498,7 @@ static NSMutableDictionary* _singletonCache;
 
 -(BOOL) isSelfChat
 {
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+    xmpp* account = self.account;
     return [self.contactJid isEqualToString:account.connectionProperties.identity.jid];
 }
 
@@ -625,7 +625,7 @@ static NSMutableDictionary* _singletonCache;
 #ifdef DISABLE_OMEMO
     return NO;
 #else
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+    xmpp* account = self.account;
     if(account == nil || account.omemo == nil)
         return NO;
     if(self.isGroup == NO)
@@ -664,7 +664,7 @@ static NSMutableDictionary* _singletonCache;
         [[DataLayer sharedInstance] unPinChat:self.accountId andBuddyJid:self.contactJid];
     self.isPinned = pinned;
     // update active chats
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+    xmpp* account = self.account;
     if(account == nil)
         return;
     [[MLNotificationQueue currentQueue] postNotificationName:kMonalContactRefresh object:account userInfo:@{@"contact":self, @"pinningChanged": @YES}];
@@ -674,7 +674,7 @@ static NSMutableDictionary* _singletonCache;
 {
     if(self.isBlocked == block)
         return YES;
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+    xmpp* account = self.account;
     if(account == nil)
         return NO;
     if(![account.connectionProperties.serverDiscoFeatures containsObject:@"urn:xmpp:blocking"])

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -47,6 +47,7 @@ static NSMutableDictionary* _singletonCache;
 @property (nonatomic, strong) NSString* contactJid;
 @property (nonatomic, strong) NSString* fullName;
 @property (nonatomic, strong) NSString* nickName;
+@property (nonatomic, strong) xmpp* account;
 
 @property (nonatomic, strong) NSDate* _Nullable lastInteractionTime;
 
@@ -569,6 +570,16 @@ static NSMutableDictionary* _singletonCache;
 +(NSSet*) keyPathsForValuesAffectingHasOutgoingContactRequest
 {
     return [NSSet setWithObjects:@"isGroup", @"ask", nil];
+}
+
+-(xmpp* _Nullable) account
+{
+    return [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountId];
+}
+
++(NSSet*) keyPathsForValuesAffectingAccount
+{
+    return [NSSet setWithObject:@"accountId"];
 }
 
 // this will cache the unread count on first access

--- a/Monal/Classes/MLImageManager.m
+++ b/Monal/Classes/MLImageManager.m
@@ -181,7 +181,7 @@
 
     if(contact.isSelfChat)
     {
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:contact.accountId];
+        xmpp* account = contact.account;
         contactLetter = [[[MLContact ownDisplayNameForAccount:account] substringToIndex:1] uppercaseString];
     }
     else

--- a/Monal/Classes/MLVoIPProcessor.m
+++ b/Monal/Classes/MLVoIPProcessor.m
@@ -165,7 +165,7 @@ static NSMutableDictionary* _pendingCalls;
 
 -(MLCall*) initiateCallWithType:(MLCallType) callType toContact:(MLContact*) contact
 {
-    xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     MLAssert(account != nil, @"account is nil in initiateCallWithType:ToContact:!", (@{@"contact": contact}));
     
     NSUUID* uuid = [NSUUID UUID];

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -647,7 +647,7 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
 -(void) sendMessageAndAddToHistory:(NSString*) message havingType:(NSString*) messageType toContact:(MLContact*) contact isEncrypted:(BOOL) encrypted uploadInfo:(NSDictionary* _Nullable) uploadInfo withCompletionHandler:(void (^ _Nullable)(BOOL success, NSString* messageId)) completion
 {
     NSString* msgid = [[NSUUID UUID] UUIDString];
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
 
     MLAssert(message != nil, @"Message should not be nil");
     MLAssert(account != nil, @"Account should not be nil");
@@ -689,7 +689,7 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
 -(void) sendMessage:(NSString*) message toContact:(MLContact*) contact isEncrypted:(BOOL) encrypted isUpload:(BOOL) isUpload messageId:(NSString*) messageId withCompletionHandler:(void (^ _Nullable)(BOOL success, NSString* messageId)) completion
 {
     BOOL success = NO;
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     if(account)
     {
         success = YES;
@@ -701,7 +701,7 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
 
 -(void) sendChatState:(BOOL) isTyping toContact:(MLContact*) contact
 {
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     if(account)
         [account sendChatState:isTyping toContact:contact];
 }
@@ -796,7 +796,7 @@ $$class_handler(handleRemoveContact, $$ID(MLContact*, contact))
 $$
 -(void) removeContact:(MLContact*) contact
 {
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     if(account)
     {
         //queue remove contact for execution once bound (e.g. on catchup done)
@@ -833,7 +833,7 @@ $$class_handler(handleAddContact, $$ID(MLContact*, contact), $_ID(NSString*, pre
 $$
 -(void) addContact:(MLContact*) contact withPreauthToken:(NSString* _Nullable) preauthToken
 {
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     if(account)
     {
         //queue add contact for execution once bound (e.g. on catchup done)
@@ -864,7 +864,7 @@ $$
 
 -(void) getEntitySoftWareVersionForContact:(MLContact*) contact andResource:(NSString*) resource
 {
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     
     NSString* xmppId = @"";
     if ((resource == nil) || ([resource length] == 0)) {
@@ -879,7 +879,7 @@ $$
 -(void) block:(BOOL) isBlocked contact:(MLContact*) contact
 {
     DDLogVerbose(@"Blocking %@: %@", contact, bool2str(isBlocked));
-    xmpp* account = [self getConnectedAccountForID:contact.accountId];
+    xmpp* account = contact.account;
     [account setBlocked:isBlocked forJid:contact.contactJid];
 }
 

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -30,7 +30,7 @@ struct MemberList: View {
     @StateObject private var overlay = LoadingOverlayState()
 
     init(mucContact: ObservableKVOWrapper<MLContact>) {
-        account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: mucContact.accountId)! as xmpp
+        account = mucContact.obj.account! as xmpp
         _muc = StateObject(wrappedValue:mucContact)
         _ownAffiliation = State(wrappedValue:"none")
         _memberList = State(wrappedValue:OrderedSet<ObservableKVOWrapper<MLContact>>())

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -879,7 +879,7 @@ $$
         MLAssert(fromContact, @"fromContact should not be nil");
         NSString* messageId = response.notification.request.content.userInfo[@"messageId"];
         MLAssert(messageId, @"messageId should not be nil");
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:fromContact.accountId];
+        xmpp* account = fromContact.account;
         //this can happen if that account got disabled
         if(account == nil)
         {
@@ -954,7 +954,7 @@ $$
         DDLogVerbose(@"notification action '%@' triggered for %@", response.actionIdentifier, response.notification.request.content.userInfo);
         MLContact* fromContact = [MLContact createContactFromJid:response.notification.request.content.userInfo[@"fromContactJid"] andAccountNo:response.notification.request.content.userInfo[@"fromContactAccountId"]];
         MLAssert(fromContact, @"fromContact should not be nil");
-        xmpp* account = [[MLXMPPManager sharedInstance] getConnectedAccountForID:fromContact.accountId];
+        xmpp* account = fromContact.account;
         //this can happen if that account got disabled
         if(account == nil)
         {

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -300,7 +300,9 @@ struct OmemoKeys: View {
 
     private func isOwnKeys() -> Bool {
         if let contact = self.viewContact, let account = self.account {
-            return (!(contact.isGroup && contact.mucType == "group") && self.account!.connectionProperties.identity.jid == contact.contactJid)
+            let isGroup = contact.isGroup && contact.mucType == "group"
+            let isOwnJid = account.connectionProperties.identity.jid == contact.contactJid
+            return !isGroup && isOwnJid
         }
         return false
     }

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -292,7 +292,7 @@ struct OmemoKeys: View {
         self.viewContact = contact
 
         if let contact = contact {
-            if let account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.accountId) {
+            if let account = contact.obj.account {
                 self.account = account
             }
         }

--- a/Monal/Classes/OmemoQrCodeView.swift
+++ b/Monal/Classes/OmemoQrCodeView.swift
@@ -30,7 +30,7 @@ struct OmemoQrCodeView: View {
     init(contact: ObservableKVOWrapper<MLContact>)
     {
         self.jid = contact.obj.contactJid
-        if let account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.obj.accountId) {
+        if let account = contact.obj.account {
             let devices = Array(account.omemo.knownDevices(forAddressName: self.jid))
             var keyList = ""
             var prefix = "?"

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -803,7 +803,7 @@ enum msgSentState {
     self.viewIsScrolling = YES;
     //stop editing (if there is some)
     [self stopEditing];
-    self.xmppAccount = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.contact.accountId];
+    self.xmppAccount = self.contact.account;
     if(!self.xmppAccount) DDLogDebug(@"Disabled account detected");
 
     [MLNotificationManager sharedInstance].currentContact = self.contact;


### PR DESCRIPTION
These are all purely refactors, there should be no change in behaviour.
Main purpose is to simplify `OmemoKeys` where there is logic that can be pushed out of the view, or removing state where we can use functions instead.