### PR TITLE
sort MUC participants in a case-insensitive manner

### DIFF
--- a/Monal/Classes/ChannelMemberList.swift
+++ b/Monal/Classes/ChannelMemberList.swift
@@ -36,7 +36,7 @@ struct ChannelMemberList: View {
             }
         }
         participants.sort {
-            (mucAffiliationToInt($0.value), $0.key) < (mucAffiliationToInt($1.value), $1.key)
+            (mucAffiliationToInt($0.value), $0.key.lowercased()) < (mucAffiliationToInt($1.value), $1.key.lowercased())
         }
     }
     

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -72,12 +72,12 @@ struct MemberList: View {
             (
                 (online[$0]! ? 0 : 1),
                 mucAffiliationToInt(affiliations[$0]),
-                (contactNames[$0]!),
+                (contactNames[$0]!.lowercased()),
                 ($0.contactJid as String)
             ) < (
                 (online[$1]! ? 0 : 1),
                 mucAffiliationToInt(affiliations[$1]),
-                (contactNames[$1]!),
+                (contactNames[$1]!.lowercased()),
                 ($1.contactJid as String)
             )
         }


### PR DESCRIPTION
match other clients in this regard, so users have a consistent experience.