### PR TITLE
Always display search bar in ContactsView

### DIFF
--- a/Monal/Classes/ContactsView.swift
+++ b/Monal/Classes/ContactsView.swift
@@ -143,7 +143,7 @@ struct ContactsView: View {
         .animation(.default, value: contactList)
         .navigationTitle("Contacts")
         .listStyle(.plain)
-        .searchable(text: $searchText)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
         .autocorrectionDisabled()
         .textInputAutocapitalization(.never)
         .keyboardType(.emailAddress)


### PR DESCRIPTION
When we open the contacts view, our main intent is to find a specific contact to chat with. As a result, the search bar should always be visible, so we can find the contact quickly.

Thank you lissine for catching this change in behaviour compared to the old version.

https://github.com/user-attachments/assets/b7cb87fc-a0d5-4740-894c-881e151317ea

https://github.com/user-attachments/assets/b2921ca7-bbe0-46c6-b877-542b0b24c3be