### PR TITLE
Fix the displaying of own Omemo Keys view on iPads

### DIFF
--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -655,10 +655,12 @@ class SwiftuiInterface : NSObject {
     @objc
     func makeOwnOmemoKeyView(_ ownContact: MLContact?) -> UIViewController {
         let host = UIHostingController(rootView:AnyView(EmptyView()))
+        let delegate = SheetDismisserProtocol()
+        delegate.host = host
         if(ownContact == nil) {
-            host.rootView = AnyView(UIKitWorkaround(OmemoKeys(contact: nil)))
+            host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:OmemoKeys(contact: nil)))
         } else {
-            host.rootView = AnyView(UIKitWorkaround(OmemoKeys(contact: ObservableKVOWrapper<MLContact>(ownContact!))))
+            host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:OmemoKeys(contact: ObservableKVOWrapper<MLContact>(ownContact!))))
         }
         return host
     }


### PR DESCRIPTION
Note: this only needs to be applied on the beta / stable branches, as the bug doesn't happen on alpha:

UIKitWorkaround switched to using (the iOS16+) NavigationStack on the develop branch, and that works correctly.

Screenshot of OmemoKeys view on beta / stable after applying this commit:
![OmemoKeys view on iPad after applying this commit](https://github.com/user-attachments/assets/fc62a1a4-713e-4667-9423-bcf504513059)

Caveat: the back button of the Omemo Keys view will close the entire Settings view.