### PR TITLE
Always show back button on mac catalyst

### DIFF
--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -573,7 +573,11 @@ struct AddTopLevelNavigation<Content: View>: View {
                 .navigationBarTitleDisplayMode(.automatic)
                 .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
                 .toolbar {
+#if targetEnvironment(macCatalyst)
+                    let shouldDisplayBackButton = true
+#else
                     let shouldDisplayBackButton = UIUserInterfaceSizeClass(rawValue: sizeClass.horizontal) == .compact
+#endif
                     if shouldDisplayBackButton {
                         ToolbarItem(placement: .topBarLeading) {
                             Button(action : {

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -573,8 +573,8 @@ struct AddTopLevelNavigation<Content: View>: View {
                 .navigationBarTitleDisplayMode(.automatic)
                 .navigationBarBackButtonHidden(true) // will not be shown because swiftui does not know we navigated here from UIKit
                 .toolbar {
-                    let isCompact = UIUserInterfaceSizeClass(rawValue: sizeClass.horizontal) == .compact
-                    if isCompact {
+                    let shouldDisplayBackButton = UIUserInterfaceSizeClass(rawValue: sizeClass.horizontal) == .compact
+                    if shouldDisplayBackButton {
                         ToolbarItem(placement: .topBarLeading) {
                             Button(action : {
                                 self.delegate.dismiss()


### PR DESCRIPTION
#1205 introduced a regression on MacOS where, once a user opens the contact details view, they cannot close it, since there is no back button and clicking outside of the modal does nothing (unlike on iOS).

This PR works around this by always showing the back button in `AddTopLevelNavigation`. The consequence of this is that we also show the back button in popovers (such as the `ContactsView` popover)

<img width="279" alt="Screenshot 2024-08-31 at 15 59 53" src="https://github.com/user-attachments/assets/07cb4664-e186-4a2d-bc4c-36022ca2bfe7">
<img width="493" alt="Screenshot 2024-08-31 at 16 00 06" src="https://github.com/user-attachments/assets/dd3f7bab-2c5e-4761-9cf9-17fef0d17d8e">
