### PR TITLE
Remove duplicate hideLoadingOverlay

### DIFF
--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -673,9 +673,6 @@ struct ContactDetails: View {
                 }
             }
         }
-        .onChange(of:contact.avatar as UIImage) { _ in
-            hideLoadingOverlay(overlay)
-        }
         .onAppear {
             self.updateRoleAndAffiliation()
         }


### PR DESCRIPTION
There are overloaded instances of showPromisingLoadingOverlay - some of which automatically hide the overlay once the promise is resolved, and some which do not and expect the caller to hide the overlay.

In ContactDetails.swift, we only call the instances that hide the overlay themselves on consumption of the promise.

Therefore, this extra call to hideLoadingOverlay is redundant - the promise overlay class itself should take care of this.


https://github.com/user-attachments/assets/ad188566-5eab-491e-9ab4-5b350eaa916e

