### PR TITLE
Make gateway detection more reliable when generating a room address

### DIFF
--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -979,7 +979,10 @@ $$
     NSString* mucServer = nil;
     for(NSString* jid in _account.connectionProperties.conferenceServers)
     {
-        if([_account.connectionProperties.conferenceServers[jid] check:@"identity<type=text>"])
+        // Do not use gateways
+        if(![_account.connectionProperties.conferenceServers[jid] check:@"identity<category=gateway>"]
+          && [_account.connectionProperties.conferenceServers[jid] check:@"identity<category=conference>"]
+          && [_account.connectionProperties.conferenceServers[jid] check:@"identity<type=text>"])
         {
             mucServer = jid;
             break;


### PR DESCRIPTION
Before this commit, monal checked that an entity is not a gateway by verifying that its identity's type is 'text'
https://xmpp.org/registrar/disco-categories.html#conference

But non-IRC gateways can have an identity type of 'text'.

Now, it will be checking that the entity does not advertise a category of 'gateway', as that's more robust.
https://xmpp.org/extensions/xep-0100.html#example-3

This should work with Biboumi and Slidge.