### PR TITLE
SwiftUI contact list

### DIFF
--- a/Monal/Classes/ActiveChatsViewController.h
+++ b/Monal/Classes/ActiveChatsViewController.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class chatViewController;
 @class MLCall;
 
+@interface SizeClassWrapper: NSObject
+@property (atomic) UIUserInterfaceSizeClass horizontal;
+@end
+
 @interface ActiveChatsViewController : UITableViewController  <DZNEmptyDataSetSource, DZNEmptyDataSetDelegate>
 
 @property (nonatomic, strong) UITableView* chatListTable;
@@ -26,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) IBOutlet UIBarButtonItem* composeButton;
 @property (nonatomic, strong) chatViewController* currentChatViewController;
 @property (nonatomic, strong) UIActivityIndicatorView* spinner;
+@property (atomic, strong) SizeClassWrapper* sizeClass;
 
 -(void) showCallContactNotFoundAlert:(NSString*) jid;
 -(void) callContact:(MLContact*) contact withUIKitSender:(_Nullable id) sender;
@@ -52,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) segueToIntroScreensIfNeeded;
 -(void) resetViewQueue;
 -(void) dismissCompleteViewChainWithAnimation:(BOOL) animation andCompletion:(monal_void_block_t _Nullable) completion;
+-(void) updateSizeClass;
 
 @end
 

--- a/Monal/Classes/ActiveChatsViewController.m
+++ b/Monal/Classes/ActiveChatsViewController.m
@@ -1106,12 +1106,12 @@ static NSMutableSet* _pushWarningDisplayed;
             return;
         }
 
-        UINavigationController* nav = segue.destinationViewController;
-        ContactsViewController* contacts = (ContactsViewController*)nav.topViewController;
-        contacts.selectContact = ^(MLContact* selectedContact) {
+        contactCompletion callback = ^(MLContact* selectedContact) {
             DDLogVerbose(@"Got selected contact from contactlist ui: %@", selectedContact);
             [self presentChatWithContact:selectedContact];
         };
+        UIViewController* contactsView = [[SwiftuiInterface new] makeContactsViewWithDismisser: callback onButton: self.composeButton];
+        [self presentViewController:contactsView animated:YES completion:^{}];
     }
 }
 

--- a/Monal/Classes/ActiveChatsViewController.m
+++ b/Monal/Classes/ActiveChatsViewController.m
@@ -62,6 +62,9 @@ typedef void (^view_queue_block_t)(PMKResolver _Nonnull);
 @property (atomic, strong) NSMutableArray* pinnedContacts;
 @end
 
+@implementation SizeClassWrapper
+@end
+
 @implementation ActiveChatsViewController
 
 enum activeChatsControllerSections {
@@ -282,6 +285,9 @@ static NSMutableSet* _pushWarningDisplayed;
     
     self.view = self.chatListTable;
     
+    self.sizeClass = [SizeClassWrapper new];
+    [self updateSizeClass];
+
     NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(handleRefreshDisplayNotification:) name:kMonalRefresh object:nil];
     [nc addObserver:self selector:@selector(handleContactRemoved:) name:kMonalContactRemoved object:nil];
@@ -1113,6 +1119,10 @@ static NSMutableSet* _pushWarningDisplayed;
         UIViewController* contactsView = [[SwiftuiInterface new] makeContactsViewWithDismisser: callback onButton: self.composeButton];
         [self presentViewController:contactsView animated:YES completion:^{}];
     }
+}
+
+-(void) updateSizeClass {
+    self.sizeClass.horizontal = self.view.traitCollection.horizontalSizeClass;
 }
 
 -(NSMutableArray*) getChatArrayForSection:(size_t) section

--- a/Monal/Classes/ContactsView.swift
+++ b/Monal/Classes/ContactsView.swift
@@ -108,6 +108,11 @@ struct ContactsView: View {
     private var contactList: [MLContact] {
         return contacts.contacts
             .filter(ContactsView.shouldDisplayContact)
+            .sorted { ContactsView.sortingCriteria($0) < ContactsView.sortingCriteria($1) }
+    }
+
+    private static func sortingCriteria(_ contact: MLContact) -> (String, String) {
+        return (contact.contactDisplayName.lowercased(), contact.contactJid.lowercased())
     }
 
     init(contacts: Contacts, delegate: SheetDismisserProtocol, dismissWithContact: @escaping (MLContact) -> ()) {

--- a/Monal/Classes/ContactsView.swift
+++ b/Monal/Classes/ContactsView.swift
@@ -1,0 +1,171 @@
+//
+//  ContactsView.swift
+//  Monal
+//
+//  Created by Matthew Fennell <matthew@fennell.dev> on 10/08/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+import SwiftUI
+
+struct ContactViewEntry: View {
+    private let contact: MLContact
+    @Binding private var selectedContactForContactDetails: ObservableKVOWrapper<MLContact>?
+    private let dismissWithContact: (MLContact) -> ()
+
+    @State private var shouldPresentRemoveContactAlert: Bool = false
+
+    private var removeContactButtonText: String {
+        if (!isDeletable) {
+            return "Cannot delete notes to self"
+        }
+        return contact.isGroup ? "Remove Conversation" : "Remove Contact"
+    }
+
+    private var removeContactConfirmationTitle: String {
+        contact.isGroup ? "Leave this converstion?" : "Remove \(contact.contactJid) from contacts?"
+    }
+
+    private var removeContactConfirmationDetail: String {
+        contact.isGroup ? "" : "They will no longer see when you are online. They may not be able to access your encryption keys."
+    }
+
+    private var isDeletable: Bool {
+        !contact.isSelfChat
+    }
+
+    init (contact: MLContact, selectedContactForContactDetails: Binding<ObservableKVOWrapper<MLContact>?>, dismissWithContact: @escaping (MLContact) -> ()) {
+        self.contact = contact
+        self._selectedContactForContactDetails = selectedContactForContactDetails
+        self.dismissWithContact = dismissWithContact
+    }
+
+    var body: some View {
+        // Apple's list dividers only extend as far left as the left-most text in the view.
+        // This means, by default, that the dividers on this screen would not extend all the way to the left of the view.
+        // This combination of HStack with spacing of 0, and empty text at the left of the view, is a workaround to override this behaviour.
+        // See https://stackoverflow.com/a/76698909
+        HStack(spacing: 0) {
+            Text("").frame(maxWidth: 0)
+            Button(action: { dismissWithContact(contact) }) {
+                // The only purpose of this NavigationLink is making the button it contains look nice.
+                // In other words: have a screen-wide touch target and the chveron on the right of the screen.
+                // This avoids having to do manual button styling that might have to be recreated in the future.
+                NavigationLink(destination: EmptyView()) {
+                    HStack {
+                        ContactEntry(contact: ObservableKVOWrapper<MLContact>(contact))
+                        Spacer()
+                        Button {
+                            selectedContactForContactDetails = ObservableKVOWrapper<MLContact>(contact)
+                        } label: {
+                            Image(systemName: "info.circle")
+                                .tint(.blue)
+                                .imageScale(.large)
+                        }
+                        .accessibilityLabel("Open contact details")
+                    }
+                }
+            }
+        }
+        .swipeActions(allowsFullSwipe: false) {
+            // We do not use a Button with destructive role here as we would like to display the confirmation dialog first.
+            // A destructive role would dismiss the row immediately, without waiting for the confirmation.
+            Button(removeContactButtonText) {
+                shouldPresentRemoveContactAlert = true
+            }
+            .tint(isDeletable ? .red : .gray)
+            .disabled(!isDeletable)
+        }
+        .confirmationDialog(removeContactConfirmationTitle, isPresented: $shouldPresentRemoveContactAlert, titleVisibility: .visible) {
+            Button(role: .cancel) {} label: {
+                Text("No")
+            }
+            Button(role: .destructive) {
+                MLXMPPManager.sharedInstance().remove(contact)
+            } label: {
+                Text("Yes")
+            }
+        } message: {
+            Text(removeContactConfirmationDetail)
+        }
+    }
+}
+
+struct ContactsView: View {
+    @ObservedObject private var contacts: Contacts
+    private let delegate: SheetDismisserProtocol
+    private let dismissWithContact: (MLContact) -> ()
+
+    @State private var selectedContactForContactDetails: ObservableKVOWrapper<MLContact>? = nil
+
+    private static func shouldDisplayContact(contact: MLContact) -> Bool {
+#if IS_QUICKSY
+        return true
+#endif
+        return contact.isSubscribedTo || contact.hasOutgoingContactRequest || contact.isSubscribedFrom
+    }
+
+    private var contactList: [MLContact] {
+        return contacts.contacts
+            .filter(ContactsView.shouldDisplayContact)
+    }
+
+    init(contacts: Contacts, delegate: SheetDismisserProtocol, dismissWithContact: @escaping (MLContact) -> ()) {
+        self.contacts = contacts
+        self.delegate = delegate
+        self.dismissWithContact = dismissWithContact
+    }
+
+    var body: some View {
+        List {
+            ForEach(contactList, id: \.self) { contact in
+                ContactViewEntry(contact: contact, selectedContactForContactDetails: $selectedContactForContactDetails, dismissWithContact: dismissWithContact)
+            }
+        }
+        .animation(.default, value: contactList)
+        .navigationTitle("Contacts")
+        .listStyle(.plain)
+        .overlay {
+            if contactList.isEmpty {
+                ContentUnavailableShimView("You need friends for this ride", systemImage: "figure.wave", description: Text("Add new contacts with the + button above. Your friends will pop up here when they can talk"))
+            }
+        }
+        .toolbar {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                NavigationLink(destination: CreateGroupMenu(delegate: SheetDismisserProtocol())) {
+                    Image(systemName: "person.3.fill")
+                }
+                .accessibilityLabel("Create contact group")
+                .tint(monalGreen)
+                NavigationLink(destination: AddContactMenu(delegate: SheetDismisserProtocol(), dismissWithNewContact: dismissWithContact)) {
+                    Image(systemName: "person.fill.badge.plus")
+                        .overlay { NumberlessBadge($contacts.requestCount) }
+                }
+                .accessibilityLabel(contacts.requestCount > 0 ? "Add contact (contact requests pending)" : "Add New Contact")
+                .tint(monalGreen)
+            }
+        }
+        .sheet(item: $selectedContactForContactDetails) { selectedContact in
+            AnyView(AddTopLevelNavigation(withDelegate: delegate, to: ContactDetails(delegate: SheetDismisserProtocol(), contact: selectedContact)))
+        }
+    }
+}
+
+class Contacts: ObservableObject {
+    @Published var contacts: Set<MLContact>
+    @Published var requestCount: Int
+
+    init() {
+        self.contacts = Set(DataLayer.sharedInstance().contactList())
+        self.requestCount = DataLayer.sharedInstance().allContactRequests().count
+
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshContacts), name: NSNotification.Name("kMonalContactRemoved"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(refreshContacts), name: NSNotification.Name("kMonalContactRefresh"), object: nil)
+    }
+
+    @objc
+    private func refreshContacts() {
+        self.contacts = Set(DataLayer.sharedInstance().contactList())
+        self.requestCount = DataLayer.sharedInstance().allContactRequests().count
+    }
+}

--- a/Monal/Classes/ContentUnavailableShimView.swift
+++ b/Monal/Classes/ContentUnavailableShimView.swift
@@ -40,6 +40,10 @@ struct ContentUnavailableShimView: View {
     }
 }
 
+extension ContentUnavailableShimView {
+    static var search: ContentUnavailableShimView = ContentUnavailableShimView("No Results", systemImage: "magnifyingglass", description: Text("Check the spelling or try a new search."))
+}
+
 #Preview {
     ContentUnavailableShimView("Cannot Display", systemImage: "iphone.homebutton.slash", description: Text("Cannot display for this reason."))
 }

--- a/Monal/Classes/ContentUnavailableShimView.swift
+++ b/Monal/Classes/ContentUnavailableShimView.swift
@@ -1,5 +1,5 @@
 //
-//  ContentNotAvailableView.swift
+//  ContentUnavailableShimView.swift
 //  Monal
 //
 //  Created by Matthew Fennell <matthew@fennell.dev> on 05/08/2024.

--- a/Monal/Classes/CreateGroupMenu.swift
+++ b/Monal/Classes/CreateGroupMenu.swift
@@ -36,6 +36,15 @@ struct CreateGroupMenu: View {
         showAlert = true
     }
 
+    // When a Form is placed inside a Popover, and the horizontal size class is regular, the spacing chosen by SwiftUI is incorrect.
+    // In particular, the spacing between the top of the first element and the navigation bar is too small, meaning the two overlap.
+    // This only happens when the view is inside a popover, and the horizontal size class is regular.
+    // Therefore, it is inconvenient to apply some manual spacing, as this we would have to work out in which situations it should be applied.
+    // Placing a Text view inside the header causes SwiftUI to add consistent spacing in all situations.
+    var popoverFormSpacingWorkaround: some View {
+        Text("")
+    }
+
     var body: some View {
         Form {
             if connectedAccounts.isEmpty {
@@ -44,7 +53,7 @@ struct CreateGroupMenu: View {
             }
             else
             {
-                Section() {
+                Section(header: popoverFormSpacingWorkaround) {
                     if connectedAccounts.count > 1 {
                         Picker(selection: $selectedAccount, label: Text("Use account")) {
                             ForEach(Array(self.connectedAccounts.enumerated()), id: \.element) { idx, account in

--- a/Monal/Classes/MLSplitViewDelegate.m
+++ b/Monal/Classes/MLSplitViewDelegate.m
@@ -28,11 +28,22 @@
     if([splitViewController.viewControllers count] > 1)
         secondaryController = splitViewController.viewControllers[1];
     
+    if([primaryController isKindOfClass:NSClassFromString(@"ActiveChatsViewController")])
+        [(ActiveChatsViewController*)primaryController updateSizeClass];
+
     if([primaryController isKindOfClass:NSClassFromString(@"ActiveChatsViewController")] && [secondaryController isKindOfClass:NSClassFromString(@"MLPlaceholderViewController")])
         [(ActiveChatsViewController*)primaryController presentSplitPlaceholder];
     
     if([primaryController isKindOfClass:NSClassFromString(@"MLSettingsTableViewController")] && [secondaryController isKindOfClass:NSClassFromString(@"MLPlaceholderViewController")])
         [(MLSettingsTableViewController*)primaryController presentSplitPlaceholder];
+}
+
+-(void) splitViewControllerDidCollapse:(UISplitViewController*) splitViewController
+{
+    UIViewController* primaryController = ((UINavigationController*)splitViewController.viewControllers[0]).viewControllers[0];
+
+    if([primaryController isKindOfClass:NSClassFromString(@"ActiveChatsViewController")])
+        [(ActiveChatsViewController*)primaryController updateSizeClass];
 }
 
 @end

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -299,21 +299,23 @@ struct MemberList: View {
                                 view
                             }
                         }
-                        .deleteDisabled(!isDeletable)
-                    }
-                }
-                .onDelete(perform: { memberIdx in
-                    let member = memberList[memberIdx.first!]
-                    showActionSheet(title: Text("Remove \(mucAffiliationToString(affiliations[member]))?"), description: self.muc.mucType == "group" ? Text("Do you want to remove that user from this group? That user won't be able to enter it again until added back to the group.") : Text("Do you want to remove that user from this channel? That user will be able to enter it again if you don't block them.")) {
-                        showPromisingLoadingOverlay(self.overlay, headlineView: Text("Removing \(mucAffiliationToString(affiliations[member]))"), descriptionView: Text("Removing \(member.contactJid as String)...")) {
-                            promisifyAction {
-                                account.mucProcessor.setAffiliation("none", ofUser: member.contactJid, inMuc: self.muc.contactJid)
+                        .swipeActions(allowsFullSwipe: false) {
+                            Button("Delete") {
+                                showActionSheet(title: Text("Remove \(mucAffiliationToString(affiliations[contact]))?"), description: self.muc.mucType == "group" ? Text("Do you want to remove that user from this group? That user won't be able to enter it again until added back to the group.") : Text("Do you want to remove that user from this channel? That user will be able to enter it again if you don't block them.")) {
+                                    showPromisingLoadingOverlay(self.overlay, headlineView: Text("Removing \(mucAffiliationToString(affiliations[contact]))"), descriptionView: Text("Removing \(contact.contactJid as String)...")) {
+                                        promisifyAction {
+                                            account.mucProcessor.setAffiliation("none", ofUser: contact.contactJid, inMuc: self.muc.contactJid)
+                                        }
+                                    }.catch { error in
+                                        showAlert(title:Text("Error removing user!"), description:Text("\(String(describing:error))"))
+                                    }
+                                }
                             }
-                        }.catch { error in
-                            showAlert(title:Text("Error removing user!"), description:Text("\(String(describing:error))"))
+                            .tint(.red)
+                            .disabled(!isDeletable)
                         }
                     }
-                })
+                }
             }
         }
         .actionSheet(isPresented: $showActionSheet) {

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -318,6 +318,7 @@ struct MemberList: View {
                 }
             }
         }
+        .animation(.default, value: memberList)
         .actionSheet(isPresented: $showActionSheet) {
             ActionSheet(
                 title: actionSheetPrompt.title,

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -265,6 +265,10 @@ struct MemberList: View {
                 }
                 
                 ForEach(memberList, id:\.self) { contact in
+                    var isDeletable: Bool {
+                        ownUserHasAffiliationToRemove(contact: contact)
+                    }
+
                     if !contact.isSelfChat {
                         HStack {
                             HStack {
@@ -295,7 +299,7 @@ struct MemberList: View {
                                 view
                             }
                         }
-                        .deleteDisabled(!ownUserHasAffiliationToRemove(contact: contact))
+                        .deleteDisabled(!isDeletable)
                     }
                 }
                 .onDelete(perform: { memberIdx in

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -563,6 +563,7 @@ struct AddTopLevelNavigation<Content: View>: View {
                 self.delegate.dismiss()
             }){
                 Image(systemName: "arrow.backward")
+                    .tint(monalGreen)
             }.keyboardShortcut(.escape, modifiers: []))
         }
     }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -456,6 +456,44 @@ extension View {
     }
 }
 
+struct NumberlessBadge: View {
+    @Binding var notificationCount: Int
+    private let size: Int
+    private let inset: Int
+
+    var badgeSize: CGFloat {
+        CGFloat(integerLiteral: size)
+    }
+
+    var edgeInset: CGFloat {
+        CGFloat(integerLiteral: inset)
+    }
+
+    init(_ notificationCount: Binding<Int>, size: Int = 7, inset: Int = 1) {
+        self._notificationCount = notificationCount
+        self.size = size
+        self.inset = inset
+    }
+
+    var body: some View {
+        HStack {
+            Spacer()
+            VStack {
+                if notificationCount > 0 {
+                    Image(systemName: "circle.fill")
+                        .resizable()
+                        .frame(width: badgeSize, height: badgeSize)
+                        .tint(.red)
+                        .padding(.trailing, edgeInset)
+                        .padding(.top, edgeInset)
+                }
+                Spacer()
+            }
+        }
+        .animation(.default, value: notificationCount)
+    }
+}
+
 // //see https://stackoverflow.com/a/68291983
 // struct OverflowContentViewModifier: ViewModifier {
 //     @State private var contentOverflow: Bool = false

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -559,12 +559,16 @@ struct AddTopLevelNavigation<Content: View>: View {
             build()
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
-            .navigationBarItems(leading: Button(action : {
-                self.delegate.dismiss()
-            }){
-                Image(systemName: "arrow.backward")
-                    .tint(monalGreen)
-            }.keyboardShortcut(.escape, modifiers: []))
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button(action : {
+                        self.delegate.dismiss()
+                    }){
+                        Image(systemName: "arrow.backward")
+                            .tint(monalGreen)
+                    }.keyboardShortcut(.escape, modifiers: [])
+                }
+            }
         }
     }
 }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -743,6 +743,19 @@ class SwiftuiInterface : NSObject {
         return host
     }
 
+    @objc(makeContactsViewWithDismisser:onButton:)
+    func makeContactsView(dismisser: @escaping (MLContact) -> (), button: UIBarButtonItem) -> UIViewController {
+        let delegate = SheetDismisserProtocol()
+        let host = UIHostingController(rootView: AnyView(EmptyView()))
+        let contactsView = ContactsView(contacts: Contacts(), delegate: delegate, dismissWithContact: dismisser)
+        delegate.host = host
+        host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: contactsView))
+        host.modalPresentationStyle = .popover
+        host.popoverPresentationController?.sourceItem = button
+        host.preferredContentSize = host.sizeThatFits(in: CGSize(width: 0, height: 600))
+        return host
+    }
+
     @objc
     func makeView(name: String) -> UIViewController {
         let delegate = SheetDismisserProtocol()

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -550,9 +550,13 @@ struct LazyClosureView<Content: View>: View {
 struct AddTopLevelNavigation<Content: View>: View {
     let build: () -> Content
     let delegate: SheetDismisserProtocol
+    @StateObject private var sizeClass: ObservableKVOWrapper<SizeClassWrapper>
     init(withDelegate delegate: SheetDismisserProtocol, to build: @autoclosure @escaping () -> Content) {
         self.build = build
         self.delegate = delegate
+
+        let activeChats = (UIApplication.shared.delegate as! MonalAppDelegate).activeChats!
+        self._sizeClass = StateObject(wrappedValue: ObservableKVOWrapper<SizeClassWrapper>(activeChats.sizeClass))
     }
     var body: some View {
         NavigationStack {
@@ -560,13 +564,16 @@ struct AddTopLevelNavigation<Content: View>: View {
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
             .toolbar {
-                ToolbarItem(placement: .topBarLeading) {
-                    Button(action : {
-                        self.delegate.dismiss()
-                    }){
-                        Image(systemName: "arrow.backward")
-                            .tint(monalGreen)
-                    }.keyboardShortcut(.escape, modifiers: [])
+                let isCompact = UIUserInterfaceSizeClass(rawValue: sizeClass.horizontal) == .compact
+                if isCompact {
+                    ToolbarItem(placement: .topBarLeading) {
+                        Button(action : {
+                            self.delegate.dismiss()
+                        }){
+                            Image(systemName: "arrow.backward")
+                                .tint(monalGreen)
+                        }.keyboardShortcut(.escape, modifiers: [])
+                    }
                 }
             }
         }

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -81,6 +81,7 @@
 		26F9794D1ACAC73A0008E005 /* MLContactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F9794C1ACAC73A0008E005 /* MLContactCell.xib */; };
 		26FE3BCB1C61A6C3003CC230 /* MLResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26FE3BCA1C61A6C3003CC230 /* MLResizingTextView.m */; };
 		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
+		34E58B4B2C68E7BC009A1634 /* ContactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E58B4A2C68E7BC009A1634 /* ContactsView.swift */; };
 		38720923251EDE07001837EB /* MLXEPSlashMeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */; };
 		389E298C25E901CA009A5268 /* MLAudioRecoderManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 389E298925E901CA009A5268 /* MLAudioRecoderManager.m */; };
 		389E298D25E901CA009A5268 /* MLAudioRecoderManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 389E298B25E901CA009A5268 /* MLAudioRecoderManager.h */; };
@@ -502,6 +503,7 @@
 		2E5021A8D40FCC591D952104 /* Pods-NotificaionService.alpha-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificaionService.alpha-ios.xcconfig"; path = "Target Support Files/Pods-NotificaionService/Pods-NotificaionService.alpha-ios.xcconfig"; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* MonalSourceCodePrefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MonalSourceCodePrefix.pch; sourceTree = "<group>"; };
 		34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableShimView.swift; sourceTree = "<group>"; };
+		34E58B4A2C68E7BC009A1634 /* ContactsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsView.swift; sourceTree = "<group>"; };
 		3872091F251EDE07001837EB /* MLXEPSlashMeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLXEPSlashMeHandler.h; sourceTree = "<group>"; };
 		38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLXEPSlashMeHandler.m; sourceTree = "<group>"; };
 		389E298925E901CA009A5268 /* MLAudioRecoderManager.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MLAudioRecoderManager.m; sourceTree = "<group>"; };
@@ -1073,6 +1075,7 @@
 				26158AF01FFA6E4500E53BDC /* MLWebViewController.h */,
 				26158AF11FFA6E4500E53BDC /* MLWebViewController.m */,
 				84FC375828981A5600634E3E /* PasswordMigration.swift */,
+				34E58B4A2C68E7BC009A1634 /* ContactsView.swift */,
 				3D631822294BAB1D00026BE7 /* ContactPicker.swift */,
 				3D27D955290B0BB60014748B /* AddContactMenu.swift */,
 				3D88BB76295BB6DC00FB30BA /* CreateGroupMenu.swift */,
@@ -2099,6 +2102,7 @@
 				E89DD32625C6626400925F62 /* MLFileTransferVideoCell.m in Sources */,
 				26E3ED871FEC0CB7008ABDA5 /* MLServerDetails.m in Sources */,
 				3DC5035C2822F5220064C8A7 /* OmemoKeysView.swift in Sources */,
+				34E58B4B2C68E7BC009A1634 /* ContactsView.swift in Sources */,
 				262797AF178A577300B85D94 /* MLContactCell.m in Sources */,
 				2696EED21791245A00BC54B8 /* chatViewController.m in Sources */,
 				C12436142434AB5D00B8F074 /* MLAttributedLabel.m in Sources */,


### PR DESCRIPTION
# Introduction

This PR implements the first part of #1094

To do in (if it's ok) future PRs:

- Use `ObservableKVOWrapper<MLContact>` everywhere for live updates
- Implement notification badge for `ContactEntry` to match the old contacts screen
- Delete unused code from `ContactsViewController.m` etc.
- #121

# Videos

## iPhone

https://github.com/user-attachments/assets/60c4f99f-fb5d-4bab-ba37-6a3662573d6e

## iPad

At 2:22, the contact gets deleted from another device.

https://github.com/user-attachments/assets/990247f4-475e-41a4-99ad-f22e6f260401

## Animated notification badge

Just before raising this PR, I noticed the contact request notification badge wasn't animated.
I didn't want to re-record everything, so here's a recording of just that animation.

https://github.com/user-attachments/assets/5bafecbe-fab8-4e68-87a1-d9216fce8ea8