### PR TITLE
Replace deprecated .edgesIgnoringSafeArea(.all)

### DIFF
--- a/Monal/Classes/AVCallUI.swift
+++ b/Monal/Classes/AVCallUI.swift
@@ -172,7 +172,7 @@ struct AVCallUI: View {
     var body: some View {
         ZStack {
             Color.background
-                .edgesIgnoringSafeArea(.all)
+                .ignoresSafeArea()
             
             if MLCallType(rawValue:call.callType) == .video && MLCallState(rawValue:call.state) == .connected {
                 VideoView(renderer:self.remoteRenderer)

--- a/Monal/Classes/LoadingOverlay.swift
+++ b/Monal/Classes/LoadingOverlay.swift
@@ -23,7 +23,7 @@ struct LoadingOverlay: ViewModifier {
     @ObservedObject var state : LoadingOverlayState
     public func body(content: Content) -> some View {
         ZStack(alignment: .center) {
-            Color(UIColor.systemGroupedBackground).ignoresSafeArea().edgesIgnoringSafeArea(.all)
+            Color(UIColor.systemGroupedBackground).ignoresSafeArea()
             
             content
             .disabled(state.enabled == true)

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -234,7 +234,7 @@ struct MediaItemSwipeView: View {
         }
         .tabViewStyle(PageTabViewStyle(indexDisplayMode: .never))
         .animation(.easeInOut, value: currentIndex)
-        .edgesIgnoringSafeArea(.all)
+        .ignoresSafeArea()
         .navigationBarHidden(true)
         .statusBar(hidden: true)
     }

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -62,7 +62,7 @@ struct ImageViewer: View {
     var body: some View {
         ZStack(alignment: .top) {
             Color.background
-                .edgesIgnoringSafeArea(.all)
+                .ignoresSafeArea()
             
             if (info["mimeType"] as! String).hasPrefix("image/svg") {
                 VStack {
@@ -187,7 +187,7 @@ struct ControlsOverlay: View {
     var body: some View {
         VStack {
             Color.background
-                .edgesIgnoringSafeArea(.all)
+                .ignoresSafeArea()
                 .overlay(
                     HStack {
                         Spacer().frame(width: 20)


### PR DESCRIPTION
This is [deprecated](https://developer.apple.com/documentation/deviceactivity/deviceactivityreport/edgesignoringsafearea(_:)) after iOS 18.1.