### PR TITLE
Improve the discovery of room names

### DIFF
--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -1417,7 +1417,7 @@ $$instance_handler(handleDiscoResponse, account.mucProcessor, $$ID(xmpp*, accoun
     }
         
     //extract further muc infos
-    NSString* mucName = [iqNode findFirst:@"{http://jabber.org/protocol/disco#info}query/\\{http://jabber.org/protocol/muc#roominfo}result@muc#roomconfig_roomname\\"];
+    NSString* mucName = [iqNode findFirst:@"{http://jabber.org/protocol/disco#info}query/identity@name"];
     NSString* mucType = @"channel";
     //both are needed for omemo, see discussion with holger 2021-01-02/03 -- Thilo Molitor
     //see also: https://docs.modernxmpp.org/client/groupchat/


### PR DESCRIPTION
Make the discovery of a room's name more reliable by getting it from the identity element, which MUST be returned by the MUC service, instead of relying on muc#roomconfig_roomname, which MAY be returned.

see https://xmpp.org/extensions/xep-0045.html#disco-roominfo

> The room MUST return its identity

> A chatroom MAY return more detailed information in its disco#info response using Service Discovery Extensions

> any field defined for the muc#roomconfig FORM_TYPE can be included in the extended service discovery fields
