### PR TITLE
Run xcbeautify in all workflows

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -4,12 +4,13 @@ function exportMacOS {
     local EXPORT_OPTIONS_CATALYST="$1"
     local BUILD_TYPE="$2"
 
-    xcodebuild -exportArchive \
+    NSUnbufferedIO=YES xcodebuild -exportArchive \
         -archivePath "build/macos_$APP_NAME.xcarchive" \
         -exportPath "build/app" \
         -exportOptionsPlist "$EXPORT_OPTIONS_CATALYST" \
         -allowProvisioningUpdates \
-        -configuration $BUILD_TYPE
+        -configuration $BUILD_TYPE \
+        2>&1 | xcbeautify
 
     echo "build dir:"
     ls -l "build"
@@ -17,6 +18,9 @@ function exportMacOS {
 
 # Abort on Error
 set -e
+
+# Needed for xcbeautify
+set -o pipefail
 
 cd Monal
 
@@ -47,7 +51,7 @@ if [ "$BUILD_SCHEME" != "Quicksy" ]; then
     echo "***************************"
     echo "*     Archiving macOS     *"
     echo "***************************"
-    xcrun xcodebuild \
+    NSUnbufferedIO=YES xcrun xcodebuild \
         -workspace "Monal.xcworkspace" \
         -scheme "$BUILD_SCHEME" \
         -sdk macosx \
@@ -57,7 +61,8 @@ if [ "$BUILD_SCHEME" != "Quicksy" ]; then
         -allowProvisioningUpdates \
         archive \
         BUILD_LIBRARIES_FOR_DISTRIBUTION=YES \
-        SUPPORTS_MACCATALYST=YES
+        SUPPORTS_MACCATALYST=YES \
+        2>&1 | xcbeautify
 
     echo ""
     echo "****************************"
@@ -97,14 +102,15 @@ echo ""
 echo "*************************"
 echo "*     Archiving iOS     *"
 echo "*************************"
-xcrun xcodebuild \
+NSUnbufferedIO=YES xcrun xcodebuild \
     -workspace "Monal.xcworkspace" \
     -scheme "$BUILD_SCHEME" \
     -sdk iphoneos \
     -configuration $BUILD_TYPE \
     -archivePath "build/ios_$APP_NAME.xcarchive" \
     -allowProvisioningUpdates \
-    archive
+    archive \
+    2>&1 | xcbeautify
 
 echo ""
 echo "*************************"
@@ -112,14 +118,15 @@ echo "*     Exporting iOS     *"
 echo "*************************"
 # see: https://gist.github.com/cocoaNib/502900f24846eb17bb29
 # and: https://forums.developer.apple.com/thread/100065
-xcodebuild \
+NSUnbufferedIO=YES xcodebuild \
     -exportArchive \
     -archivePath "build/ios_$APP_NAME.xcarchive" \
     -exportPath "build/ipa" \
     -exportOptionsPlist $EXPORT_OPTIONS_IOS \
     -configuration $BUILD_TYPE \
     -allowProvisioningUpdates \
-    -allowProvisioningDeviceRegistration
+    -allowProvisioningDeviceRegistration \
+    2>&1 | xcbeautify
 
 echo "build dir:"
 find build

--- a/scripts/updateLocalization.sh
+++ b/scripts/updateLocalization.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# Needed for xcbeautify
+set -o pipefail
+
 cd "$(dirname "$0")"
 cd ../Monal
 
@@ -116,7 +119,7 @@ dummy="DON'T TRANSLATE: $(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -
 x=$((1))
 while [[ $x -lt 16 ]]; do
     echo "STARTING RUN $x..."
-    while ! xcrun xcodebuild -workspace "Monal.xcworkspace" -scheme "Monal" -sdk iphoneos -configuration "Beta" -allowProvisioningUpdates -exportLocalizations -localizationPath localization.tmp -exportLanguage base SWIFT_EMIT_LOC_STRINGS="$compile_swift"; do
+    while ! NSUnbufferedIO=YES xcrun xcodebuild -workspace "Monal.xcworkspace" -scheme "Monal" -sdk iphoneos -configuration "Beta" -allowProvisioningUpdates -exportLocalizations -localizationPath localization.tmp -exportLanguage base SWIFT_EMIT_LOC_STRINGS="$compile_swift" 2>&1 | xcbeautify; do
         echo "ERROR, TRYING AGAIN..."
     done
     echo "RUN $x SUCCEEDED, EXTRACTING STRINGS FROM XLIFF!"


### PR DESCRIPTION
The Github Actions renderer is not useful in these cases since these scripts are not run against PRs. Therefore: just run standard `xcbeautify` with no extra arguments.

I tested, to see if the Github Actions renderer would add the comments to the commit view in Github, but it did not show anything.

I also tested the while loop in updateLocalization to make sure both `pipefail` and the piped command continue to work as expected.