### PR TITLE
Update checkout version in dependency workfow

### DIFF
--- a/.github/workflows/xcode-swift-dependencies.yaml
+++ b/.github/workflows/xcode-swift-dependencies.yaml
@@ -16,7 +16,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Resolve Dependencies
         id: resolution


### PR DESCRIPTION
actions/checkout@v2 is deprecated. This brings the version of inline with the other workflows in the repository.