### PR TITLE
Fixes for Media Gallery

### DIFF
--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -388,15 +388,16 @@ struct ContactDetails: View {
                 let displayName = contact.contactDisplayName as String
                 let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {
+                    NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountID: contact.accountID)}) {
+                        Text("View Media Gallery")
+                    }
+
                     Button(action: {
                             UIApplication.shared.open(sharedUrl, options:[:])
                     }) {
                         Text("Show shared Media and Files")
                     }
                     .tint(Color.primary)
-                }
-                NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountNo: contact.accountId)}) {
-                    Text("View Media Gallery")
                 }
                 
                 NavigationLink(destination: LazyClosureView(BackgroundSettings(contact:contact))) {

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -389,13 +389,13 @@ struct ContactDetails: View {
                 let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {
                     NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountID: contact.accountID)}) {
-                        Text("View Media Gallery")
+                        Text("Shared Media")
                     }
 
                     Button(action: {
                             UIApplication.shared.open(sharedUrl, options:[:])
                     }) {
-                        Text("Show shared Media and Files")
+                        Text("Shared Files")
                     }
                     .tint(Color.primary)
                 }

--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -37,6 +37,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class DDFileLogger;
 @class UIView;
 @class UITapGestureRecognizer;
+@class AVURLAsset;
 
 typedef NS_ENUM(NSUInteger, MLVersionType) {
     MLVersionTypeIQ,
@@ -114,6 +115,8 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSData*) serializeObject:(id) obj;
 +(id) unserializeData:(NSData*) data;
 +(NSError* _Nullable) postUserNotificationRequest:(UNNotificationRequest*) request;
++(void) createAVURLAssetFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension withCompletionHandler:(void(^)(AVURLAsset* _Nullable)) completion;
++(AnyPromise*) generateVideoThumbnailFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension;
 +(void) addUploadItemPreviewForItem:(NSURL* _Nullable) url provider:(NSItemProvider* _Nullable) provider andPayload:(NSMutableDictionary*) payload withCompletionHandler:(void(^)(NSMutableDictionary* _Nullable)) completion;
 +(void) handleUploadItemProvider:(NSItemProvider*) provider withCompletionHandler:(void (^)(NSMutableDictionary* _Nullable)) completion;
 +(UIImage* _Nullable) rotateImage:(UIImage* _Nullable) image byRadians:(CGFloat) rotation;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -912,6 +912,82 @@ void swizzle(Class c, SEL orig, SEL new)
     return retval;
 }
 
++(void) createAVURLAssetFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension withCompletionHandler:(void(^)(AVURLAsset* _Nullable)) completion
+{
+    NSURL* fileUrl = [NSURL fileURLWithPath:file];
+    if(@available(iOS 17.0, macCatalyst 17.0, *))
+    {
+        //generate an AVURLAsset using the modern ios 17 method to attach a mime type to an AVURLAsset
+        return completion([AVURLAsset URLAssetWithURL:fileUrl options:@{AVURLAssetOverrideMIMETypeKey: mimeType}]);
+    }
+    
+    //TODO: instead of this symlink method hack, we *maybe* could use the AVURLAssetOutOfBandMIMETypeKey in place of
+    //TODO: AVURLAssetOverrideMIMETypeKey on ios 16, BUT: that symbol isn't public and may be catched by apple review
+    //TODO: (but it makes our code way cleaner than using this symlink stuff)
+    DDLogDebug(@"Generating thumbnail with symlink method...");
+    if(fileExtension == nil)
+    {
+        //this will return nil if the mime type isn't known by apple
+        fileExtension = [[UTType typeWithMIMEType:mimeType] preferredFilenameExtension];
+        //--> bail out if this is still nil
+        if(fileExtension == nil)
+        {
+            DDLogWarn(@"Could not get file extension for file, not creating AVURLAsset...");
+            return completion(nil);
+        }
+    }
+    
+    NSURL* symlinkUrl = [self getContainerURLForPathComponents:@[
+        @"documentCache",
+        [NSString stringWithFormat:@"tmp.avurlasset_symlink.%@.%@", fileUrl.lastPathComponent, fileExtension]
+    ]];
+    NSError* error = nil;
+    if([[NSFileManager defaultManager] fileExistsAtPath:symlinkUrl.path])
+        [[NSFileManager defaultManager] removeItemAtURL:symlinkUrl error:&error];
+    if(error != nil)
+    {
+        DDLogError(@"Could not delete old leftover symlink file at '%@': %@", symlinkUrl, error);
+        return completion(nil);
+    }
+    [[NSFileManager defaultManager] createSymbolicLinkAtURL:symlinkUrl withDestinationURL:fileUrl error:&error];
+    if(error != nil)
+    {
+        DDLogError(@"Could not create symlink file '%@' pointing to '%@': %@", symlinkUrl, fileUrl, error);
+        return completion(nil);
+    }
+    
+    //create the AVURLAsset and invoke the callback using it
+    completion([AVURLAsset URLAssetWithURL:fileUrl options:@{}]);
+    
+    //remove file afterwards and just log errors if removal of symlink fails
+    [[NSFileManager defaultManager] removeItemAtURL:symlinkUrl error:&error];
+    if(error != nil)
+        DDLogError(@"Could not clean up symlink file '%@' pointing to '%@': %@", symlinkUrl, fileUrl, error);
+}
+
++(AnyPromise*) generateVideoThumbnailFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension
+{
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        [self createAVURLAssetFromFile:file havingMimeType:mimeType andFileExtension:fileExtension withCompletionHandler:^(AVURLAsset* asset) {
+            if(asset == nil)
+                return resolve([NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Could not create AVURLAsset"}]);
+            
+            AVAssetImageGenerator* imageGenerator = [[AVAssetImageGenerator alloc] initWithAsset:asset];
+            imageGenerator.appliesPreferredTrackTransform=TRUE;
+            CMTime time = CMTimeMakeWithSeconds(1, 600);
+
+            [imageGenerator generateCGImageAsynchronouslyForTime:time completionHandler:^(CGImageRef image, CMTime actualTime, NSError* error) {
+                if(error != nil)
+                {
+                    DDLogError(@"Error generating thumbnail: %@", error);
+                    return resolve(error);
+                }
+                return resolve([UIImage imageWithCGImage:image]);
+            }];  
+        }];
+    }];
+}
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wcompletion-handler"
 +(void) addUploadItemPreviewForItem:(NSURL* _Nullable) url provider:(NSItemProvider* _Nullable) provider andPayload:(NSMutableDictionary*) payload withCompletionHandler:(void(^)(NSMutableDictionary* _Nullable)) completion
@@ -986,8 +1062,18 @@ void swizzle(Class c, SEL orig, SEL new)
                 }
             }
             
-            //last resort
-            useProvider();
+            //try to generate video thumbnail
+            [self generateVideoThumbnailFromFile:url.path havingMimeType:[UTType typeWithFilenameExtension:url.pathExtension].preferredMIMEType andFileExtension:url.pathExtension].then(^(UIImage* image) {
+                payload[@"preview"] = image;
+                DDLogVerbose(@"Managed to generate thumbnail for url=%@ using generateVideoThumbnailFromFile: %@", url, image);
+                [url stopAccessingSecurityScopedResource];
+                return completion(payload);
+            }).catch(^(NSError* error) {
+                DDLogError(@"Could not create video thumbnail, using provider as last resort: %@", error);
+                
+                //last resort
+                useProvider();
+            });
         }];
     }
     else

--- a/Monal/Classes/MLFileTransferVideoCell.m
+++ b/Monal/Classes/MLFileTransferVideoCell.m
@@ -7,7 +7,7 @@
 //
 
 #import "MLFileTransferVideoCell.h"
-
+#import "HelperTools.h"
 
 @implementation MLFileTransferVideoCell
 
@@ -63,9 +63,17 @@ AVPlayer *avplayer;
         mimeType = @"audio/mp4";
     }
     
-    AVURLAsset* videoAsset = [[AVURLAsset alloc] initWithURL:videoFileUrl options:@{
-        @"AVURLAssetOutOfBandMIMETypeKey": mimeType
+    __block AVURLAsset* videoAsset = nil;
+    //the completion is calles synchronously
+    [HelperTools createAVURLAssetFromFile:fileUrlStr havingMimeType:mimeType andFileExtension:nil withCompletionHandler:^(AVURLAsset* asset) {
+        videoAsset = asset;
     }];
+    if(videoAsset == nil)
+    {
+        DDLogWarn(@"Could not create AVURLAsset for video cell!");
+        return;
+    }
+    
     avplayer = [AVPlayer playerWithPlayerItem:[AVPlayerItem playerItemWithAsset:videoAsset]];
     DDLogInfo(@"Created AVPlayer(%@): %@", mimeType, avplayer);
     avplayerVC.player = avplayer;

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -69,7 +69,7 @@ class MediaItem: Identifiable, ObservableObject {
         }
 
         if mimeType.starts(with: "image/") {
-            if let image = UIImage(contentsOfFile: cacheFile)?.thumbnail(size: CGSize(width: 100, height: 100)) {
+            if let image = UIImage(contentsOfFile: cacheFile) {
                 self.thumbnail = image
             } else {
                 DDLogError("Failed to generate image thumbnail for: \(fileInfo)")
@@ -78,7 +78,7 @@ class MediaItem: Identifiable, ObservableObject {
             return
         } else if mimeType.starts(with: "video/") {
             if let thumbnail = await videoPreview(for:fileInfo) {
-                self.thumbnail = thumbnail.thumbnail(size: CGSize(width: 100, height: 100))
+                self.thumbnail = thumbnail
             } else {
                 DDLogError("Failed to generate video thumbnail for: \(fileInfo)")
                 self.thumbnail = UIImage(systemName: "video")
@@ -123,14 +123,14 @@ struct MediaItemView: View {
                 if let thumbnail = item.thumbnail {
                     Image(uiImage: thumbnail)
                         .resizable()
-                        .scaledToFill()
+                        //.scaledToFit()        //leaves empty room around image if not having a square format
+                        .scaledToFill()         //this is what the ios gallery app uses (will crop the edges of that preview)
                 } else {
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
-                        .frame(width: 50, height: 50)
                 }
             }
-            .frame(width: 100, height: 100)
+            .frame(width: 100, height: 100, alignment: .center)
             .clipShape(RoundedRectangle(cornerRadius: 10))
             .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.gray, lineWidth: 1))
             

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -27,7 +27,7 @@ struct MediaGalleryView: View {
             }
             .padding()
         }
-        .navigationTitle("Media Gallery")
+        .navigationTitle("Shared Media")
         .onAppear {
             fetchDownloadedMediaItems()
         }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -699,12 +699,12 @@ class SwiftuiInterface : NSObject {
         return host
     }
     
-    @objc(makeImageViewerForCurrentItem:)
-    func makeImageViewerFor(currentItem:[String:AnyObject]) -> UIViewController {
+    @objc(makeImageViewerForCurrentItem:allItems:)
+    func makeImageViewerFor(currentItem:[String:AnyObject], allItems: [[String:AnyObject]]) -> UIViewController {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(MediaItemSwipeView(currentItem: currentItem, allItems: [currentItem]))
+        host.rootView = AnyView(MediaItemSwipeView(currentItem: currentItem, allItems: allItems))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -704,7 +704,7 @@ class SwiftuiInterface : NSObject {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(try! ImageViewer(delegate:delegate, info:info))
+        host.rootView = AnyView(MediaItemSwipeView(currentItem: info, allItems: [info]))
         return host
     }
     

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -699,12 +699,12 @@ class SwiftuiInterface : NSObject {
         return host
     }
     
-    @objc(makeImageViewerForInfo:)
-    func makeImageViewerFor(info:[String:AnyObject]) -> UIViewController {
+    @objc(makeImageViewerForCurrentItem:)
+    func makeImageViewerFor(currentItem:[String:AnyObject]) -> UIViewController {
         let delegate = SheetDismisserProtocol()
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         delegate.host = host
-        host.rootView = AnyView(MediaItemSwipeView(currentItem: info, allItems: [info]))
+        host.rootView = AnyView(MediaItemSwipeView(currentItem: currentItem, allItems: [currentItem]))
         return host
     }
     

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -2357,8 +2357,8 @@ enum msgSentState {
                 [(MLChatCell *)cell openlink:self];
             } else  {
                 dispatch_async(dispatch_get_main_queue(), ^{
-                    NSDictionary* info = [MLFiletransfer getFileInfoForMessage:[self.messageList objectAtIndex:indexPath.row]];
-                    UIViewController* imageViewer = [[SwiftuiInterface new] makeImageViewerForInfo:info];
+                    NSDictionary* selectedItem = [MLFiletransfer getFileInfoForMessage:[self.messageList objectAtIndex:indexPath.row]];
+                    UIViewController* imageViewer = [[SwiftuiInterface new] makeImageViewerForCurrentItem:selectedItem];
                     imageViewer.modalPresentationStyle = UIModalPresentationOverFullScreen;
                     [self presentViewController:imageViewer animated:YES completion:^{}];
                 });

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -2358,7 +2358,8 @@ enum msgSentState {
             } else  {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     NSDictionary* selectedItem = [MLFiletransfer getFileInfoForMessage:[self.messageList objectAtIndex:indexPath.row]];
-                    UIViewController* imageViewer = [[SwiftuiInterface new] makeImageViewerForCurrentItem:selectedItem];
+                    NSMutableArray* allItems = [[DataLayer sharedInstance] allAttachmentsFromContact:self.contact.contactJid forAccount:self.contact.accountID];
+                    UIViewController* imageViewer = [[SwiftuiInterface new] makeImageViewerForCurrentItem:selectedItem allItems:allItems];
                     imageViewer.modalPresentationStyle = UIModalPresentationOverFullScreen;
                     [self presentViewController:imageViewer animated:YES completion:^{}];
                 });


### PR DESCRIPTION
Lets use this PR to do bookkepping of open issues in the media gallery.

The following list is not exhaustive, feel free to comment more issues and create pull requests to this branch @matthewrfennell @lissine0. This will allow @thevaidik so easily see what we changed on top of his code.

- [x] Wrong coding style in the objc part
- [x] Don't use NSLog but proper DDLogXXX
- [ ] If I tap the X icon in media viewer I don't get back to the gallery, but back to the contact details
- [ ] Share button of MediaViewer isn't displayed for video files, only for images
- [x] The thumbnail in the gallery does not indicate that this is a video at all
- [x] The thumbnails in the gallery are squished to a square aspect ratio
- [ ] The native video UI VERY BADLY interferes with the MediaViewer UI (pinch, zoom, show close and share buttons etc.)
- [x] Opening an image from the chat view doesn't allow the user to swipe left/right in the mediaviewer like when opening a media file from gallery.
- [ ] Images opened via media gallery should show in a fullscreen view, like when tapping onto an image in the chat
- [ ] Don't use an `extension` for UIImage to calculate a thumbnail (currently defined at the end of `SwiftHelpers.swift`)