### PR TITLE
Detect device migrations more reliably

### DIFF
--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -969,10 +969,8 @@
         if(![[HelperTools defaultsDB] boolForKey:@"isSandboxAPNS"])
         {
             NSString* stored_id = (NSString*)[db executeScalar:@"SELECT value FROM flags WHERE name='device_id';"];
-            NSString* current_id = UIDevice.currentDevice.identifierForVendor.UUIDString;
-            if(current_id == nil)
-                DDLogWarn(@"Deviceid is nil, not checking for deviceid change");
-            else if(![current_id isEqualToString:stored_id])
+            NSString* current_id = [[HelperTools deviceUUID] UUIDString];
+            if(![current_id isEqualToString:stored_id])
             {
                 DDLogWarn(@"Device id has changed (%@ --> %@), invalidating state AND omemo identity keys!", stored_id, current_id);
                 //invalidate account state because the app was migrated to a new device
@@ -989,10 +987,10 @@
                 [db executeNonQuery:@"DELETE FROM signalPreKey;"];
                 [db executeNonQuery:@"DELETE FROM signalSignedPreKey;"];
                 //update device id in db
-                [db executeNonQuery:@"UPDATE flags SET value=? WHERE name='device_id';" andArguments:@[UIDevice.currentDevice.identifierForVendor.UUIDString]];
+                [db executeNonQuery:@"UPDATE flags SET value=? WHERE name='device_id';" andArguments:@[current_id]];
             }
         }
-        
+
         //turn foreign keys on again
         //needed for sqlite >= 3.26.0 (see https://sqlite.org/lang_altertable.html point 2)
         [db executeNonQuery:@"PRAGMA legacy_alter_table=off;"];

--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -179,6 +179,7 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSString*) generateDateTimeString:(NSDate*) datetime;
 +(NSString*) generateRandomPassword;
 +(NSString*) encodeRandomResource;
++(NSUUID*) deviceUUID;
 
 +(NSData* _Nullable) sha1:(NSData* _Nullable) data;
 +(NSString* _Nullable) stringSha1:(NSString* _Nullable) data;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -65,6 +65,7 @@ extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 @import CoreImage.CIFilterBuiltins;
 @import UIKit;
 @import AVFoundation;
+@import SAMKeychain;
 @import UniformTypeIdentifiers;
 @import QuickLookThumbnailing;
 
@@ -676,8 +677,8 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
 +(NSDictionary<NSString*, NSString*>*) getInvalidPushServers
 {
     return @{
-        @"ios13push.monal.im": nilWrapper([[[UIDevice currentDevice] identifierForVendor] UUIDString]),
-        @"push.monal.im": nilWrapper([[[UIDevice currentDevice] identifierForVendor] UUIDString]),
+        @"ios13push.monal.im": nilWrapper([[HelperTools deviceUUID] UUIDString]),
+        @"push.monal.im": nilWrapper([[HelperTools deviceUUID] UUIDString]),
         @"us.prod.push.monal-im.org": nilWrapper(nil),
     };
 }
@@ -2788,6 +2789,29 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
             return _versionInfoCache[@(type)] = [NSString stringWithFormat:@"Version %@, %@ on iOS/macOS %@", rawVersionString, [[NSBundle mainBundle] objectForInfoDictionaryKey:@"CFBundleIdentifier"], [UIDevice currentDevice].systemVersion];
         unreachable(@"unknown version type!");
     }
+}
+
+// Similar to UIDevice.currentDevice.identifierForVendor, but provides stable IDs
+// Fixes issue #1401
++(NSUUID*) deviceUUID
+{
+    NSError* error;
+    NSString* deviceUUID = [SAMKeychain passwordForService:kMonalDeviceUUIDKeychainName account:kDeviceUUIDKeychainAccount error:&error];
+    if(error)
+    {
+        //The keychain is empty (due to a device migration for example)
+        NSUUID* newDeviceUUID = nilDefault([[UIDevice currentDevice] identifierForVendor], [NSUUID UUID]);
+        //Save the new device UUID in the special keychain, which uses a `ThisDeviceOnly` accessibility.
+        //This accessibility ensures we can't migrate this keychain to another device
+        NSError* deviceUUIDSavingError;
+        [SAMKeychain setAccessibilityType:kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly];
+        [SAMKeychain setPassword:[newDeviceUUID UUIDString] forService:kMonalDeviceUUIDKeychainName account:kDeviceUUIDKeychainAccount error:&deviceUUIDSavingError];
+        if(deviceUUIDSavingError)
+            DDLogError(@"Failed to save the device UUID in the keychain, error: %@", deviceUUIDSavingError);
+        return newDeviceUUID;
+    }
+    else
+        return [[NSUUID alloc] initWithUUIDString:deviceUUID];
 }
 
 +(NSNumber*) currentTimestampInSeconds

--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -47,6 +47,8 @@ static const DDLogLevel ddLogLevel = LOG_LEVEL_STDOUT;
 
 #define kMonalKeychainName @"Monal"
 #define kMonalTmpKeychainName @"Monal.tmp"
+#define kMonalDeviceUUIDKeychainName @"Monal.deviceUUID"
+#define kDeviceUUIDKeychainAccount @"deviceUUIDKeychainAccount"
 
 //this is in seconds
 #if TARGET_OS_MACCATALYST

--- a/Monal/Classes/Quicksy_RegisterAccount.swift
+++ b/Monal/Classes/Quicksy_RegisterAccount.swift
@@ -13,7 +13,7 @@ func sendSMSRequest(to number:String) -> Promise<(data: Data, response: URLRespo
     var rq = URLRequest(url: URL(string: "\(QUICKSY_BASE_URL)/authentication/\(number)")!)
     rq.httpMethod = "GET"
     rq.addValue(Locale.current.language.languageCode?.identifier ?? DEFAULT_REGION_CODE, forHTTPHeaderField: "Accept-Language")
-    rq.addValue(UIDevice.current.identifierForVendor?.uuidString.lowercased() ?? UUID().uuidString.lowercased(), forHTTPHeaderField: "Installation-Id")
+    rq.addValue(HelperTools.deviceUUID().uuidString.lowercased(), forHTTPHeaderField: "Installation-Id")
     rq.addValue("Quicksy-iOS/\(Bundle.main.infoDictionary!["CFBundleShortVersionString"]!)", forHTTPHeaderField: "User-Agent")
     DDLogDebug("Request: \(String(describing:rq))")
     if let headers = rq.allHTTPHeaderFields {

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -3090,7 +3090,7 @@ NSString* const kStanza = @"stanza";
                         andChildren:@[
                             [[MLXMLNode alloc] initWithElement:@"initial-response" andData:[HelperTools encodeBase64WithString:[self->_scramHandler clientFirstMessageWithChannelBinding:[self channelBindingToUse]]]],
                             [[MLXMLNode alloc] initWithElement:@"user-agent" withAttributes:@{
-                                @"id":[[[UIDevice currentDevice] identifierForVendor] UUIDString],
+                                @"id":[[HelperTools deviceUUID] UUIDString],
                             } andChildren:@[
                                 [[MLXMLNode alloc] initWithElement:@"software" andData:@"Monal IM"],
                                 [[MLXMLNode alloc] initWithElement:@"device" andData:[[UIDevice currentDevice] name]],


### PR DESCRIPTION
I tested that this prevents generating new Omemo keys on reboot on macOS.
But I didn't test if the Omemo keys would be regenerated when an actual device migration happens.
Fixes #1401