### PR TITLE
Promise registry

### DIFF
--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -144,11 +144,11 @@ struct ContactDetails: View {
                                             Text("Yes"),
                                             action: {
                                                 showPromisingLoadingOverlay(overlay, headlineView:Text("Removing avatar..."), descriptionView:Text("")) {
-                                                    promisifyMucAction(account:account, mucJid:contact.contactJid) {
-                                                        self.account.mucProcessor.publishAvatar(nil, forMuc: contact.contactJid)
-                                                    }
+                                                    self.account.mucProcessor.publishAvatar(nil, forMuc: contact.contactJid)
                                                 }.catch { error in
-                                                    errorAlert(title: Text("Error removing avatar!"), message: Text("\(String(describing:error))"))
+                                                    let nsError = error as NSError
+                                                    let description: String = nsError.userInfo[NSLocalizedDescriptionKey] as? String ?? "Could not remove avatar. Please try again."
+                                                    errorAlert(title: Text("Error removing avatar!"), message: Text(description))
                                                     hideLoadingOverlay(overlay)
                                                 }
                                             }
@@ -664,11 +664,11 @@ struct ContactDetails: View {
                 inputImage = nil
             }) { (image, cropRect, angle) in
                 showPromisingLoadingOverlay(overlay, headlineView:Text("Uploading avatar..."), descriptionView:Text("")) {
-                    promisifyMucAction(account:account, mucJid:contact.contactJid) {
-                        self.account.mucProcessor.publishAvatar(image, forMuc: contact.contactJid)
-                    }
+                    self.account.mucProcessor.publishAvatar(image, forMuc: contact.contactJid)
                 }.catch { error in
-                    errorAlert(title: Text("Error changing avatar!"), message: Text("\(String(describing:error))"))
+                    let nsError = error as NSError
+                    let description: String = nsError.userInfo[NSLocalizedDescriptionKey] as? String ?? "Could not remove avatar. Please try again."
+                    errorAlert(title: Text("Error changing avatar!"), message: Text(description))
                     hideLoadingOverlay(overlay)
                 }
             }

--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -11,6 +11,7 @@
 #import "XMPPPresence.h"
 #import "MLMessage.h"
 #import "MLContact.h"
+#import "MLPromise.h"
 #import "MLContactSoftwareVersionInfo.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -323,6 +324,10 @@ extern NSString* const kMessageTypeFiletransfer;
 -(void) delIdleTimerWithId:(NSNumber* _Nullable) timerId;
 -(void) cleanupIdleTimerOnAccountID:(NSNumber*) accountID;
 -(void) decrementIdleTimersForAccount:(xmpp*) account;
+
+-(void) addPromise:(MLPromise*) promise;
+-(void) removePromise:(MLPromise*) promise;
+-(MLPromise*) getPromise:(MLPromise*) promise;
 
 @end
 

--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -1147,6 +1147,15 @@
             [db executeNonQuery:@"ALTER TABLE buddylist DROP COLUMN 'blocked';"];
         }];
 
+        // Allow persistence of MLPromises.
+        // This is needed so they can be exchanged between the main app and app extension.
+        [self updateDB:db withDataLayer:dataLayer toVersion:6.412 withBlock:^{
+            [db executeNonQuery:@"CREATE TABLE 'promises' (\
+                'uuid' CHAR(36) PRIMARY KEY, \
+                'promise' BLOB NOT NULL \
+            );"];
+        }];
+
 
         //check if device id changed and invalidate state, if so
         //but do so only for non-sandbox (e.g. non-development) installs

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -985,6 +985,9 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         [OmemoState class],
         [MLContactSoftwareVersionInfo class],
         [Quicksy_Country class],
+        [NSUUID class],
+        [MLPromise class],
+        [NSError class],
     ]] fromData:data error:&error];
     if(error)
         @throw [NSException exceptionWithName:@"NSError" reason:[NSString stringWithFormat:@"%@", error] userInfo:@{@"error": error}];

--- a/Monal/Classes/MLMucProcessor.h
+++ b/Monal/Classes/MLMucProcessor.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) destroyRoom:(NSString*) room;
 -(void) changeNameOfMuc:(NSString*) room to:(NSString*) name;
 -(void) changeSubjectOfMuc:(NSString*) room to:(NSString*) subject;
--(void) publishAvatar:(UIImage* _Nullable) image forMuc:(NSString*) room;
+-(AnyPromise*) publishAvatar:(UIImage* _Nullable) image forMuc:(NSString*) room;
 -(void) setAffiliation:(NSString*) affiliation ofUser:(NSString*) jid inMuc:(NSString*) roomJid;
 -(void) inviteUser:(NSString*) jid inMuc:(NSString*) roomJid;
 

--- a/Monal/Classes/MLPromise.h
+++ b/Monal/Classes/MLPromise.h
@@ -1,0 +1,37 @@
+//
+//  MLPromise.h
+//  Monal
+//
+//  Created by Matthew Fennell on 29/09/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+#import "MLConstants.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ In Monal, we use the handler framework to create "serializable callbacks" so that processing can be handed off between the main app and app extension.
+ (See https://github.com/monal-im/Monal/wiki/Handler-Framework/ for more information).
+ Meanwhile, in SwiftUI, we use AnyPromises (aka PMKResolvers) to update the state of the UI as a result of an asynchronous action.
+
+ If an async action that should trigger a UI update gets started from the main app, but then the app is put into the background, the handler for that action will get called from the app extension. The UI should reflect the new state when the app is reopened.
+ Critically, the main app and app extension are separate processes and do not share memory, so we need a way to co-ordinate them.
+
+ This class handle this co-ordination via the database. Any function that creates a handler to respond to the response from the server, but returns an AnyPromise to the UI, could create an MLPromise, call toAnyPromise on it to return an AnyPromise to the UI, then pass the MLPromise instance to the handler. Then, the handler can fulfill or reject the promise, and the MLPromise will take care of updating the UI.
+
+ Meanwhile, the MLPromise takes care of:
+ * Co-ordinating whether the promise has been fulfilled, and its value, between the main app and app extension (via the database)
+ * Checking when the main app reopens whether the app extension had fulfilled a promise in the meantime, and then calling the AnyPromise for the UI
+ */
+@interface MLPromise : NSObject<NSSecureCoding>
+
+@property(nonatomic, strong) NSUUID* uuid;
+
+-(void) fulfill:(id _Nullable) arg;
+-(void) reject:(NSError*) error;
+-(AnyPromise*) toAnyPromise;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Monal/Classes/MLPromise.m
+++ b/Monal/Classes/MLPromise.m
@@ -1,0 +1,168 @@
+//
+//  MLPromise.m
+//  monalxmpp
+//
+//  Created by Matthew Fennell on 29/09/2024.
+//  Copyright © 2024 monal-im.org. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+#import "DataLayer.h"
+#import "HelperTools.h"
+#import "MLPromise.h"
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MLPromise()
+
+-(void) resolve:(id _Nullable) argument;
+
+@property(nonatomic, strong) AnyPromise* anyPromise;
+@property(nonatomic, strong) id resolvedArgument;
+@property(nonatomic, assign) BOOL isResolved;
+
+@end
+
+@implementation MLPromise
+
+static NSMutableDictionary* _resolvers;
+
++(void) initialize
+{
+    _resolvers = [NSMutableDictionary new];
+}
+
+-(instancetype) init
+{
+    self.uuid = [NSUUID UUID];
+    self.isResolved = false;
+
+    [self serialize];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(deserialize) name:kMonalUnfrozen object:nil];
+
+    DDLogVerbose(@"Initialized promise %@ with uuid %@", self, self.uuid);
+
+    return self;
+}
+
+-(nullable instancetype) initWithCoder:(NSCoder*) coder
+{
+    self.uuid = [coder decodeObjectForKey:@"uuid"];
+    self.resolvedArgument = [coder decodeObjectForKey:@"resolvedArgument"];
+    self.isResolved = [coder decodeBoolForKey:@"isResolved"];
+    DDLogVerbose(@"Initialised from coder a promise %@ with uuid %@", self, self.uuid);
+    return self;
+}
+
+-(void) dealloc
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self];
+    DDLogVerbose(@"Deallocated promise %@ with uuid %@", self, self.uuid);
+}
+
+-(void) serialize
+{
+    [[DataLayer sharedInstance] addPromise:self];
+    DDLogVerbose(@"Serialized promise %@ with uuid %@", self, self.uuid);
+}
+
+-(void) deserialize
+{
+    MLPromise* dbPromise = [[DataLayer sharedInstance] getPromise:self];
+    self.resolvedArgument = dbPromise.resolvedArgument;
+    self.isResolved = dbPromise.isResolved;
+    DDLogVerbose(@"Deserialized promise %@ with uuid %@", self, self.uuid);
+
+    [self attemptConsume];
+}
+
+-(void) resolve:(id _Nullable) argument
+{
+    DDLogDebug(@"Resolving promise %@ with uuid %@ and argument %@", self, self.uuid, argument);
+    NSAssert(!self.isResolved, @"Trying to resolve an already resolved promise");
+
+    self.resolvedArgument = argument;
+    self.isResolved = true;
+    [self serialize];
+    [self attemptConsume];
+}
+
+-(void) fulfill:(id _Nullable) argument
+{
+    [self resolve:argument];
+}
+
+-(void) reject:(NSError*) error
+{
+    [self resolve:error];
+}
+
+-(AnyPromise*) toAnyPromise
+{
+    DDLogDebug(@"Converting promise %@ with uuid %@ to AnyPromise", self, self.uuid);
+
+    if(self.anyPromise != nil)
+    {
+        DDLogVerbose(@"Returning already existing AnyPromise");
+        return self.anyPromise;
+    }
+
+    self.anyPromise = [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        [_resolvers setObject:resolve forKey:self.uuid];
+        DDLogVerbose(@"Adding resolver %@ with uuid %@ to resolvers map", resolve, self.uuid);
+        DDLogVerbose(@"Resolvers map is now: %@", _resolvers);
+    }];
+
+    return self.anyPromise;
+}
+
+-(void) attemptConsume
+{
+    DDLogDebug(@"Intend to consume promise %@ with uuid %@ and argument %@", self, self.uuid, self.resolvedArgument);
+
+    if([HelperTools isAppExtension])
+    {
+        DDLogDebug(@"Not consuming promise %@ with uuid %@ as we are in the app extension", self, self.uuid);
+        return;
+    }
+
+    if(!self.isResolved)
+    {
+        DDLogDebug(@"Not consuming promise %@ with uuid %@ as it has not been resolved yet", self, self.uuid);
+        return;
+    }
+
+    PMKResolver resolve = _resolvers[self.uuid];
+
+    if(resolve == nil)
+    {
+        DDLogDebug(@"Tried to consume promise %@ with uuid %@ when there is no resolver available", self, self.uuid);
+        return;
+    }
+
+    DDLogDebug(@"Resolving promise %@ with uuid %@ and argument %@", self, self.uuid, self.resolvedArgument);
+    resolve(self.resolvedArgument);
+
+    [_resolvers removeObjectForKey:self.uuid];
+    DDLogVerbose(@"Removed resolver with uuid %@ from resolvers map", self.uuid);
+    DDLogVerbose(@"Resolvers map is now: %@", _resolvers);
+
+    [[DataLayer sharedInstance] removePromise:self];
+}
+
++(BOOL) supportsSecureCoding
+{
+    return YES;
+}
+
+-(void) encodeWithCoder:(NSCoder*) coder
+{
+    [coder encodeObject:self.uuid forKey:@"uuid"];
+    [coder encodeObject:self.resolvedArgument forKey:@"resolvedArgument"];
+    [coder encodeBool:self.isResolved forKey:@"isResolved"];
+}
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -78,6 +78,8 @@
 		26E8462824EABAED00ECE419 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 26E8462A24EABAED00ECE419 /* Main.storyboard */; };
 		26F9794D1ACAC73A0008E005 /* MLContactCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = 26F9794C1ACAC73A0008E005 /* MLContactCell.xib */; };
 		26FE3BCB1C61A6C3003CC230 /* MLResizingTextView.m in Sources */ = {isa = PBXBuildFile; fileRef = 26FE3BCA1C61A6C3003CC230 /* MLResizingTextView.m */; };
+		341F44662CAF427500AA6C7D /* MLPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 341F44642CAF427500AA6C7D /* MLPromise.h */; };
+		341F44672CAF427500AA6C7D /* MLPromise.m in Sources */ = {isa = PBXBuildFile; fileRef = 341F44652CAF427500AA6C7D /* MLPromise.m */; };
 		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
 		34E58B4B2C68E7BC009A1634 /* ContactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E58B4A2C68E7BC009A1634 /* ContactsView.swift */; };
 		38720923251EDE07001837EB /* MLXEPSlashMeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */; };
@@ -499,6 +501,8 @@
 		2C59BAF969550DFAC27E5F2B /* Pods_MonalXMPPUnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_MonalXMPPUnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		2E5021A8D40FCC591D952104 /* Pods-NotificaionService.alpha-ios.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificaionService.alpha-ios.xcconfig"; path = "Target Support Files/Pods-NotificaionService/Pods-NotificaionService.alpha-ios.xcconfig"; sourceTree = "<group>"; };
 		32CA4F630368D1EE00C91783 /* MonalSourceCodePrefix.pch */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MonalSourceCodePrefix.pch; sourceTree = "<group>"; };
+		341F44642CAF427500AA6C7D /* MLPromise.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MLPromise.h; sourceTree = "<group>"; };
+		341F44652CAF427500AA6C7D /* MLPromise.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MLPromise.m; sourceTree = "<group>"; };
 		34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentUnavailableShimView.swift; sourceTree = "<group>"; };
 		34E58B4A2C68E7BC009A1634 /* ContactsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContactsView.swift; sourceTree = "<group>"; };
 		3872091F251EDE07001837EB /* MLXEPSlashMeHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MLXEPSlashMeHandler.h; sourceTree = "<group>"; };
@@ -861,6 +865,8 @@
 				262D9EAB17924532009292B4 /* MLConstants.h */,
 				26EC411117BDE39E0031304D /* MLImageManager.h */,
 				26EC411217BDE39E0031304D /* MLImageManager.m */,
+				341F44642CAF427500AA6C7D /* MLPromise.h */,
+				341F44652CAF427500AA6C7D /* MLPromise.m */,
 				263AFDFA209B3B35007F9CEE /* MLSignalStore.h */,
 				263AFDFB209B3B35007F9CEE /* MLSignalStore.m */,
 				C16D18332792A4AF00F869A0 /* DataLayerMigrations.h */,
@@ -1510,6 +1516,7 @@
 				26D4389123A5EB6C00242AAA /* MLConstants.h in Headers */,
 				C158D40025A0AB810005AA40 /* MLMucProcessor.h in Headers */,
 				54A22D2D26185E7E00B56EAD /* MLNotificationQueue.h in Headers */,
+				341F44662CAF427500AA6C7D /* MLPromise.h in Headers */,
 				541E4CC4254D369200FD7B28 /* MLPubSubProcessor.h in Headers */,
 				844921EC2C29F9BE00B99A9C /* MLDelayableTimer.h in Headers */,
 				84C1CD542A8F6196007076ED /* MLStreamRedirect.h in Headers */,
@@ -2167,6 +2174,7 @@
 			files = (
 				5427C94E276A6BE1003217D5 /* UIColor+Extension.m in Sources */,
 				540E13A524CF6A8C0038FDA0 /* MLNotificationManager.m in Sources */,
+				341F44672CAF427500AA6C7D /* MLPromise.m in Sources */,
 				54D2308424CB10EE00638D65 /* MLLogFileManager.m in Sources */,
 				26CC57B323A086CC00ABB92A /* XMPPIQ.m in Sources */,
 				C1613B5B2520723D0062C0C2 /* MLBasePaser.m in Sources */,


### PR DESCRIPTION
To test this, I:

- Added a plugin to my server that delays its response and ultimately returns an error or success.
- Triggered the update from the app, swiped it away to put it in the background, and waited for the app to suspend.
- Then, I triggered a notification from CloudKit to wake up the appex.
- Then, while the appex was awake, the server gave its response.
- Then, I swiped back to the app and saw the promise get consumed successfully:

https://github.com/user-attachments/assets/19a4f510-0c16-4247-ac8c-26dac996fbe7



Todo:

- [x] Test all scenarios
- [x] Consider creating a protocol (not sure if it's possible to pass a protocol to a handler - yes it is, a protocol can be used just like any other types)
- [x] Display only the error description instead of a debug description of the error in case of timeout / server error
- [x] Add comments to `MLPromise`
- [x] Split up commits / better commit messages