### PR TITLE
Roster Group - Backend

### DIFF
--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -282,6 +282,7 @@ extern NSString* const kMessageTypeFiletransfer;
 
 -(NSDictionary *) getSubscriptionForContact:(NSString*) contact andAccount:(NSNumber*) accountID;
 -(void) setSubscription:(NSString *)sub andAsk:(NSString*) ask forContact:(NSString*) contact andAccount:(NSNumber*) accountID;
+-(void) setGroups:(NSSet*) groups forContact:(NSString*) contact inAccount:(NSNumber*) accountNo;
 
 #pragma mark History Message Search
 /*

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -479,16 +479,14 @@ static NSDateFormatter* dbFormatter;
 
         if([results count] == 0)
             return (NSMutableDictionary*)nil;
-        else
-        {
-            NSMutableDictionary* contact = [results[0] mutableCopy];
-            //correctly extract NSDate object or 1970, if last interaction is zero
-            contact[@"lastInteraction"] = nilWrapper([self lastInteractionOfJid:username forAccountID:accountID]);
-            //if we have this muc in our favorites table, this muc is "subscribed"
-            if([self.db executeScalar:@"SELECT room FROM muc_favorites WHERE room=? AND account_id=?;" andArguments:@[username, accountID]] != nil)
-                contact[@"subscription"] = @"both";
-            return contact;
-        }
+
+        NSMutableDictionary* contact = [results[0] mutableCopy];
+        //correctly extract NSDate object or 1970, if last interaction is zero
+        contact[@"lastInteraction"] = nilWrapper([self lastInteractionOfJid:username forAccountID:accountID]);
+        //if we have this muc in our favorites table, this muc is "subscribed"
+        if([self.db executeScalar:@"SELECT room FROM muc_favorites WHERE room=? AND account_id=?;" andArguments:@[username, accountID]] != nil)
+            contact[@"subscription"] = @"both";
+        return contact;
     }];
 }
 

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -461,7 +461,7 @@ static NSDateFormatter* dbFormatter;
         return nil;
 
     return [self.db idReadTransaction:^{
-        NSArray* results = [self.db executeReader:@"SELECT b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', blocked, encrypt, muted, \
+        NSArray* results = [self.db executeReader:@"SELECT b.buddy_id, b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', blocked, encrypt, muted, \
             CASE \
                 WHEN a.buddy_name IS NOT NULL THEN 1 \
                 ELSE 0 \
@@ -481,6 +481,7 @@ static NSDateFormatter* dbFormatter;
             return (NSMutableDictionary*)nil;
 
         NSMutableDictionary* contact = [results[0] mutableCopy];
+        [contact removeObjectForKey:@"buddy_id"];
         //correctly extract NSDate object or 1970, if last interaction is zero
         contact[@"lastInteraction"] = nilWrapper([self lastInteractionOfJid:username forAccountID:accountID]);
         //if we have this muc in our favorites table, this muc is "subscribed"

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -481,7 +481,13 @@ static NSDateFormatter* dbFormatter;
             return (NSMutableDictionary*)nil;
 
         NSMutableDictionary* contact = [results[0] mutableCopy];
+        NSNumber* buddyId = contact[@"buddy_id"];
         [contact removeObjectForKey:@"buddy_id"];
+
+        NSArray* groupArray = [self.db executeScalarReader:@"SELECT DISTINCT group_name FROM buddy_groups WHERE buddy_id=?;" andArguments:@[buddyId]];
+        NSSet* groups = [NSSet setWithArray:groupArray];
+        [contact setValue:groups forKey:@"rosterGroups"];
+
         //correctly extract NSDate object or 1970, if last interaction is zero
         contact[@"lastInteraction"] = nilWrapper([self lastInteractionOfJid:username forAccountID:accountID]);
         //if we have this muc in our favorites table, this muc is "subscribed"

--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -1091,6 +1091,17 @@
             [db executeNonQuery:@"ALTER TABLE account DROP COLUMN 'supports_sasl2';"];
         }];
         
+        //allow for storage of roster groups
+        [self updateDB:db withDataLayer:dataLayer toVersion:6.407 withBlock:^{
+            [db executeNonQuery:@"CREATE TABLE 'buddy_groups' ( \
+                'buddy_id' INTEGER NOT NULL, \
+                'group_name' VARCHAR(50) NOT NULL, \
+                FOREIGN KEY('buddy_id') REFERENCES 'buddylist'('buddy_id') ON DELETE CASCADE, \
+                PRIMARY KEY('buddy_id', 'group_name') \
+            );"];
+            [db executeNonQuery:@"CREATE INDEX buddyIdIndex ON 'buddy_groups'('buddy_id');"];
+        }];
+
         
         //check if device id changed and invalidate state, if so
         //but do so only for non-sandbox (e.g. non-development) installs

--- a/Monal/Classes/MLContact.h
+++ b/Monal/Classes/MLContact.h
@@ -54,6 +54,7 @@ FOUNDATION_EXPORT NSString* const kAskSubscribe;
 @property (nonatomic, readonly) BOOL hasAvatar;
 @property (nonatomic, readonly) NSString* fullName;
 @property (nonatomic, readonly) xmpp* _Nullable account;
+@property (nonatomic, readonly) NSSet<NSString*>* rosterGroups;
 /**
  usually user assigned nick name
  */

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -858,6 +858,9 @@ static NSMutableDictionary* _singletonCache;
     contact.lastInteractionTime = nilExtractor([dic objectForKey:@"lastInteraction"]);        //no default needed, already done in DataLayer
     contact.rosterGroups = [dic objectForKey:@"rosterGroups"];
     contact->_avatar = nil;
+
+    MLAssert(contact.rosterGroups != nil, @"rosterGroups must be non-nil (if a user is in no groups, it should be empty set)");
+
     return contact;
 }
 

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -48,6 +48,7 @@ static NSMutableDictionary* _singletonCache;
 @property (nonatomic, strong) NSString* fullName;
 @property (nonatomic, strong) NSString* nickName;
 @property (nonatomic, strong) xmpp* account;
+@property (nonatomic, strong) NSSet<NSString*>* rosterGroups;
 
 @property (nonatomic, strong) NSDate* _Nullable lastInteractionTime;
 
@@ -100,6 +101,7 @@ static NSMutableDictionary* _singletonCache;
             @"count": @1,
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:0],
+            @"rosterGroups": [NSSet new],
         }];
     }
     else if(type == 2)
@@ -124,6 +126,7 @@ static NSMutableDictionary* _singletonCache;
             @"count": @2,
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640153174],
+            @"rosterGroups": [NSSet new],
         }];
     }
     else if(type == 3)
@@ -148,6 +151,7 @@ static NSMutableDictionary* _singletonCache;
             @"count": @3,
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640157074],
+            @"rosterGroups": [NSSet new],
         }];
     }
     else
@@ -171,6 +175,7 @@ static NSMutableDictionary* _singletonCache;
             @"count": @4,
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640157174],
+            @"rosterGroups": [NSSet new],
         }];
     }
 }
@@ -223,6 +228,7 @@ static NSMutableDictionary* _singletonCache;
             @"count": @0,
             @"isActiveChat": @NO,
             @"lastInteraction": nilWrapper(nil),
+            @"rosterGroups": [NSSet set],
         }];
     }
     else
@@ -725,6 +731,7 @@ static NSMutableDictionary* _singletonCache;
     [coder encodeBool:self.isEncrypted forKey:@"isEncrypted"];
     [coder encodeBool:self.isMuted forKey:@"isMuted"];
     [coder encodeObject:self.lastInteractionTime forKey:@"lastInteractionTime"];
+    [coder encodeObject:self.rosterGroups forKey:@"rosterGroups"];
 }
 
 -(instancetype) initWithCoder:(NSCoder*) coder
@@ -750,6 +757,7 @@ static NSMutableDictionary* _singletonCache;
     self.isEncrypted = [coder decodeBoolForKey:@"isEncrypted"];
     self.isMuted = [coder decodeBoolForKey:@"isMuted"];
     self.lastInteractionTime = [coder decodeObjectForKey:@"lastInteractionTime"];
+    self.rosterGroups = [coder decodeObjectForKey:@"rosterGroups"];
     return self;
 }
 
@@ -777,6 +785,7 @@ static NSMutableDictionary* _singletonCache;
     updateIfPrimitiveNotEqual(self.isMuted, contact.isMuted);
     //don't update lastInteractionTime from contact, we dynamically update ourselves by handling kMonalLastInteractionUpdatedNotice
     //updateIfIdNotEqual(self.lastInteractionTime, contact.lastInteractionTime);
+    updateIfIdNotEqual(self.rosterGroups, contact.rosterGroups);
 }
 
 -(BOOL) isEqualToMessage:(MLMessage*) message
@@ -847,6 +856,7 @@ static NSMutableDictionary* _singletonCache;
     contact.isMuted = [[dic objectForKey:@"muted"] boolValue];
     // initial value comes from db, all other values get updated by our kMonalLastInteractionUpdatedNotice handler
     contact.lastInteractionTime = nilExtractor([dic objectForKey:@"lastInteraction"]);        //no default needed, already done in DataLayer
+    contact.rosterGroups = [dic objectForKey:@"rosterGroups"];
     contact->_avatar = nil;
     return contact;
 }

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -370,6 +370,12 @@ $$
                                              forContact:contact[@"jid"]
                                              andAccount:account.accountID];
             
+            NSSet* groups = [NSSet setWithArray:[contactNode find:@"group#"]];
+            DDLogVerbose(@"Setting following groups: %@ for contact %@", groups, contact[@"jid"]);
+            [[DataLayer sharedInstance] setGroups:groups
+                                       forContact:contact[@"jid"]
+                                        inAccount:account.accountID];
+
 #ifndef DISABLE_OMEMO
             if(contactObj.isMuc == NO)
             {

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -310,9 +310,11 @@ $$
         return NO;
     }
     
-    NSArray* rosterList = [iqNode find:@"{jabber:iq:roster}query/item@@"];
-    for(NSMutableDictionary* contact in rosterList)
+    NSArray* rosterList = [iqNode find:@"{jabber:iq:roster}query/item"];
+    for(MLXMLNode* contactNode in rosterList)
     {
+        NSMutableDictionary* contact = [contactNode findFirst:@"/@@"];
+
         //ignore roster entries without jid (is this even possible?)
         if(contact[@"jid"] == nil)
             continue;


### PR DESCRIPTION
Implement the backend changes for #121.

I did some verification during debugging on the DB and MLContact.

I think the DB logic is a little complex. I considered writing some automated tests for this part, maybe interacting maybe with a fake DB. But this would take some time to explore and might be overkill. If this is something you'd be interested in me looking into, let me know, I'd be happy to give it a go.

# Testing

## Receive stanza

```
RECV Stanza:
<iq id='FC2DF395-1F08-49C3-987C-7308387D292D' to='user1@continuous.nonprod.fennell.dev/Monal-iOS.236ee368' xmlns='jabber:client' type='result'>
  <query xmlns='jabber:iq:roster'>
    …
    <item name='' subscription='both' jid='user2@continuous.nonprod.fennell.dev'>
      <group>Sharks</group>
    </item>
  </query></iq>
```

## DB State after persistence

```SQL
select bl.buddy_name, bg.*, rg.*
from buddylist bl
join buddy_groups bg on bl.buddy_id = bg.buddy_id
join roster_groups rg on bg.roster_group_id = rg.roster_group_id
```
buddy_name | buddy_id | roster_group_id | roster_group_id | account_id | group_name
-- | -- | -- | -- | -- | --
user2@continuous.nonprod.fennell.dev | 73 | 1 | 1 | 2 | Sharks

## Group added to MLContact

(see `_rosterGroups` field)

<img width="451" alt="sharks-user" src="https://github.com/user-attachments/assets/fb495e92-ae94-4e00-87eb-13dd55c79575">