### PR TITLE
Revert #1092 (sheet dismisser removal)

### DIFF
--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -10,6 +10,7 @@ import MobileCoreServices
 import UniformTypeIdentifiers
 
 struct AddContactMenu: View {
+    var delegate: SheetDismisserProtocol
     static private let jidFaultyPattern = "^([^@]+@)?.+(\\..{2,})?$"
 
     @State private var connectedAccounts: [xmpp]
@@ -32,12 +33,11 @@ struct AddContactMenu: View {
 
     @State private var isEditingJid = false
 
-    @Environment(\.dismiss) private var dismiss
-
     private let dismissWithNewContact: (MLContact) -> ()
     private let preauthToken: String?
 
-    init(dismissWithNewContact: @escaping (MLContact) -> (), prefillJid: String = "", preauthToken:String? = nil, prefillAccount:xmpp? = nil, omemoFingerprints: [NSNumber:Data]? = nil) {
+    init(delegate: SheetDismisserProtocol, dismissWithNewContact: @escaping (MLContact) -> (), prefillJid: String = "", preauthToken:String? = nil, prefillAccount:xmpp? = nil, omemoFingerprints: [NSNumber:Data]? = nil) {
+        self.delegate = delegate
         self.dismissWithNewContact = dismissWithNewContact
         //self.toAdd = State(wrappedValue: prefillJid)
         self.toAdd = prefillJid
@@ -260,7 +260,7 @@ struct AddContactMenu: View {
                     if self.newContact != nil {
                         self.dismissWithNewContact(newContact!)
                     } else {
-                        dismiss()
+                        self.delegate.dismiss()
                     }
                 }
             }))
@@ -349,8 +349,9 @@ struct AddContactMenu: View {
 }
 
 struct AddContactMenu_Previews: PreviewProvider {
+    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        AddContactMenu(dismissWithNewContact: { c in
+        AddContactMenu(delegate: delegate, dismissWithNewContact: { c in
         })
     }
 }

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -7,7 +7,7 @@
 //
 
 struct ContactDetails: View {
-    @Environment(\.dismiss) private var dismiss
+    var delegate: SheetDismisserProtocol
     private var account: xmpp
     @State private var ownRole = "participant"
     @State private var ownAffiliation = "none"
@@ -32,7 +32,8 @@ struct ContactDetails: View {
     @State private var successCallback: monal_void_block_t?
     @StateObject private var overlay = LoadingOverlayState()
 
-    init(contact: ObservableKVOWrapper<MLContact>) {
+    init(delegate: SheetDismisserProtocol, contact: ObservableKVOWrapper<MLContact>) {
+        self.delegate = delegate
         _contact = StateObject(wrappedValue: contact)
         self.account = MLXMPPManager.sharedInstance().getConnectedAccount(forID: contact.accountId)!
     }
@@ -476,8 +477,8 @@ struct ContactDetails: View {
                                             action: {
                                                 contact.obj.removeFromRoster()      //this will dismiss the chatview via kMonalContactRemoved notification
                                                 //this will do nothing for contact details opened through group members list (which is fine!)
-                                                //NOTE: this holds for all dismiss() calls
-                                                dismiss()
+                                                //NOTE: this holds for all delegate.dismiss() calls
+                                                self.delegate.dismiss()
                                             }
                                         )
                                     ]
@@ -677,11 +678,12 @@ struct ContactDetails: View {
 }
 
 struct ContactDetails_Previews: PreviewProvider {
+    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(0)))
-        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(1)))
-        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(2)))
-        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(3)))
-        ContactDetails(contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(4)))
+        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(0)))
+        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(1)))
+        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(2)))
+        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(3)))
+        ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(MLContact.makeDummyContact(4)))
     }
 }

--- a/Monal/Classes/ImageViewer.swift
+++ b/Monal/Classes/ImageViewer.swift
@@ -46,12 +46,13 @@ struct SVGRepresentation: Transferable {
 }
 
 struct ImageViewer: View {
+    var delegate: SheetDismisserProtocol
     let info: [String:AnyObject]
     @State private var previewImage: UIImage?
     @State private var controlsVisible = false
-    @Environment(\.dismiss) private var dismiss
 
-    init(info:[String:AnyObject]) throws {
+    init(delegate: SheetDismisserProtocol, info:[String:AnyObject]) throws {
+        self.delegate = delegate
         self.info = info
     }
     
@@ -136,7 +137,7 @@ struct ImageViewer: View {
                                 }
                                 
                                 Button(action: {
-                                    dismiss()
+                                    self.delegate.dismiss()
                                 }, label: {
                                     Image(systemName: "xmark")
                                         .foregroundColor(.primary)

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -278,7 +278,7 @@ struct MemberList: View {
                             .accessibilityLabel(Text("Open Profile of \(contact.contactDisplayName as String)"))
                             //invisible navigation link that can be triggered programmatically
                             .background(
-                                NavigationLink(destination: LazyClosureView(ContactDetails(contact:contact)), tag:contact, selection:$navigationActive) { EmptyView() }
+                                NavigationLink(destination: LazyClosureView(ContactDetails(delegate:SheetDismisserProtocol(), contact:contact)), tag:contact, selection:$navigationActive) { EmptyView() }
                                     .opacity(0)
                             )
                             

--- a/Monal/Classes/PasswordMigration.swift
+++ b/Monal/Classes/PasswordMigration.swift
@@ -7,7 +7,7 @@
 //
 
 struct PasswordMigration: View {
-    @Environment(\.dismiss) private var dismiss
+    let delegate: SheetDismisserProtocol
     @State var needingMigration: [Int:[String:NSObject]]
 #if IS_ALPHA
     let appLogoId = "AlphaAppLogo"
@@ -17,7 +17,8 @@ struct PasswordMigration: View {
     let appLogoId = "AppLogo"
 #endif
     
-    init(needingMigration:[[String:NSObject]]) {
+    init(delegate:SheetDismisserProtocol, needingMigration:[[String:NSObject]]) {
+        self.delegate = delegate
         var tmpState = [Int:[String:NSObject]]()
         for entry in needingMigration {
             let id = (entry["account_id"] as! NSNumber).intValue
@@ -112,7 +113,7 @@ struct PasswordMigration: View {
                             }
                         }
                         NotificationCenter.default.post(name:Notification.Name("kMonalRefresh"), object:nil);
-                        dismiss()
+                        self.delegate.dismiss()
                     }, label: {
                         Text("Done")
                     })
@@ -143,7 +144,8 @@ func previewMock() -> [[String:NSObject]] {
 }
 
 struct PasswordMigration_Previews: PreviewProvider {
+    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        PasswordMigration(needingMigration:previewMock())
+        PasswordMigration(delegate:delegate, needingMigration:previewMock())
     }
 }

--- a/Monal/Classes/RegisterAccount.swift
+++ b/Monal/Classes/RegisterAccount.swift
@@ -60,9 +60,10 @@ struct RegisterAccount: View {
     @State private var showWebView = false
     @State private var errorObserverEnabled = false
 
-    @Environment(\.dismiss) private var dismiss
+    var delegate: SheetDismisserProtocol
 
-    init(registerData:[String:AnyObject]? = nil) {
+    init(delegate: SheetDismisserProtocol, registerData:[String:AnyObject]? = nil) {
+        self.delegate = delegate
         if let registerData = registerData {
             DDLogDebug("RegisterAccount created with data: \(registerData)");
             //for State stuff see https://forums.swift.org/t/assignment-to-state-var-in-init-doesnt-do-anything-but-the-compiler-gened-one-works/35235
@@ -413,7 +414,7 @@ struct RegisterAccount: View {
                             .alert(isPresented: $showAlert) {
                                 Alert(title: alertPrompt.title, message: alertPrompt.message, dismissButton: .default(alertPrompt.dismissLabel, action: {
                                     if(self.registerComplete == true) {
-                                        dismiss()
+                                        self.delegate.dismiss()
                                         
                                         if let completion = self.completionHandler {
                                             DDLogVerbose("Calling reg completion handler...")
@@ -500,7 +501,8 @@ struct RegisterAccount: View {
 }
 
 struct RegisterAccount_Previews: PreviewProvider {
+    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        RegisterAccount()
+        RegisterAccount(delegate:delegate)
     }
 }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -700,9 +700,9 @@ class SwiftuiInterface : NSObject {
             case "DebugView":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(DebugView())))
             case "WelcomeLogIn":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn())))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn(delegate:delegate))))
             case "LogIn":
-                host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn())))
+                host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn(delegate:delegate))))
             case "CreateGroup":
                 host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: CreateGroupMenu(delegate: delegate))))
             case "ChatPlaceholder":

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -511,9 +511,10 @@ struct LazyClosureView<Content: View>: View {
 // use this to wrap a view into NavigationView, if it should be the outermost swiftui view of a new view stack
 struct AddTopLevelNavigation<Content: View>: View {
     let build: () -> Content
-    @Environment(\.dismiss) private var dismiss
-    init(to build: @autoclosure @escaping () -> Content) {
+    let delegate: SheetDismisserProtocol
+    init(withDelegate delegate: SheetDismisserProtocol, to build: @autoclosure @escaping () -> Content) {
         self.build = build
+        self.delegate = delegate
     }
     var body: some View {
         NavigationView {
@@ -521,7 +522,7 @@ struct AddTopLevelNavigation<Content: View>: View {
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
             .navigationBarItems(leading: Button(action : {
-                dismiss()
+                self.delegate.dismiss()
             }){
                 Image(systemName: "arrow.backward")
             }.keyboardShortcut(.escape, modifiers: []))
@@ -619,7 +620,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
         return host
     }
     
@@ -637,7 +638,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
         return host
     }
     
@@ -671,7 +672,7 @@ class SwiftuiInterface : NSObject {
         delegate.host = host
         host.rootView = AnyView(Quicksy_RegisterAccount(delegate:delegate))
 #else
-        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(delegate:delegate, registerData:registerData)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:RegisterAccount(delegate:delegate, registerData:registerData)))
 #endif
         return host
     }
@@ -681,7 +682,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
         return host
     }
     
@@ -690,7 +691,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
         return host
     }
     
@@ -699,7 +700,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
         return host
     }
 
@@ -712,19 +713,19 @@ class SwiftuiInterface : NSObject {
             case "DebugView":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(DebugView())))
             case "WelcomeLogIn":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to:WelcomeLogIn(delegate:delegate))))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate:delegate, to:WelcomeLogIn(delegate:delegate))))
             case "LogIn":
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(WelcomeLogIn(delegate:delegate))))
             case "CreateGroup":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: CreateGroupMenu(delegate: delegate))))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: CreateGroupMenu(delegate: delegate))))
             case "ChatPlaceholder":
                 host = UIHostingController(rootView:AnyView(ChatPlaceholder()))
             case "GeneralSettings" :
                 host = UIHostingController(rootView:AnyView(UIKitWorkaround(GeneralSettings())))
             case "ActiveChatsGeneralSettings":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: GeneralSettings())))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: GeneralSettings())))
             case "ActiveChatsNotificationSettings":
-                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(to: NotificationSettings())))
+                host = UIHostingController(rootView:AnyView(AddTopLevelNavigation(withDelegate: delegate, to: NotificationSettings())))
             case "OnboardingView":
                 host = UIHostingController(rootView:AnyView(createOnboardingView(delegate:delegate)))
             

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -616,7 +616,9 @@ public extension UIViewController {
 class SwiftuiInterface : NSObject {
     @objc(makeAccountPickerForContacts:andCallType:)
     func makeAccountPicker(for contacts: [MLContact], and callType: UInt) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
+        delegate.host = host
         host.rootView = AnyView(AddTopLevelNavigation(to:AccountPicker(contacts:contacts, callType:MLCallType(rawValue: callType)!)))
         return host
     }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -674,8 +674,10 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makePasswordMigration(_ needingMigration: [[String:NSObject]]) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(needingMigration:needingMigration)))
+        delegate.host = host
+        host.rootView = AnyView(AddTopLevelNavigation(to:PasswordMigration(delegate:delegate, needingMigration:needingMigration)))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -634,8 +634,10 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makeContactDetails(_ contact: MLContact) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(contact:ObservableKVOWrapper<MLContact>(contact))))
+        delegate.host = host
+        host.rootView = AnyView(AddTopLevelNavigation(to:ContactDetails(delegate:delegate, contact:ObservableKVOWrapper<MLContact>(contact))))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -643,8 +643,10 @@ class SwiftuiInterface : NSObject {
     
     @objc(makeImageViewerForInfo:)
     func makeImageViewerFor(info:[String:AnyObject]) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(try! ImageViewer(info:info))
+        delegate.host = host
+        host.rootView = AnyView(try! ImageViewer(delegate:delegate, info:info))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -661,13 +661,15 @@ class SwiftuiInterface : NSObject {
     
     @objc
     func makeAccountRegistration(_ registerData: [String:AnyObject]?) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
+        delegate.host = host
 #if IS_QUICKSY
         let delegate = SheetDismisserProtocol()
         delegate.host = host
         host.rootView = AnyView(Quicksy_RegisterAccount(delegate:delegate))
 #else
-        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(registerData:registerData)))
+        host.rootView = AnyView(AddTopLevelNavigation(to:RegisterAccount(delegate:delegate, registerData:registerData)))
 #endif
         return host
     }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -683,15 +683,19 @@ class SwiftuiInterface : NSObject {
     
     @objc(makeAddContactViewWithDismisser:)
     func makeAddContactView(dismisser: @escaping (MLContact) -> ()) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(dismissWithNewContact: dismisser)))
+        delegate.host = host
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser)))
         return host
     }
     
     @objc
     func makeAddContactView(forJid jid:String, preauthToken: String?, prefillAccount: xmpp?, andOmemoFingerprints omemoFingerprints: [NSNumber:Data]?, withDismisser dismisser: @escaping (MLContact) -> ()) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
+        delegate.host = host
+        host.rootView = AnyView(AddTopLevelNavigation(to: AddContactMenu(delegate: delegate, dismissWithNewContact: dismisser, prefillJid: jid, preauthToken: preauthToken, prefillAccount: prefillAccount, omemoFingerprints: omemoFingerprints)))
         return host
     }
 

--- a/Monal/Classes/WelcomeLogIn.swift
+++ b/Monal/Classes/WelcomeLogIn.swift
@@ -215,7 +215,7 @@ struct WelcomeLogIn: View {
                                 }
                             }
                             
-                            NavigationLink(destination: LazyClosureView(RegisterAccount())) {
+                            NavigationLink(destination: LazyClosureView(RegisterAccount(delegate: self.delegate))) {
                                 Text("Register a new account")
                                 .foregroundColor(monalDarkGreen)
                             }

--- a/Monal/Classes/WelcomeLogIn.swift
+++ b/Monal/Classes/WelcomeLogIn.swift
@@ -9,7 +9,7 @@
 struct WelcomeLogIn: View {
     static private let credFaultyPattern = "^.+@.+\\..{2,}$"
     
-    @Environment(\.dismiss) private var dismiss
+    var delegate: SheetDismisserProtocol
 
     @State private var isEditingJid: Bool = false
     @State private var jid: String = ""
@@ -183,7 +183,7 @@ struct WelcomeLogIn: View {
                                 .alert(isPresented: $showAlert) {
                                     Alert(title: alertPrompt.title, message: alertPrompt.message, dismissButton: .default(alertPrompt.dismissLabel, action: {
                                         if(self.loginComplete == true) {
-                                            dismiss()
+                                            self.delegate.dismiss()
                                         }
                                     }))
                                 }
@@ -222,7 +222,7 @@ struct WelcomeLogIn: View {
                             
                             if(DataLayer.sharedInstance().enabledAccountCnts() == 0) {
                                 Button(action: {
-                                    dismiss()
+                                    self.delegate.dismiss()
                                 }){
                                     Text("Set up account later")
                                         .frame(maxWidth: .infinity)
@@ -308,7 +308,8 @@ struct WelcomeLogIn: View {
 }
 
 struct WelcomeLogIn_Previews: PreviewProvider {
+    static var delegate = SheetDismisserProtocol()
     static var previews: some View {
-        WelcomeLogIn()
+        WelcomeLogIn(delegate:delegate)
     }
 }


### PR DESCRIPTION
I found a relatively fundamental problem with #1092, which is that the DismissAction only goes as far as the boundary between SwiftUI and UIKit. For example, if I register via the "Add Account" button in the settings, there is no way to get back to the list of chats via DismissAction.

Therefore - this PR reverts my changes to remove the SheetDismisserProtocol. I wasn't able to get rid of all the usages anyway, and I think it will be much easier to implement once we only have SwiftUI, and programmatic navigation.