### PR TITLE
Avoid template injection in Github workflows

### DIFF
--- a/.github/workflows/create-stable-pr.yml
+++ b/.github/workflows/create-stable-pr.yml
@@ -71,17 +71,21 @@ jobs:
             const existingPR = pullRequests.find(pr => pr.labels.some(label => label.name === 'automated-pr'));
             console.log(`Existing PR: `, existingPR);
             if(existingPR)
-              return existingPR.number;
+              core.setOutput('prNumber', existingPR.number);
             else
-              return null;
+              core.setOutput('prNumber', null);
       - name: Create or Update Pull Request
         id: create_or_update_pr
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.find_pr.outputs.prNumber }}
+          PR_TITLE: ${{ steps.get_commits.outputs.buildVersion }}
+          PR_BODY: ${{ steps.get_commits.outputs.description }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-            const prNumber = ${{ steps.find_pr.outputs.result }};
+            const prNumber = process.env.PR_NUMBER;
             let pullRequest;
             if(prNumber)
             {
@@ -90,8 +94,8 @@ jobs:
                 owner,
                 repo,
                 pull_number: prNumber,
-                title: `${{ steps.get_commits.outputs.buildVersion }}`,
-                body: `${{ steps.get_commits.outputs.description }}`,
+                title: process.env.PR_TITLE,
+                body: process.env.PR_BODY,
               });
               console.log(`Updated pull request #${prNumber}`);
             }
@@ -104,8 +108,8 @@ jobs:
                 head: 'beta',
                 base: 'stable',
                 draft: false,
-                title: `${{ steps.get_commits.outputs.buildVersion }}`,
-                body: `${{ steps.get_commits.outputs.description }}`,
+                title: process.env.PR_TITLE,
+                body: process.env.PR_BODY,
               });
               console.log(`Created pull request #${pullRequest.data.number}`);
               //update pr after creation to trigger our pr-semver-title workflow
@@ -113,19 +117,21 @@ jobs:
                 owner,
                 repo,
                 pull_number: pullRequest.data.number,
-                title: `${{ steps.get_commits.outputs.buildVersion }}`,
-                body: `${{ steps.get_commits.outputs.description }}`,
+                title: process.env.PR_TITLE,
+                body: process.env.PR_BODY,
               });
               console.log(`Updated pull request #${pullRequest.data.number}`);
             }
-            return pullRequest.data.number;
+            core.setOutput('prNumber', pullRequest.data.number);
       - name: Add Label to Pull Request
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.create_or_update_pr.outputs.prNumber }}
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-            const pullNumber = ${{ steps.create_or_update_pr.outputs.result }};
+            const pullNumber = process.env.PR_NUMBER;
             await github.rest.issues.addLabels({
               owner,
               repo,

--- a/.github/workflows/pr-semver-title.yml
+++ b/.github/workflows/pr-semver-title.yml
@@ -23,29 +23,36 @@ jobs:
     steps:
       - name: Get PR details
         id: find_pr
+        env:
+          INPUT_PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          EVENT_PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [ -z "${{ github.event.inputs.pr_number }}" ]; then
-            prNumber=${{ github.event.pull_request.number }}
+          if [ -z "${INPUT_PR_NUMBER}" ]; then
+            prNumber=${EVENT_PR_NUMBER}
           else
-            prNumber=${{ github.event.inputs.pr_number }}
+            prNumber=${INPUT_PR_NUMBER}
           fi
           echo "prNumber=$prNumber" | tee /dev/stderr >> "$GITHUB_OUTPUT"
       - name: Fetch pull request title
         id: pr_title
         uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ steps.find_pr.outputs.prNumber }}
         with:
           script: |
             const [owner, repo] = process.env.GITHUB_REPOSITORY.split("/");
-            const prNumber = ${{ steps.find_pr.outputs.prNumber }};
+            const prNumber = process.env.PR_NUMBER;
             const { data: pull_request } = await github.rest.pulls.get({
               owner: owner,
               repo: repo,
               pull_number: prNumber
             });
-            return pull_request.title;
+            core.setOutput('prTitle', pull_request.title);
       - name: Check PR title format
+        env:
+          VERSION: ${{ steps.pr_title.outputs.prTitle }}
         run: |
-          version="${{ steps.pr_title.outputs.result }}"
+          version="${VERSION}"
           if ! [[ "$version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-((0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*)(\.(0|[1-9][0-9]*|[0-9]*[a-zA-Z-][0-9a-zA-Z-]*))*))?(\+([0-9a-zA-Z-]+(\.[0-9a-zA-Z-]+)*))?$ ]]; then
             echo "Invalid semver: '$version'!"
             exit 1

--- a/.github/workflows/publish-quicksy-release.yml
+++ b/.github/workflows/publish-quicksy-release.yml
@@ -22,8 +22,10 @@ jobs:
       #     echo ${{ github.event.client_payload.appVersionNumber }}
       - name: Load release info
         id: releasenotes
+        env:
+          APP_VERSION_NUMBER: ${{ github.event.client_payload.appVersionNumber }}
         run: |
-          buildNumber="$(fastlane run app_store_build_number api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" app_identifier:"G7YU7X7KRJ.SworIM" live:false version:"${{ github.event.client_payload.appVersionNumber }}" 2>&1 | tee /dev/stderr | grep Result | sed -E 's/^.*Result: ([0-9]+).*$/\1/g')"
+          buildNumber="$(fastlane run app_store_build_number api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" app_identifier:"G7YU7X7KRJ.SworIM" live:false version:"${APP_VERSION_NUMBER}" 2>&1 | tee /dev/stderr | grep Result | sed -E 's/^.*Result: ([0-9]+).*$/\1/g')"
           mkdir -p /Users/ci/releases
           OUTPUT_FILE="/Users/ci/quicksy_releases/$buildNumber.output"
           touch "$OUTPUT_FILE"

--- a/.github/workflows/publish-stable-release.yml
+++ b/.github/workflows/publish-stable-release.yml
@@ -24,8 +24,10 @@ jobs:
       #     echo ${{ github.event.client_payload.appVersionNumber }}
       - name: Load release info
         id: releasenotes
+        env:
+          APP_VERSION_NUMBER: ${{ github.event.client_payload.appVersionNumber }}
         run: |
-          buildNumber="$(fastlane run app_store_build_number api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" app_identifier:"G7YU7X7KRJ.SworIM" live:false version:"${{ github.event.client_payload.appVersionNumber }}" 2>&1 | tee /dev/stderr | grep Result | sed -E 's/^.*Result: ([0-9]+).*$/\1/g')"
+          buildNumber="$(fastlane run app_store_build_number api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" app_identifier:"G7YU7X7KRJ.SworIM" live:false version:"${APP_VERSION_NUMBER}" 2>&1 | tee /dev/stderr | grep Result | sed -E 's/^.*Result: ([0-9]+).*$/\1/g')"
           mkdir -p /Users/ci/releases
           OUTPUT_FILE="/Users/ci/releases/$buildNumber.output"
           touch "$OUTPUT_FILE"
@@ -37,16 +39,18 @@ jobs:
     needs: [extractChangelog]
     permissions:
       contents: write
+    env:
+      RELEASE_ID: ${{ needs.extractChangelog.outputs.release-id }}
     steps:
       - name: Promote draft release to live release
         run: |
-          echo "ID: ${{ needs.extractChangelog.outputs.release-id }}"
+          echo "ID: ${RELEASE_ID}"
           curl -L \
             -X PATCH \
             -H "Accept: application/vnd.github+json" \
             -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "https://api.github.com/repos/${{ github.repository }}/releases/${{ needs.extractChangelog.outputs.release-id }}" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/${RELEASE_ID}" \
             -d '{"draft": false, "prerelease": false, "make_latest": true}'
 
   notifyMuc:
@@ -76,9 +80,10 @@ jobs:
         id: changelog
         env:
           NOTES: ${{ needs.extractChangelog.outputs.release-notes }}
+          RELEASE_TAG: ${{ needs.extractChangelog.outputs.release-tag }}
         run: |
           if [ "${#NOTES}" -gt 400 ]; then
-            NOTES="To see the complete list of bugfixes and improvements, check our releases page: https://github.com/monal-im/Monal/releases/tag/${{ needs.extractChangelog.outputs.release-tag }}"
+            NOTES="To see the complete list of bugfixes and improvements, check our releases page: https://github.com/monal-im/Monal/releases/tag/${RELEASE_TAG}"
           fi
           echo "notes<<__EOF__" | tee /dev/stderr >> "$GITHUB_OUTPUT"
           echo "$NOTES" >> "$GITHUB_OUTPUT"
@@ -93,7 +98,11 @@ jobs:
           visibility: "public"
           language: "en"
       - name: Get toot information
+        env:
+          TOOT_ID: ${{ steps.toot.outputs.id }}
+          TOOT_URL: ${{ steps.toot.outputs.url }}
+          SCHEDULED_AT: ${{ steps.toot.outputs.scheduled_at }}
         run: |
-          echo "Toot ID: ${{ steps.toot.outputs.id }}"
-          echo "Toot URL: ${{ steps.toot.outputs.url }}"
-          echo "Scheduled at: ${{ steps.toot.outputs.scheduled_at }}"
+          echo "Toot ID: ${TOOT_ID}"
+          echo "Toot URL: ${TOOT_URL}"
+          echo "Scheduled at: ${SCHEDULED_AT}"

--- a/.github/workflows/quicksy.build-push.yml
+++ b/.github/workflows/quicksy.build-push.yml
@@ -38,10 +38,12 @@ jobs:
       - name: Checkout submodules
         run: git submodule update -f --init --remote
       - name: Check for proper semantic versioning
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
           buildNumber="$(git tag --sort="v:refname" | grep "Quicksy_Build_iOS" | tail -n1 | sed 's/Quicksy_Build_iOS_//g')"
           version="$(git log -n 1 --merges --pretty=format:%s | sed -E 's/^[\t\n ]*([^\n\t ]+)[\t\n ]+\(([^\n\t ]+)\)[\t\n ]*$/\1/g')"
-          if [ "${{ github.ref }}" != "refs/heads/stable" ]; then
+          if [ "${GITHUB_REF}" != "refs/heads/stable" ]; then
             version="1.$buildNumber.0"
           fi
           
@@ -56,6 +58,8 @@ jobs:
           echo "New buildNumber is $buildNumber"
           git tag Quicksy_Build_iOS_$buildNumber
       - name: Extract version number and changelog from newest merge commit
+        env:
+          GITHUB_REF: ${{ github.ref }}
         id: releasenotes
         run: |
           function repairNotes {
@@ -79,7 +83,7 @@ jobs:
           }
           buildNumber="$(git tag --sort="v:refname" | grep "Quicksy_Build_iOS" | tail -n1 | sed 's/Quicksy_Build_iOS_//g')"
           version="$(git log -n 1 --merges --pretty=format:%s | sed -E 's/^[\t\n ]*([^\n\t ]+)[\t\n ]+\(([^\n\t ]+)\)[\t\n ]*$/\1/g')"
-          if [ "${{ github.ref }}" != "refs/heads/stable" ]; then
+          if [ "${GITHUB_REF}" != "refs/heads/stable" ]; then
             version="1.$buildNumber.0"
           fi
           mkdir -p /Users/ci/quicksy_releases
@@ -155,9 +159,11 @@ jobs:
       - name: Publish ios to appstore connect
         #run: xcrun altool --upload-app --file ./Monal/build/ipa/Quicksy.ipa --type ios --asc-provider S8D843U34Y --team-id S8D843U34Y -u $(cat /Users/ci/apple_connect_upload_mail.txt) -p "$(cat /Users/ci/apple_connect_upload_secret.txt)"
         env:
+          APP_VERSION: ${{ steps.releasenotes.outputs.version }}
           DELIVER_METADATA_PATH: ${{ steps.metadata.outputs.path_ios }}
+          FASTLANE_METADATA_DIRECTORY: ${{ steps.metadata.outputs.path }}
         run: |
-          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" ipa:"./Monal/build/ipa/Quicksy.ipa" app_version:"${{ steps.releasenotes.outputs.version }}" platform:ios reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
+          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" ipa:"./Monal/build/ipa/Quicksy.ipa" app_version:"${APP_VERSION}" platform:ios reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
       - name: Remove fastlane metadata directory
         run: |
-          rm -rf "${{ steps.metadata.outputs.path }}"
+          rm -rf "${FASTLANE_METADATA_DIRECTORY}"

--- a/.github/workflows/stable.build-push.yml
+++ b/.github/workflows/stable.build-push.yml
@@ -167,9 +167,10 @@ jobs:
       - name: Publish ios to appstore connect
         #run: xcrun altool --upload-app --file ./Monal/build/ipa/Monal.ipa --type ios --asc-provider S8D843U34Y --team-id S8D843U34Y -u $(cat /Users/ci/apple_connect_upload_mail.txt) -p "$(cat /Users/ci/apple_connect_upload_secret.txt)"
         env:
+          APP_VERSION: ${{ steps.releasenotes.outputs.version }}
           DELIVER_METADATA_PATH: ${{ steps.metadata.outputs.path_ios }}
         run: |
-          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" ipa:"./Monal/build/ipa/Monal.ipa" app_version:"${{ steps.releasenotes.outputs.version }}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
+          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" ipa:"./Monal/build/ipa/Monal.ipa" app_version:"${APP_VERSION}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
       - name: Notarize catalyst
         run: xcrun notarytool submit ./Monal/build/app/Monal.zip --wait --team-id S8D843U34Y --key "/Users/ci/appstoreconnect/apiKey.p8" --key-id "$(cat /Users/ci/appstoreconnect/apiKeyId.txt)" --issuer "$(cat /Users/ci/appstoreconnect/apiIssuerId.txt)"
       - name: Staple notarisation
@@ -197,15 +198,19 @@ jobs:
       - name: Publish catalyst to appstore connect
         #run: xcrun altool --upload-app --file ./Monal/build/app/Monal.pkg --type macos --asc-provider S8D843U34Y -u "$(cat /Users/ci/apple_connect_upload_mail.txt)" -p "$(cat /Users/ci/apple_connect_upload_secret.txt)" --primary-bundle-id maccatalyst.G7YU7X7KRJ.SworIM
         env:
+          APP_VERSION: ${{ steps.releasenotes.outputs.version }}
           DELIVER_METADATA_PATH: ${{ steps.metadata.outputs.path_macos }}
         run: |
-          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" pkg:"./Monal/build/app/Monal.pkg" app_version:"${{ steps.releasenotes.outputs.version }}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
+          fastlane run upload_to_app_store api_key_path:"/Users/ci/appstoreconnect/key.json" team_id:"S8D843U34Y" pkg:"./Monal/build/app/Monal.pkg" app_version:"${APP_VERSION}" reject_if_possible:true submit_for_review:true automatic_release:true skip_metadata:false skip_screenshots:true precheck_include_in_app_purchases:false version_check_wait_retry_limit:10 force:true
       # - name: Update xmpp.org client list with new timestamp
       #   run: ./scripts/push_xmpp.org.sh
       - name: Remove fastlane metadata directory
+        env:
+          METADATA_IOS: ${{ steps.metadata.outputs.path_ios }}
+          METADATA_MACOS: ${{ steps.metadata.outputs.path_macos }}
         run: |
-          rm -rf "${{ steps.metadata.outputs.path_ios }}"
-          rm -rf "${{ steps.metadata.outputs.path_macos }}"
+          rm -rf "${METADATA_IOS}"
+          rm -rf "${METADATA_MACOS}"
       - name: Create Draft Release
         id: draftrelease
         uses: softprops/action-gh-release@v2
@@ -224,5 +229,8 @@ jobs:
           prerelease: false
           draft: true
       - name: Write draft release id to build env
+        env:
+          RELEASE_ID: ${{ steps.draftrelease.outputs.id }}
+          OUTPUT_FILE: ${{ steps.releasenotes.outputs.OUTPUT_FILE }}
         run: |
-          echo "releaseID=${{ steps.draftrelease.outputs.id }}" | tee /dev/stderr >> "${{ steps.releasenotes.outputs.OUTPUT_FILE }}"
+          echo "releaseID=${RELEASE_ID}" | tee /dev/stderr >> "${OUTPUT_FILE}"


### PR DESCRIPTION
GitHub workflow variables (`${{ ... }}`) use string replacement - simply replacing the variable with its value before the step gets executed.

Depending on where the input for these variables comes from, this makes it possible to pass malicious shell code that gets executed in the step.

It is safer to first pass the variables through an environment variable, and then from the environment variable to the script. This is because the shell will itself substitute the value, avoiding executing any code contained within it.