### PR TITLE
Active chats order and timestamp fixes

### DIFF
--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -1924,8 +1924,8 @@ static NSDateFormatter* dbFormatter;
         //add contact if possible (ignore already existing contacts)
         [self addContact:buddyname forAccount:accountID nickname:nil];
 
-        // insert or update active chat
-        NSString* query = @"INSERT INTO activechats (buddy_name, account_id, lastMessageTime) VALUES(?, ?, current_timestamp) ON CONFLICT(buddy_name, account_id) DO UPDATE SET lastMessageTime=current_timestamp;";
+        // insert active chat (do nothing if it's already there)
+        NSString* query = @"INSERT INTO activechats (buddy_name, account_id, lastMessageTime) VALUES(?, ?, current_timestamp) ON CONFLICT(buddy_name, account_id) DO NOTHING;";
         [self.db executeNonQuery:query andArguments:@[buddyname, accountID]];
     }];
     return;

--- a/Monal/Classes/MLContactCell.m
+++ b/Monal/Classes/MLContactCell.m
@@ -109,7 +109,10 @@
             self.time.hidden = YES;
     }
     else
+    {
         [self showStatusText:nil inboundDir:NO fromUser:nil];
+        self.time.hidden = YES;
+    }
 }
 
 -(void) showStatusText:(NSString *) text inboundDir:(BOOL) inboundDir fromUser:(NSString* _Nullable) fromUser


### PR DESCRIPTION
Don't place a chat at the top of the active chats list when accessing it. (#961)

Also, fix another bug that led to entries in ActiveChats that have no messages to display timestamps (which were randomly assigned when clicking other entries in the list).