### PR TITLE
Remove unnecessary calls to .obj on MLContact

### DIFF
--- a/Monal/Classes/ChannelMemberList.swift
+++ b/Monal/Classes/ChannelMemberList.swift
@@ -15,7 +15,7 @@ struct ChannelMemberList: View {
     @State private var participants: OrderedDictionary<String, String>
 
     init(mucContact: ObservableKVOWrapper<MLContact>) {
-        account = mucContact.obj.account! as xmpp
+        account = (mucContact.account as xmpp?)!
         _channel = StateObject(wrappedValue:mucContact)
         _ownAffiliation = State(wrappedValue:"none")
         _participants = State(wrappedValue:OrderedDictionary<String, String>())

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -35,7 +35,7 @@ struct ContactDetails: View {
     init(delegate: SheetDismisserProtocol, contact: ObservableKVOWrapper<MLContact>) {
         self.delegate = delegate
         _contact = StateObject(wrappedValue: contact)
-        self.account = contact.obj.account!
+        self.account = (contact.account as xmpp?)!
     }
 
     private func updateRoleAndAffiliation() {

--- a/Monal/Classes/EditGroupSubject.swift
+++ b/Monal/Classes/EditGroupSubject.swift
@@ -19,7 +19,7 @@ struct EditGroupSubject: View {
         
         _subject = State(wrappedValue: contact.obj.groupSubject)
         _contact = StateObject(wrappedValue: contact)
-        self.account = contact.obj.account! as xmpp
+        self.account = (contact.account as xmpp?)!
     }
 
     var body: some View {

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -30,7 +30,7 @@ struct MemberList: View {
     @StateObject private var overlay = LoadingOverlayState()
 
     init(mucContact: ObservableKVOWrapper<MLContact>) {
-        account = mucContact.obj.account! as xmpp
+        account = (mucContact.account as xmpp?)!
         _muc = StateObject(wrappedValue:mucContact)
         _ownAffiliation = State(wrappedValue:"none")
         _memberList = State(wrappedValue:OrderedSet<ObservableKVOWrapper<MLContact>>())

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -292,7 +292,7 @@ struct OmemoKeys: View {
         self.viewContact = contact
 
         if let contact = contact {
-            if let account = contact.obj.account {
+            if let account = contact.account as xmpp? {
                 self.account = account
             }
         }

--- a/Monal/Classes/OmemoQrCodeView.swift
+++ b/Monal/Classes/OmemoQrCodeView.swift
@@ -30,7 +30,7 @@ struct OmemoQrCodeView: View {
     init(contact: ObservableKVOWrapper<MLContact>)
     {
         self.jid = contact.obj.contactJid
-        if let account = contact.obj.account {
+        if let account = contact.account as xmpp? {
             let devices = Array(account.omemo.knownDevices(forAddressName: self.jid))
             var keyList = ""
             var prefix = "?"

--- a/Monal/localization/Base.lproj/Main.storyboard
+++ b/Monal/localization/Base.lproj/Main.storyboard
@@ -1358,11 +1358,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="A Status message would go here. That is correct, a status message. " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15o-hp-DgI">
                                                     <rect key="frame" x="10" y="9" width="1004" height="34"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="33.670000000000002" id="0ag-YG-RGy"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                     <attributedString key="userComments">
                                                         <fragment content="#bc-ignore!"/>


### PR DESCRIPTION
We must explicitly cast MLContact.account to type xmpp?, as Swift struggles to infer this by itself.