### PR TITLE
Own OmemoKeys view: Display the navigation bar on large iphones in landscape mode

### DIFF
--- a/Monal/Classes/ActiveChatsViewController.h
+++ b/Monal/Classes/ActiveChatsViewController.h
@@ -18,6 +18,10 @@ NS_ASSUME_NONNULL_BEGIN
 @class chatViewController;
 @class MLCall;
 
+@interface SizeClassWrapper: NSObject
+@property (atomic) UIUserInterfaceSizeClass horizontal;
+@end
+
 @interface ActiveChatsViewController : UITableViewController  <DZNEmptyDataSetSource, DZNEmptyDataSetDelegate>
 
 @property (nonatomic, strong) UITableView* chatListTable;
@@ -26,6 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, weak) IBOutlet UIBarButtonItem* composeButton;
 @property (nonatomic, strong) UIActivityIndicatorView* spinner;
 @property (atomic, readonly) chatViewController* _Nullable currentChatView;
+@property (atomic, strong) SizeClassWrapper* sizeClass;
 
 -(void) showCallContactNotFoundAlert:(NSString*) jid;
 -(void) callContact:(MLContact*) contact withUIKitSender:(_Nullable id) sender;
@@ -52,6 +57,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) segueToIntroScreensIfNeeded;
 -(void) resetViewQueue;
 -(void) dismissCompleteViewChainWithAnimation:(BOOL) animation andCompletion:(monal_void_block_t _Nullable) completion;
+-(void) updateSizeClass;
 
 @end
 

--- a/Monal/Classes/ActiveChatsViewController.m
+++ b/Monal/Classes/ActiveChatsViewController.m
@@ -62,6 +62,9 @@ typedef void (^view_queue_block_t)(PMKResolver _Nonnull);
 @property (atomic, strong) NSMutableArray* pinnedContacts;
 @end
 
+@implementation SizeClassWrapper
+@end
+
 @implementation ActiveChatsViewController
 
 enum activeChatsControllerSections {
@@ -282,6 +285,9 @@ static NSMutableSet* _pushWarningDisplayed;
     
     self.view = self.chatListTable;
     
+    self.sizeClass = [SizeClassWrapper new];
+    [self updateSizeClass];
+
     NSNotificationCenter* nc = [NSNotificationCenter defaultCenter];
     [nc addObserver:self selector:@selector(handleRefreshDisplayNotification:) name:kMonalRefresh object:nil];
     [nc addObserver:self selector:@selector(handleContactRemoved:) name:kMonalContactRemoved object:nil];
@@ -1118,6 +1124,10 @@ static NSMutableSet* _pushWarningDisplayed;
             [self presentChatWithContact:selectedContact];
         };
     }
+}
+
+-(void) updateSizeClass {
+    self.sizeClass.horizontal = self.view.traitCollection.horizontalSizeClass;
 }
 
 -(NSMutableArray*) getChatArrayForSection:(size_t) section

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -616,6 +616,11 @@ public extension UIViewController {
 // Interfaces between ObjectiveC/Storyboards and SwiftUI
 @objc
 class SwiftuiInterface : NSObject {
+    @StateObject private var sizeClass: ObservableKVOWrapper<SizeClassWrapper>
+    override init() {
+        let activeChats = (UIApplication.shared.delegate as! MonalAppDelegate).activeChats!
+        self._sizeClass = StateObject(wrappedValue: ObservableKVOWrapper<SizeClassWrapper>(activeChats.sizeClass))
+    }
     @objc(makeAccountPickerForContacts:andCallType:)
     func makeAccountPicker(for contacts: [MLContact], and callType: UInt) -> UIViewController {
         let delegate = SheetDismisserProtocol()
@@ -666,10 +671,11 @@ class SwiftuiInterface : NSObject {
                 OmemoKeys(contact: ObservableKVOWrapper<MLContact>(ownContact!))
             }
         }
-        if (UIDevice.current.userInterfaceIdiom == .phone) || ProcessInfo().isMacCatalystApp {
+        let isCompact = UIUserInterfaceSizeClass(rawValue: sizeClass.horizontal) == .compact
+        if isCompact || ProcessInfo().isMacCatalystApp {
             host.rootView = AnyView(UIKitWorkaround(omemoKeysView))
         } else {
-            // The app is running on an iPad
+            // The app is running on an iPad or a big iPhone in landscape mode
             host.rootView = AnyView(AddTopLevelNavigation(withDelegate:delegate, to:omemoKeysView))
         }
         return host


### PR DESCRIPTION
This only works if the screen orientation is the same as the one the _app_ was launched with.
In order for it take into consideration a different screen orientation, the app needs to be closed from the recent apps switcher, and re-opened with the desired screen orientation.