### PR TITLE
Increase contact list popover width

### DIFF
--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -772,7 +772,7 @@ class SwiftuiInterface : NSObject {
         host.rootView = AnyView(AddTopLevelNavigation(withDelegate: delegate, to: contactsView))
         host.modalPresentationStyle = .popover
         host.popoverPresentationController?.sourceItem = button
-        host.preferredContentSize = host.sizeThatFits(in: CGSize(width: 0, height: 600))
+        host.preferredContentSize = host.sizeThatFits(in: CGSize(width: 400, height: 600))
         return host
     }
 


### PR DESCRIPTION
Aspect ratio is 2:3. Here's how it looks now,

on Mac OS:

<img width="1037" alt="macos-list" src="https://github.com/user-attachments/assets/669b8e7f-6624-434e-b754-7e5fcd9b3265">
<img width="1037" alt="macos-add-contact" src="https://github.com/user-attachments/assets/edd5d19e-468c-40e9-83a1-b8fc18cf5890">

on iPad mini (6th generation)

![ipad-mini-list](https://github.com/user-attachments/assets/58f77ee4-d802-4510-a4d1-796c0631855d)
![ipad-mini-add-contact](https://github.com/user-attachments/assets/f9a6ef5f-0cce-4899-aa0c-b11f50c26ca9)