### PR TITLE
Remove NavigationLink workaround in ContactsView

### DIFF
--- a/Monal/Classes/ContactsView.swift
+++ b/Monal/Classes/ContactsView.swift
@@ -48,21 +48,16 @@ struct ContactViewEntry: View {
         HStack(spacing: 0) {
             Text("").frame(maxWidth: 0)
             Button(action: { dismissWithContact(contact) }) {
-                // The only purpose of this NavigationLink is making the button it contains look nice.
-                // In other words: have a screen-wide touch target and the chveron on the right of the screen.
-                // This avoids having to do manual button styling that might have to be recreated in the future.
-                NavigationLink(destination: EmptyView()) {
-                    HStack {
-                        ContactEntry(contact: ObservableKVOWrapper<MLContact>(contact))
-                        Spacer()
-                        Button {
-                            selectedContactForContactDetails = ObservableKVOWrapper<MLContact>(contact)
-                        } label: {
-                            Image(systemName: "info.circle")
-                                .imageScale(.large)
-                        }
-                        .accessibilityLabel("Open contact details")
+                HStack {
+                    ContactEntry(contact: ObservableKVOWrapper<MLContact>(contact))
+                    Spacer()
+                    Button {
+                        selectedContactForContactDetails = ObservableKVOWrapper<MLContact>(contact)
+                    } label: {
+                        Image(systemName: "info.circle")
+                            .imageScale(.large)
                     }
+                    .accessibilityLabel("Open contact details")
                 }
             }
         }


### PR DESCRIPTION
This workaround mainly existed to give us the NavigationLink chevron on the trailing edge of each contact entry, without needing to do any manual styling.

However, on iOS 18.0, nesting the buttons and NavigationLink in this way causes the inner button not to be tappable. So, let's remove this workaround and rely on the default styling.


https://github.com/user-attachments/assets/51fe0041-9084-49cb-b61a-fce39265bfb3

