### PR TITLE
Fix crash when opening settings on iOS 18

### DIFF
--- a/Monal/Classes/AccountListController.m
+++ b/Monal/Classes/AccountListController.m
@@ -76,7 +76,6 @@
 -(void) initContactCell:(MLSwitchCell*) cell forAccNo:(NSUInteger) accNo
 {
     [cell initTapCell:@"\n\n"];
-    cell = [cell initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"AccountCell"];
     NSDictionary* account = [self.accountList objectAtIndex:accNo];
     MLAssert(account != nil, ([NSString stringWithFormat:@"Expected non nil account in row %lu", (unsigned long)accNo]));
     if([(NSString*)[account objectForKey:@"domain"] length] > 0) {
@@ -89,7 +88,6 @@
     }
 
     UIImageView* accessory = [[UIImageView alloc] initWithFrame:CGRectMake(0, 0, 30, 30)];
-    cell.detailTextLabel.text = nil;
 
     if([[account objectForKey:@"enabled"] boolValue] == YES)
     {
@@ -98,17 +96,11 @@
         {
             accessory.image = [UIImage imageNamed:@"Connected"];
             cell.accessoryView = accessory;
-            
-            NSDate* connectedTime = [[MLXMPPManager sharedInstance] connectedTimeFor:[[self.accountList objectAtIndex:accNo] objectForKey:@"account_id"]];
-            if(connectedTime) {
-                cell.detailTextLabel.text = [NSString stringWithFormat:NSLocalizedString(@"Connected since: %@", @""), [self.uptimeFormatter stringFromDate:connectedTime]];
-            }
         }
         else
         {
             accessory.image = [UIImage imageNamed:@"Disconnected"];
             cell.accessoryView = accessory;
-            cell.detailTextLabel.text = NSLocalizedString(@"Connecting...", @"");
         }
     }
     else
@@ -116,7 +108,6 @@
         cell.imageView.image = [UIImage systemImageNamed:@"circle"];
         accessory.image = nil;
         cell.accessoryView = accessory;
-        cell.detailTextLabel.text = NSLocalizedString(@"Account disabled", @"");
     }
 }
 


### PR DESCRIPTION
If you open the settings page on iOS 18.0, the app will crash. On iOS 17.4, it works fine. The crash happens because UIKit complains that the account cell is initialised twice.

```
CRASH(NSInternalInconsistencyException): View was already initialized: <MLSwitchCell: 0x10c03f000; baseClass = UITableViewCell ...>
```

We initialise the cell for the first time in
`MLSettingsTableViewController:tableView`:

```objective-c
MLSwitchCell* cell = [tableView dequeueReusableCellWithIdentifier:@"AccountCell" forIndexPath:indexPath];
```

Just below, we call `AccountListController:initContactCell`, which initialises the cell for the second time:

```objective-c
cell = [cell initWithStyle:UITableViewCellStyleSubtitle reuseIdentifier:@"AccountCell"];
```

We seem to do this so we can mostly resuse the styling defined in the nib file for AccountCell, but additionally add the subtitle styling that lets us show the time that the account was last connected. This approach is recommended here: https://stackoverflow.com/a/40809039

However, this seems incorrect since it leads to the cell being initialised twice. Probably Apple were not asserting this condition before, but are now.

So, only for the account cell, manually initialise the cell.

This changes the cells styling slightly. However, it still looks fine, and the settings screens will be rewritten in SwiftUI soon anyway, so I don't think it is worth spending lots of time on. But - if you disagree, I'm happy to do it :)

Before:

![settings-contact-before](https://github.com/user-attachments/assets/e2534c94-0deb-4d09-9315-68beadb377ec)

After:

![settings-contact-after](https://github.com/user-attachments/assets/0173372b-dc67-4572-8cc3-d779df2cd79b)