### PR TITLE
Properly initialize a contact's blocked state

### DIFF
--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -461,7 +461,7 @@ static NSDateFormatter* dbFormatter;
         return nil;
 
     return [self.db idReadTransaction:^{
-        NSArray* results = [self.db executeReader:@"SELECT b.buddy_id, b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', blocked, encrypt, muted, \
+        NSArray* results = [self.db executeReader:@"SELECT b.buddy_id, b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', encrypt, muted, \
             CASE \
                 WHEN a.buddy_name IS NOT NULL THEN 1 \
                 ELSE 0 \

--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -1141,6 +1141,12 @@
             );"];
         }];
 
+        //a contact's blocked state is deduced directly from the blocklistCache table.
+        //as such, this column is redundant.
+        [self updateDB:db withDataLayer:dataLayer toVersion:6.411 withBlock:^{
+            [db executeNonQuery:@"ALTER TABLE buddylist DROP COLUMN 'blocked';"];
+        }];
+
 
         //check if device id changed and invalidate state, if so
         //but do so only for non-sandbox (e.g. non-development) installs


### PR DESCRIPTION
Fixes #1254

The changes I _force-pushed_ are not strictly necessary. But I think they make it clearer that we don't expect a `@"blocked"` key in the dictionary we get from DataLayer
This works because an uninitialized BOOL is set to false by default.
