### PR TITLE
Refactor stale promise consumption

### DIFF
--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -329,6 +329,7 @@ extern NSString* const kMessageTypeFiletransfer;
 -(void) removePromise:(MLPromise*) promise;
 -(void) removeAllPromises;
 -(MLPromise*) getPromise:(MLPromise*) promise;
+-(NSSet<MLPromise*>*) getAllPromises;
 
 @end
 

--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -327,7 +327,6 @@ extern NSString* const kMessageTypeFiletransfer;
 
 -(void) addPromise:(MLPromise*) promise;
 -(void) removePromise:(MLPromise*) promise;
--(void) removeAllPromises;
 -(MLPromise*) getPromise:(MLPromise*) promise;
 -(NSSet<MLPromise*>*) getAllPromises;
 

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -2583,4 +2583,19 @@ static NSDateFormatter* dbFormatter;
     }];
 }
 
+-(NSSet<MLPromise*>*) getAllPromises
+{
+    DDLogDebug(@"Getting all promises from the DB");
+    return [self.db idReadTransaction:^{
+        NSString* query = @"SELECT promise FROM promises;";
+        NSArray<NSData*>* results = [self.db executeScalarReader:query];
+        NSMutableSet<MLPromise*>* promises = [NSMutableSet new];
+        for(NSData* data in results)
+        {
+            [promises addObject:[HelperTools unserializeData:data]];
+        }
+        return promises;
+    }];
+}
+
 @end

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -2561,15 +2561,6 @@ static NSDateFormatter* dbFormatter;
     }];
 }
 
--(void) removeAllPromises
-{
-    DDLogDebug(@"Removing all promises from the DB");
-    [self.db voidWriteTransaction:^{
-        NSString* query = @"DELETE FROM promises;";
-        [self.db executeNonQuery:query];
-    }];
-}
-
 -(MLPromise*) getPromise:(MLPromise*) promise
 {
     DDLogDebug(@"Getting promise %@ with uuid %@ from DB", promise, promise.uuid);

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -988,6 +988,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         [NSUUID class],
         [MLPromise class],
         [NSError class],
+        [MLPromiseRejection class],
     ]] fromData:data error:&error];
     if(error)
         @throw [NSException exceptionWithName:@"NSError" reason:[NSString stringWithFormat:@"%@", error] userInfo:@{@"error": error}];

--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -1311,7 +1311,7 @@ $$
 $$instance_handler(handleAvatarPublishResultInvalidation, account.mucProcessor, $$ID(xmpp*, account), $$ID(NSString*, room), $$ID(MLPromise*, promise))
     NSString* errorString = [NSString stringWithFormat:NSLocalizedString(@"Publishing avatar for muc '%@' returned timeout", @""), room];
     NSError* error = [NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: errorString}];
-    [promise reject:error];
+    [promise rejectWithError:error andNode:nil forAccountWithID:account.accountID];
 $$
 
 $$instance_handler(handleAvatarPublishResult, account.mucProcessor, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode), $$ID(MLPromise*, promise))
@@ -1320,7 +1320,7 @@ $$instance_handler(handleAvatarPublishResult, account.mucProcessor, $$ID(xmpp*, 
         DDLogError(@"Publishing avatar for muc '%@' returned error: %@", iqNode.fromUser, [iqNode findFirst:@"error"]);
         NSString* errorString = [NSString stringWithFormat:NSLocalizedString(@"Failed to publish avatar image for group/channel %@", @""), iqNode.fromUser];
         NSError* error = [NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: errorString}];
-        [promise reject:error];
+        [promise rejectWithError:error andNode:iqNode forAccountWithID:account.accountID];
         return;
     }
     DDLogInfo(@"Successfully published avatar for muc: %@", iqNode.fromUser);

--- a/Monal/Classes/MLPromise.h
+++ b/Monal/Classes/MLPromise.h
@@ -27,10 +27,14 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, strong) NSUUID* uuid;
 
 -(void) fulfill:(id _Nullable) arg;
--(void) reject:(NSError*) error;
+-(void) rejectWithError:(NSError*) error andNode:(XMPPStanza* _Nullable) node forAccountWithID:(NSNumber*) accountID;
 -(AnyPromise*) toAnyPromise;
 
 +(void) removeStalePromises;
+
+@end
+
+@interface MLPromiseRejection : NSObject<NSSecureCoding>
 
 @end
 

--- a/Monal/Classes/MLPromise.h
+++ b/Monal/Classes/MLPromise.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) rejectWithError:(NSError*) error andNode:(XMPPStanza* _Nullable) node forAccountWithID:(NSNumber*) accountID;
 -(AnyPromise*) toAnyPromise;
 
-+(void) removeStalePromises;
++(void) consumeStalePromises;
 
 @end
 

--- a/Monal/Classes/MLPromise.m
+++ b/Monal/Classes/MLPromise.m
@@ -129,7 +129,7 @@ static NSMutableDictionary* _resolvers;
 // A stale promise is a promise that is still in the DB, but doesn't have an entry in the resolvers map.
 // It is "stale" because it is not possible to consume it - we've lost the linkage from MLPromise to AnyPromise that _resolvers provides.
 // When we start the app, the resolvers map is empty; therefore, all promises still in the DB are stale.
-+(void) removeStalePromises
++(void) consumeStalePromises
 {
     MLAssert([_resolvers count] == 0, @"Resolvers map should be empty, but it was not. This function should only be called on app start-up");
     [[DataLayer sharedInstance] removeAllPromises];

--- a/Monal/Classes/MLPromise.m
+++ b/Monal/Classes/MLPromise.m
@@ -94,6 +94,7 @@ static NSMutableDictionary* _resolvers;
 {
     DDLogDebug(@"Resolving promise %@ with uuid %@ and argument %@", self, self.uuid, argument);
     NSAssert(self.state == PromiseResolutionStateUnresolved, @"Trying to resolve an already resolved promise");
+    NSAssert(self.resolvedArgument == nil, @"Promise is unresolved, therefore resolvedArgument should be nil");
 
     self.resolvedArgument = argument;
     self.state = state;

--- a/Monal/Classes/MLPromise.m
+++ b/Monal/Classes/MLPromise.m
@@ -16,8 +16,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MLPromise()
 
--(void) resolve:(id _Nullable) argument;
-
 @property(nonatomic, strong) AnyPromise* anyPromise;
 @property(nonatomic, strong) id resolvedArgument;
 @property(nonatomic, assign) BOOL isResolved;

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -395,7 +395,7 @@ $$
     });
     
     // Remove stale promises left in the DB that weren't consumed last time we ran the app
-    [MLPromise removeStalePromises];
+    [MLPromise consumeStalePromises];
 
     //only proceed with launching if the NotificationServiceExtension is *not* running
     if([MLProcessLock checkRemoteRunning:@"NotificationServiceExtension"])


### PR DESCRIPTION
This WIP PR contains refactors to allow an error popup on consumption of stale, rejected promises.

See https://github.com/matthewrfennell/Monal/pull/1/commits/3d8c5d2fe4a7108305b684318948ecb5e7b81fb8 for how I was thinking of implementing that error posting (based off this branch).

Feedback welcome, I've left as WIP as there are still some things I want to check (left comments for myself to review later)