### PR TITLE
Bump FrameUp to v0.9.7

### DIFF
--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -4688,7 +4688,7 @@
 			repositoryURL = "https://github.com/ryanlintott/FrameUp";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.2;
+				minimumVersion = 0.9.7;
 			};
 		};
 		C1F5C7AD2777638B0001F295 /* XCRemoteSwiftPackageReference "swift-collections" */ = {

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/ryanlintott/FrameUp",
         "state": {
           "branch": null,
-          "revision": "3b1f65fd0a78dd2058005f6e070260531ff14d3e",
-          "version": "0.9.6"
+          "revision": "3b46ddcfc02a85ed060bb0c9e7ab14a7f90f415a",
+          "version": "0.9.7"
         }
       },
       {


### PR DESCRIPTION
v0.9.7 contains a fix in VGridMasonry that fixes a main actor related compile error on XCode 16.2