### PR TITLE
Remove deprecated navigation view

### DIFF
--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -296,7 +296,6 @@ struct AddContactMenu: View {
         }
         .addLoadingOverlay(overlay)
         .navigationBarTitle(Text("Add Contact or Channel"), displayMode: .inline)
-        .navigationViewStyle(.stack)
         .toolbar(content: {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
                 if account.connectionProperties.discoveredAdhocCommands["urn:xmpp:invite#invite"] != nil {

--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -326,7 +326,7 @@ struct AddContactMenu: View {
             }
         })
         .sheet(isPresented: $showQRCodeScanner) {
-            NavigationView {
+            NavigationStack {
                 MLQRCodeScanner(handleClose: {
                     self.showQRCodeScanner = false
                 })

--- a/Monal/Classes/CreateGroupMenu.swift
+++ b/Monal/Classes/CreateGroupMenu.swift
@@ -121,7 +121,6 @@ struct CreateGroupMenu: View {
         }
         .addLoadingOverlay(overlay)
         .navigationBarTitle(Text("Create new group"), displayMode: .inline)
-        .navigationViewStyle(.stack)
     }
 }
 

--- a/Monal/Classes/DebugView.swift
+++ b/Monal/Classes/DebugView.swift
@@ -196,7 +196,7 @@ struct DebugView: View {
 }
 
 #Preview {
-    NavigationView {
+    NavigationStack {
         DebugView()
     }
 }

--- a/Monal/Classes/EditGroupSubject.swift
+++ b/Monal/Classes/EditGroupSubject.swift
@@ -23,7 +23,7 @@ struct EditGroupSubject: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack {
                 Form {
                     Section(header: Text("Group Description (optional)")) {

--- a/Monal/Classes/RegisterAccount.swift
+++ b/Monal/Classes/RegisterAccount.swift
@@ -436,7 +436,7 @@ struct RegisterAccount: View {
                                 }
                                 .frame(maxWidth: .infinity)
                                 .sheet(isPresented: $showWebView) {
-                                    NavigationView {
+                                    NavigationStack {
                                         WebView(url: termsSiteForCurrentLanguage())
                                             .navigationBarTitle(Text("Terms of \(RegisterAccount.XMPPServer[$selectedServerIndex.wrappedValue]["XMPPServer"]!)"), displayMode: .inline)
                                             .toolbar(content: {

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -508,7 +508,7 @@ struct LazyClosureView<Content: View>: View {
     }
 }
 
-// use this to wrap a view into NavigationView, if it should be the outermost swiftui view of a new view stack
+// use this to wrap a view into NavigationStack, if it should be the outermost swiftui view of a new view stack
 struct AddTopLevelNavigation<Content: View>: View {
     let build: () -> Content
     let delegate: SheetDismisserProtocol
@@ -517,7 +517,7 @@ struct AddTopLevelNavigation<Content: View>: View {
         self.delegate = delegate
     }
     var body: some View {
-        NavigationView {
+        NavigationStack {
             build()
             .navigationBarTitleDisplayMode(.automatic)
             .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
@@ -527,7 +527,6 @@ struct AddTopLevelNavigation<Content: View>: View {
                 Image(systemName: "arrow.backward")
             }.keyboardShortcut(.escape, modifiers: []))
         }
-        .navigationViewStyle(.stack)
     }
 }
 
@@ -547,11 +546,10 @@ struct UIKitWorkaround<Content: View>: View {
 #if targetEnvironment(macCatalyst)
             build().navigationBarTitleDisplayMode(.inline)
 #else
-            NavigationView {
+            NavigationStack {
                 build()
                 .navigationBarTitleDisplayMode(.automatic)
             }
-            .navigationViewStyle(.stack)
 
 #endif
         }


### PR DESCRIPTION
I based this off Apple's [migration guide](https://developer.apple.com/documentation/swiftui/migrating-to-new-navigation-types#Update-single-column-navigation).