### PR TITLE
Replace audio permission which is deprecated in iOS 17

### DIFF
--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -1201,9 +1201,15 @@ enum msgSentState {
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         DDLogInfo(@"Record button pressed...");
-        [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
-            [self handleRecord:granted];
-        }];
+        if(@available(iOS 17, macCatalyst 17.0, *)) {
+            [AVAudioApplication requestRecordPermissionWithCompletionHandler:^(BOOL granted) {
+                [self handleRecord:granted];
+            }];
+        } else {
+            [[AVAudioSession sharedInstance] requestRecordPermission:^(BOOL granted) {
+                [self handleRecord:granted];
+            }];
+        }
     });
 }
 


### PR DESCRIPTION
This is so we can easily bump the minimum target to test out new features, without having to comment out parts of the code.


https://github.com/user-attachments/assets/1ab2e65f-3654-483e-a41a-cc5e16e6e9bd


https://github.com/user-attachments/assets/d606b0c9-845a-420c-a30a-0177315d0eb2


https://github.com/user-attachments/assets/50c0019b-04b1-4b6a-aa1f-73dc9bc3f4b2


https://github.com/user-attachments/assets/c3fa1414-e55a-4575-8da2-617296939475

