### PR TITLE
Add ContentUnavailableView to OmemoKeys

### DIFF
--- a/Monal/Classes/ContentUnavailableShimView.swift
+++ b/Monal/Classes/ContentUnavailableShimView.swift
@@ -1,0 +1,45 @@
+//
+//  ContentNotAvailableView.swift
+//  Monal
+//
+//  Created by Matthew Fennell <matthew@fennell.dev> on 05/08/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContentUnavailableShimView: View {
+    private var reason: String
+    private var systemImage: String
+    private var description: Text
+
+    init(_ reason: String, systemImage: String, description: Text) {
+        self.reason = reason
+        self.systemImage = systemImage
+        self.description = description
+    }
+
+    var body: some View {
+        if #available(iOS 17, *) {
+            ContentUnavailableView(reason, systemImage: systemImage, description: description)
+        } else {
+            VStack {
+                Image(systemName: systemImage)
+                    .foregroundStyle(.secondary)
+                    .font(.largeTitle)
+                    .padding(.bottom, 4)
+                Text(reason)
+                    .fontWeight(.bold)
+                    .font(.title3)
+                description
+                    .foregroundStyle(.secondary)
+                    .font(.footnote)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+}
+
+#Preview {
+    ContentUnavailableShimView("Cannot Display", systemImage: "iphone.homebutton.slash", description: Text("Cannot display for this reason."))
+}

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -429,9 +429,9 @@ struct OmemoKeys: View {
         if self.account != nil && !self.contacts.isEmpty {
             OmemoKeysForChat(contact: viewContact)
         } else if self.contacts.isEmpty {
-            ContentUnavailableShimView("No contacts", systemImage: "person.2.slash", description: Text("Error: No contacts to display keys for!"))
+            ContentUnavailableShimView("No Contacts", systemImage: "person.2.slash", description: Text("Cannot display keys as there are no contacts to display keys for."))
         } else if self.account == nil {
-            ContentUnavailableShimView("Account disabled", systemImage: "iphone.homebutton.slash", description: Text("Error: Account disabled, can not display keys!"))
+            ContentUnavailableShimView("Account Disabled", systemImage: "iphone.homebutton.slash", description: Text("Cannot display keys as the account is disabled."))
         }
     }
 }

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -269,7 +269,7 @@ struct OmemoKeysForContact: View {
     }
 }
 
-struct OmemoKeys: View {
+struct OmemoKeysForChat: View {
     private var viewContact: ObservableKVOWrapper<MLContact>? // store initial contact with which the view was initialized for refreshs...
     private var account: xmpp?
 
@@ -349,11 +349,7 @@ struct OmemoKeys: View {
             Text("You should trust a key when you have verified it. Verify by comparing the key below to the one on your contact's screen. Double tap onto a fingerprint to copy to clipboard.")
 
             Section(header:helpDescription) {
-                if(self.contacts.count == 0) {
-                    Text("Error: No contacts to display keys for!").foregroundColor(.red).font(.headline)
-                } else if(self.account == nil) {
-                    Text("Error: Account disabled, can not display keys!").foregroundColor(.red).font(.headline)
-                } else if (self.contacts.count == 1) {
+                if (self.contacts.count == 1) {
                     ForEach(self.contacts, id: \.self.obj) { contact in
                         OmemoKeysForContact(contact: contact, account: self.account!)
                     }
@@ -414,6 +410,28 @@ struct OmemoKeys: View {
                     self.scannedFingerprints = [:]
                     self.contacts = getContactList(viewContact: self.viewContact) // refresh all contacts because trust may have changed
             }))
+        }
+    }
+}
+
+struct OmemoKeys: View {
+    private var viewContact: ObservableKVOWrapper<MLContact>?
+    private var account: xmpp?
+    @State private var contacts: OrderedSet<ObservableKVOWrapper<MLContact>>
+
+    init(contact: ObservableKVOWrapper<MLContact>?) {
+        self.viewContact = contact
+        self.account = contact?.account
+        self.contacts = getContactList(viewContact: contact)
+    }
+
+    var body: some View {
+        if self.account != nil && !self.contacts.isEmpty {
+            OmemoKeysForChat(contact: viewContact)
+        } else if self.contacts.isEmpty {
+            ContentUnavailableShimView("No contacts", systemImage: "person.2.slash", description: Text("Error: No contacts to display keys for!"))
+        } else if self.account == nil {
+            ContentUnavailableShimView("Account disabled", systemImage: "iphone.homebutton.slash", description: Text("Error: Account disabled, can not display keys!"))
         }
     }
 }

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		26E8462824EABAED00ECE419 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 26E8462A24EABAED00ECE419 /* Main.storyboard */; };
 		26F9794D1ACAC73A0008E005 /* MLContactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F9794C1ACAC73A0008E005 /* MLContactCell.xib */; };
 		26FE3BCB1C61A6C3003CC230 /* MLResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26FE3BCA1C61A6C3003CC230 /* MLResizingTextView.m */; };
+		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
 		38720923251EDE07001837EB /* MLXEPSlashMeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */; };
 		389E298C25E901CA009A5268 /* MLAudioRecoderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 389E298925E901CA009A5268 /* MLAudioRecoderManager.m */; };
 		389E298D25E901CA009A5268 /* MLAudioRecoderManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 389E298B25E901CA009A5268 /* MLAudioRecoderManager.h */; };
@@ -500,6 +501,7 @@
 		2C59BAF969550DFAC27E5F2B /* Pods_MonalXMPPUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MonalXMPPUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E5021A8D40FCC591D952104 /* Pods-NotificaionService.alpha-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificaionService.alpha-ios.xcconfig"; path = "Target Support Files/Pods-NotificaionService/Pods-NotificaionService.alpha-ios.xcconfig"; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* MonalSourceCodePrefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MonalSourceCodePrefix.pch; sourceTree = "<group>"; };
+		34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableShimView.swift; sourceTree = "<group>"; };
 		3872091F251EDE07001837EB /* MLXEPSlashMeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLXEPSlashMeHandler.h; sourceTree = "<group>"; };
 		38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLXEPSlashMeHandler.m; sourceTree = "<group>"; };
 		389E298925E901CA009A5268 /* MLAudioRecoderManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLAudioRecoderManager.m; sourceTree = "<group>"; };
@@ -1079,6 +1081,7 @@
 				841898AB2957DBAC00FEC77D /* RichAlert.swift */,
 				C114D13C2B15B903000FB99F /* ContactEntry.swift */,
 				952EBC7F2BAF72F300183DBF /* DebugView.swift */,
+				34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */,
 			);
 			name = "View Controllers";
 			path = Classes;
@@ -2130,6 +2133,7 @@
 				2644D4951FF046E800F46AB5 /* MLBaseCell.m in Sources */,
 				268DD58617C4541000C673A9 /* MLChatCell.m in Sources */,
 				2644D4991FF29E5600F46AB5 /* MLSettingsTableViewController.m in Sources */,
+				34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */,
 				846DF27C2937FAA600AAB9C0 /* ChatPlaceholder.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;


### PR DESCRIPTION
iPhone iOS 18:

![iphone-ios18-no-contacts](https://github.com/user-attachments/assets/13091454-c70a-4956-96b3-dca232648c55)
![iphone-ios18-account-disabled](https://github.com/user-attachments/assets/510717a9-ec96-48a9-96ea-7ad0a2d0e4ff)

iPhone iOS 16:

![iphone-ios-16-no-contacts](https://github.com/user-attachments/assets/b6c25ed5-486f-46eb-b0aa-ac2b18386427)
![iphone-ios-16-account-disabled](https://github.com/user-attachments/assets/11ccdf6d-cab1-44f6-89fc-5c2e91ffc4b6)

iPad iOS 18:

![ipad-ios18-no-contacts](https://github.com/user-attachments/assets/753526d5-4e08-49d9-a722-fbfa5bd0f887)
![ipad-ios18-account-disabled](https://github.com/user-attachments/assets/60408e99-eaa4-437f-8e27-d46e77ff57b7)

iPad iOS 16:

![ipad-ios16-no-contacts](https://github.com/user-attachments/assets/0eaa6928-89e7-4320-8344-ec62d9ebea63)
![ipad-ios16-account-disabled](https://github.com/user-attachments/assets/64550612-8b58-4741-8ddc-cc691922806b)

One extra thing I noticed is that there is no back button on the `OmemoKeys` view on the iPad. It's already like that even before this commit (even when there are keys to display), but I'll take a look and see if I can find a way to add it in.

Also - I modified the wording a little, but appreciate that will generate new translations, so if we'd rather stick with the existing wording, we can just drop the last commit.