### PR TITLE
Use UIKitWorkaround for own OmemoKeysView

### DIFF
--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -730,9 +730,9 @@ class SwiftuiInterface : NSObject {
     func makeOwnOmemoKeyView(_ ownContact: MLContact?) -> UIViewController {
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         if(ownContact == nil) {
-            host.rootView = AnyView(OmemoKeysView(omemoKeys: OmemoKeysForChat(viewContact: nil)))
+            host.rootView = AnyView(UIKitWorkaround(OmemoKeysView(omemoKeys: OmemoKeysForChat(viewContact: nil))))
         } else {
-            host.rootView = AnyView(OmemoKeysView(omemoKeys: OmemoKeysForChat(viewContact: ObservableKVOWrapper<MLContact>(ownContact!))))
+            host.rootView = AnyView(UIKitWorkaround(OmemoKeysView(omemoKeys: OmemoKeysForChat(viewContact: ObservableKVOWrapper<MLContact>(ownContact!)))))
         }
         return host
     }


### PR DESCRIPTION
This makes OmemoKeysView's top bar visible on iPad when accessed from AccountEdit

Before this commit:
![before](https://github.com/user-attachments/assets/6a6a9309-64f2-4023-96b1-d01abf64370f)

After this commit:
![after](https://github.com/user-attachments/assets/7e2e249f-35cd-44c1-9ff1-5836e6491824)
(Some things were redacted from the screenshots for privacy)

This commit should be included in https://github.com/monal-im/Monal/pull/1258
