### PR TITLE
Remove stale promises from the DB on app startup

### DIFF
--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -327,6 +327,7 @@ extern NSString* const kMessageTypeFiletransfer;
 
 -(void) addPromise:(MLPromise*) promise;
 -(void) removePromise:(MLPromise*) promise;
+-(void) removeAllPromises;
 -(MLPromise*) getPromise:(MLPromise*) promise;
 
 @end

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -2561,6 +2561,15 @@ static NSDateFormatter* dbFormatter;
     }];
 }
 
+-(void) removeAllPromises
+{
+    DDLogDebug(@"Removing all promises from the DB");
+    [self.db voidWriteTransaction:^{
+        NSString* query = @"DELETE FROM promises;";
+        [self.db executeNonQuery:query];
+    }];
+}
+
 -(MLPromise*) getPromise:(MLPromise*) promise
 {
     DDLogDebug(@"Getting promise %@ with uuid %@ from DB", promise, promise.uuid);

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -2556,7 +2556,7 @@ static NSDateFormatter* dbFormatter;
 {
     DDLogDebug(@"Removing promise %@ with uuid %@ from DB", promise, promise.uuid);
     [self.db voidWriteTransaction:^{
-        NSString* query = @"DELETE FROM promises WHERE uuid = ?";
+        NSString* query = @"DELETE FROM promises WHERE uuid = ?;";
         [self.db executeNonQuery:query andArguments:@[[promise.uuid UUIDString]]];
     }];
 }
@@ -2565,7 +2565,7 @@ static NSDateFormatter* dbFormatter;
 {
     DDLogDebug(@"Getting promise %@ with uuid %@ from DB", promise, promise.uuid);
     return [self.db idReadTransaction:^{
-        NSString* query = @"SELECT promise FROM promises WHERE uuid = ?";
+        NSString* query = @"SELECT promise FROM promises WHERE uuid = ?;";
         NSArray* results = [self.db executeScalarReader:query andArguments:@[[promise.uuid UUIDString]]];
         MLAssert([results count] == 1, @"Tried to retrieve a promise that did not exist in the DB");
         NSData* data = results[0];

--- a/Monal/Classes/MLPromise.h
+++ b/Monal/Classes/MLPromise.h
@@ -30,6 +30,8 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) reject:(NSError*) error;
 -(AnyPromise*) toAnyPromise;
 
++(void) removeStalePromises;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Monal/Classes/MLPromise.m
+++ b/Monal/Classes/MLPromise.m
@@ -77,6 +77,15 @@ static NSMutableDictionary* _resolvers;
     [self attemptConsume];
 }
 
+// A stale promise is a promise that is still in the DB, but doesn't have an entry in the resolvers map.
+// It is "stale" because it is not possible to consume it - we've lost the linkage from MLPromise to AnyPromise that _resolvers provides.
+// When we start the app, the resolvers map is empty; therefore, all promises still in the DB are stale.
++(void) removeStalePromises
+{
+    MLAssert([_resolvers count] == 0, @"Resolvers map should be empty, but it was not. This function should only be called on app start-up");
+    [[DataLayer sharedInstance] removeAllPromises];
+}
+
 -(void) resolve:(id _Nullable) argument
 {
     DDLogDebug(@"Resolving promise %@ with uuid %@ and argument %@", self, self.uuid, argument);

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -394,6 +394,9 @@ $$
         [[MLImageManager sharedInstance] cleanupHashes];
     });
     
+    // Remove stale promises left in the DB that weren't consumed last time we ran the app
+    [MLPromise removeStalePromises];
+
     //only proceed with launching if the NotificationServiceExtension is *not* running
     if([MLProcessLock checkRemoteRunning:@"NotificationServiceExtension"])
     {


### PR DESCRIPTION
Before this commit, promises were only removed from the DB once they
were consumed.

Therefore, it was possible to end up with "stale" promises lingering in
the promise table of the DB, if the promise was created and persisted,
but the app got closed before they could be consumed.

These promises would linger forever because there was no way to consume
them anymore (resolvers map was empty) and would therefore just take up
space in the table for no reason.

This commit fixes this by truncating the promise table on each restart
of the application. We can truncate the whole table as we know that all
of the promises still in the DB at app start-up are unconsumable, as
the resolvers map will be empty at this point.