### PR TITLE
Fix crash when deleting device in OmemoKeysView

### DIFF
--- a/Monal/Classes/OmemoKeysView.swift
+++ b/Monal/Classes/OmemoKeysView.swift
@@ -137,7 +137,7 @@ struct OmemoKeysEntryView: View {
             setTrustLevel(keyEnabled)
         })
 
-        let fingerprintString = HelperTools.signalHexKeyWithSpaces(with: fingerprint)
+        let fingerprintString: String = self.fingerprint.isEmpty ? "" : HelperTools.signalHexKeyWithSpaces(with: fingerprint)
         let clipboardValue = "OMEMO fingerprint of \(self.contactJid), device \(self.deviceId): \(fingerprintString)"
         GroupBox {
             HStack(alignment:.bottom) {


### PR DESCRIPTION
In this commit, we create a fallback/default value for the fingerprint when no data is retrieved from the database.

This is needed to prevent crashes when removing a device from the list.

The order of operations without this fallback is:
* User clicks on the delete button to remove a device
* The device gets removed from the DB
* A notification is sent to the view
* The view picks up the notification, via the ObservableObject
* SwiftUI decides to recreate the view, while playing the animation
* self.fingerprint is now empty, as there is no such device in the DB
* We call signalHexKeyWithSpaces with this empty fingerprint
* This function assumes the result is more than 2 characters long
* This causes the crash