### PR TITLE
Fix unexpected zoom when toggling toolbar overlay

### DIFF
--- a/Monal/Classes/ZoomableContainer.swift
+++ b/Monal/Classes/ZoomableContainer.swift
@@ -87,10 +87,11 @@ struct ZoomableContainer<Content: View>: View {
                 uiView.setZoomScale(currentScale, animated: true)
             } else if tapLocation != .zero { // Scale in to a specific point
                 uiView.zoom(to: zoomRect(for: uiView, scale: uiView.maximumZoomScale, center: tapLocation), animated: true)
-                // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
-                // Use the main thread to prevent unexpected behavior
-                DispatchQueue.main.async { tapLocation = .zero }
             }
+
+            // Reset the location to prevent scaling to it in case of a negative scale (manual pinch)
+            // Use the main thread to prevent unexpected behavior
+            DispatchQueue.main.async { tapLocation = .zero }
 
             assert(context.coordinator.hostingController.view.superview == uiView)
         }


### PR DESCRIPTION
The media viewer needs to be able to respond to double-taps, to zoom in/out of the media, and single taps, to hide/show the overlay.

We track the tap position so that we know where the user wants to zoom into. However, we currently do not reset this tap position after double-tapping to zoom out of a view.

For example, consider the following scenario:

* Double-tap. We zoom in, and tapLocation is set to zero
* Double-tap again. We zoom out, but tapLocation is not reset
* Single-tap. We fall into the "Scale in to a specific point" branch
* This causes an unexpected zoom-in followed by zoom-out

To fix this, we make sure to always reset the tapPosition to zero after each zoom action has taken place.

I've raised this to `develop` instead of `fix/media_viewer` as I think this bug existed before the GSoC project. But I can raise to the other branch if preferred.

https://github.com/user-attachments/assets/97811dca-8786-4ae5-9955-368fb30336e9

https://github.com/user-attachments/assets/8c81de94-e4b9-4596-9298-9e7149e10013
