### PR TITLE
Minimise workflow permissions

### DIFF
--- a/.github/workflows/beta.build-push.yml
+++ b/.github/workflows/beta.build-push.yml
@@ -9,6 +9,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -27,6 +29,9 @@ jobs:
       EXPORT_OPTIONS_CATALYST_APPSTORE: "../scripts/exportOptions/Stable_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_CATALYST_APP_EXPORT: "../scripts/exportOptions/Beta_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_IOS: "../scripts/exportOptions/Beta_iOS_ExportOptions.plist"
+    permissions:
+      actions: write # needed to upload artifacts
+      contents: write # needed for git push
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4
@@ -250,6 +255,8 @@ jobs:
       APP_NAME: "Monal"
       APP_DIR: "Monal.app"
       BUILD_TYPE: "Beta"
+    permissions:
+      contents: write # needed for git push in updateLocalization
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/create-stable-pr.yml
+++ b/.github/workflows/create-stable-pr.yml
@@ -5,9 +5,13 @@ on:
     branches: [ beta ]
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   create-pull-request:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - name: Checkout Beta Branch
         uses: actions/checkout@v4

--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -9,6 +9,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -27,6 +29,8 @@ jobs:
       ALPHA_UPLOAD_SECRET: ${{ secrets.ALPHA_UPLOAD_SECRET }}
       EXPORT_OPTIONS_CATALYST_APP_EXPORT: "../scripts/exportOptions/Alpha_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_IOS: "../scripts/exportOptions/Alpha_iOS_ExportOptions.plist"
+    permissions:
+      actions: write # needed to upload artifacts
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-semver-title.yml
+++ b/.github/workflows/pr-semver-title.yml
@@ -13,6 +13,8 @@ on:
         required: true
         type: number
 
+permissions: {}
+
 jobs:
   check-pr-semver-title:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-quicksy-release.yml
+++ b/.github/workflows/publish-quicksy-release.yml
@@ -2,6 +2,7 @@ name: Publish Quicksy release
 on:
   repository_dispatch:
     types: [quicksy_release]
+permissions: {}
 jobs:
   extractChangelog:
     runs-on: self-hosted

--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -2,6 +2,7 @@ name: Publish release
 on:
   repository_dispatch:
     types: [monal_release]
+permissions: {}
 jobs:
   extractChangelog:
     runs-on: self-hosted
@@ -34,6 +35,8 @@ jobs:
     name: Promote draft release to live release
     runs-on: ubuntu-latest
     needs: [extractChangelog]
+    permissions:
+      contents: write
     steps:
       - name: Promote draft release to live release
         run: |

--- a/.github/workflows/quicksy.build-push.yml
+++ b/.github/workflows/quicksy.build-push.yml
@@ -9,6 +9,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -20,6 +22,9 @@ jobs:
       BUILD_SCHEME: "Quicksy"
       BUILD_TYPE: "AppStore-Quicksy"
       EXPORT_OPTIONS_IOS: "../scripts/exportOptions/Quicksy_Stable_iOS_ExportOptions.plist"
+    permissions:
+      actions: write # needed to upload artifacts
+      contents: write # needed for git push
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/stable.build-push.yml
+++ b/.github/workflows/stable.build-push.yml
@@ -9,6 +9,8 @@ on:
 
   workflow_dispatch:
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"
@@ -23,6 +25,9 @@ jobs:
       EXPORT_OPTIONS_CATALYST_APPSTORE: "../scripts/exportOptions/Stable_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_CATALYST_APP_EXPORT: "../scripts/exportOptions/Beta_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_IOS: "../scripts/exportOptions/Stable_iOS_ExportOptions.plist"
+    permissions:
+      actions: write # needed to upload artifacts
+      contents: write # needed for git push
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -5,6 +5,8 @@ name: update-translations
 on:
   workflow_dispatch:
 
+permissions: {}
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   # This workflow contains a single job called "build"

--- a/.github/workflows/update-translations.yml
+++ b/.github/workflows/update-translations.yml
@@ -20,6 +20,8 @@ jobs:
       EXPORT_OPTIONS_CATALYST_APPSTORE: "../scripts/exportOptions/Stable_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_CATALYST_APP_EXPORT: "../scripts/exportOptions/Beta_Catalyst_ExportOptions.plist"
       EXPORT_OPTIONS_IOS: "../scripts/exportOptions/Beta_iOS_ExportOptions.plist"
+    permissions:
+      contents: write # needed for git push in updateLocalization
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/xcode-swift-dependencies.yaml
+++ b/.github/workflows/xcode-swift-dependencies.yaml
@@ -5,13 +5,15 @@ on:
   #  - cron: '17 13 * * *'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   dependencies:
     runs-on: self-hosted
+
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I established the permissions needed using a combination of these two docs:

* https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token
* https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps?apiVersion=2022-11-28#repository-permissions-for-contents

I've marked this as WIP for now as I haven't tested these yet.

To test: I was thinking of simplifying the runners so they only contain the bits that interact with GitHub, and then running them on a standard `macos-latest` runner on my fork.

That should provide at least some assurance that we won't suddenly get permission denied errors :)