### PR TITLE
Own OmemoKeys view: use AddTopLevelNavigation only for iPads

### DIFF
--- a/Monal/Classes/MLDelayableTimer.m
+++ b/Monal/Classes/MLDelayableTimer.m
@@ -122,8 +122,8 @@
         DDLogDebug(@"Canceling timer: %@", self);
         [self invalidate];
         [self scheduleBlockInRunLoop:^{
-            if(_cancelHandler != nil)
-                _cancelHandler(self);
+            if(self->_cancelHandler != nil)
+                self->_cancelHandler(self);
         }];
     }
 }

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -19,7 +19,7 @@ import FLAnimatedImage
 import OrderedCollections
 import CropViewController
 
-extension MLContact : Identifiable {}       //make MLContact be usable in swiftui ForEach clauses
+extension MLContact : @retroactive Identifiable {}       //make MLContact be usable in swiftui ForEach clauses
 
 let monalGreen = Color(UIColor(red:128.0/255, green:203.0/255, blue:182.0/255, alpha:1.0));
 let monalDarkGreen = Color(UIColor(red:20.0/255, green:138.0/255, blue:103.0/255, alpha:1.0));

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -657,10 +657,20 @@ class SwiftuiInterface : NSObject {
         let host = UIHostingController(rootView:AnyView(EmptyView()))
         let delegate = SheetDismisserProtocol()
         delegate.host = host
-        if(ownContact == nil) {
-            host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:OmemoKeys(contact: nil)))
+
+        @ViewBuilder
+        var omemoKeysView: some View {
+            if(ownContact == nil) {
+                OmemoKeys(contact: nil)
+            } else {
+                OmemoKeys(contact: ObservableKVOWrapper<MLContact>(ownContact!))
+            }
+        }
+        if (UIDevice.current.userInterfaceIdiom == .phone) || ProcessInfo().isMacCatalystApp {
+            host.rootView = AnyView(UIKitWorkaround(omemoKeysView))
         } else {
-            host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:OmemoKeys(contact: ObservableKVOWrapper<MLContact>(ownContact!))))
+            // The app is running on an iPad
+            host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:omemoKeysView))
         }
         return host
     }


### PR DESCRIPTION
In #1405, I forgot to test the commit on iPhone / Mac.
That change resulted in two navigation bars being displayed on iPhone / Mac.
Thus, this commit confines that change to iPads. (feel free to squash this commit with  #1405 if you want)

This PR was tested on iPhone and iPad simulators, as well as on Mac.
Screenshots:
<img src="https://github.com/user-attachments/assets/d1010c23-ea9a-476a-8f6b-6735fdf20e8f" width="270" height="480">
![Simulator Screenshot - iPad ](https://github.com/user-attachments/assets/bba2af50-5872-489c-8759-49e4a71da084)
<img width="1024" alt="Mac Screenshot" src="https://github.com/user-attachments/assets/a43fa006-2141-4916-844d-abd4bd58457c" />
