### PR TITLE
Make buttons to open the media viewer more clear

### DIFF
--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -388,15 +388,16 @@ struct ContactDetails: View {
                 let displayName = contact.contactDisplayName as String
                 let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {
+                    NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountID: contact.accountID)}) {
+                        Text("View Media Gallery")
+                    }
+
                     Button(action: {
                             UIApplication.shared.open(sharedUrl, options:[:])
                     }) {
                         Text("Show shared Media and Files")
                     }
                     .tint(Color.primary)
-                }
-                NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountNo: contact.accountId)}) {
-                    Text("View Media Gallery")
                 }
                 
                 NavigationLink(destination: LazyClosureView(BackgroundSettings(contact:contact))) {

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -389,13 +389,13 @@ struct ContactDetails: View {
                 let sharedUrl = HelperTools.getSharedDocumentsURL(forPathComponents:[accountJid, displayName])
                 if UIApplication.shared.canOpenURL(sharedUrl) && FileManager.default.fileExists(atPath:sharedUrl.path) {
                     NavigationLink(destination: LazyClosureView{MediaGalleryView(contact: contact.contactJid as String, accountID: contact.accountID)}) {
-                        Text("View Media Gallery")
+                        Text("Shared Media")
                     }
 
                     Button(action: {
                             UIApplication.shared.open(sharedUrl, options:[:])
                     }) {
-                        Text("Show shared Media and Files")
+                        Text("Shared Files")
                     }
                     .tint(Color.primary)
                 }

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -27,7 +27,7 @@ struct MediaGalleryView: View {
             }
             .padding()
         }
-        .navigationTitle("Media Gallery")
+        .navigationTitle("Shared Media")
         .onAppear {
             fetchDownloadedMediaItems()
         }


### PR DESCRIPTION
Here's how it looks if there is media in the chat:

![is-media](https://github.com/user-attachments/assets/10ca0cc8-5fbb-4437-b1bb-4f199cfb7aa9)

And if there's no media:

![no-media](https://github.com/user-attachments/assets/073e6105-a0d8-4cd7-932a-b87bfddc6a6c)
