### PR TITLE
Improve button colors in ContactDetails

### DIFF
--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -275,25 +275,24 @@ struct ContactDetails: View {
                                 contact.isMuc ? Text("Notifications disabled") : Text("Contact is muted")
                             } icon: {
                                 Image(systemName: "bell.slash.fill")
-                                    .foregroundColor(.red)
                             }
+                            .foregroundStyle(Color.red)
                         } else if contact.isMuc && contact.isMentionOnly {
                             Label {
                                 Text("Notify only when mentioned")
                             } icon: {
                                 Image(systemName: "bell.badge")
-                                    .foregroundColor(.primary)
                             }
+                            .foregroundStyle(Color.primary)
                         } else {
                             Label {
                                 contact.isMuc ? Text("Notify on all messages") : Text("Contact is not muted")
                             } icon: {
                                 Image(systemName: "bell.fill")
-                                    .foregroundColor(.green)
                             }
+                            .foregroundStyle(Color.green)
                         }
                     }
-                    .tint(Color.primary)
                 }
                 
 #if !DISABLE_OMEMO
@@ -310,15 +309,15 @@ struct ContactDetails: View {
                                 Text("Messages are encrypted")
                             } icon: {
                                 Image(systemName: "lock.fill")
-                                    .foregroundColor(.green)
                             }
+                            .foregroundStyle(Color.green)
                         } else {
                             Label {
                                 Text("Messages are NOT encrypted")
                             } icon: {
                                 Image(systemName: "lock.open.fill")
-                                    .foregroundColor(.red)
                             }
+                            .foregroundStyle(Color.red)
                         }
                     }
                     .alert(isPresented: $showingCannotEncryptAlert) {
@@ -394,7 +393,6 @@ struct ContactDetails: View {
                     }) {
                         Text("Show shared Media and Files")
                     }
-                    .tint(Color.primary)
                 }
                 NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountID: contact.accountID)}) {
                     Text("View Media Gallery")
@@ -632,6 +630,7 @@ struct ContactDetails: View {
 #endif
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .tint(Color.primary)
         .addLoadingOverlay(overlay)
         .navigationBarTitle(contact.contactDisplayName as String, displayMode:.inline)
         .alert(isPresented: $showAlert) {


### PR DESCRIPTION
Change the `Add Contact` button to primary color.
Make the notification and encryption button text match their label's color.

Note: I kept the color of `Notify only when mentioned` as primary color.

Feel free to change the colors if you wish.

<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/1b48ffa1-a802-4995-a47a-91f2361ffba5">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/f21ff9c2-0d18-4dfc-ae3e-c0781a8cfd02">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/fff29777-a9f8-47c1-85df-649fb49becd6">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/42183012-8b1d-4161-91df-4a65bb227239">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/c5097c61-af02-4cc5-b1f2-4ce2f0f30199">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/547e3404-879d-4f38-b69e-87c67ce66796">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/056fb611-9729-426a-b915-a235085d4ee1">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/fb95f1ea-a727-4ab0-8fc6-cfde4c4d84e6">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/17d6015b-42e9-43e2-b59a-743ac36409c7">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/2f88f318-b90c-459c-841a-3f1a1801493e">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/372da6c5-501b-486f-9214-c6fd9ac8480c">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/ced9756c-4a47-485c-82a2-5d9357841696">
<img alt="" width="270" height="480" src="https://github.com/user-attachments/assets/25c3602a-5cfb-44f8-95ee-aa1f82958e01">