### PR TITLE
Update app badge with UNUserNotificationCenter

### DIFF
--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -355,7 +355,7 @@ $$
         if(unreadMsgCnt != nil)
             unread = [unreadMsgCnt integerValue];
         DDLogInfo(@"Updating unread badge to: %ld", (long)unread);
-        [UIApplication sharedApplication].applicationIconBadgeNumber = unread;
+        [[UNUserNotificationCenter currentNotificationCenter] setBadgeCount:unread withCompletionHandler:nil];
     }];
 }
 


### PR DESCRIPTION
This is due to UIApplication being deprecated in iOS 17.


https://github.com/user-attachments/assets/acc36dbe-6723-427c-beed-f7638a3cec12

