### PR TITLE
Update opensource.html

### DIFF
--- a/Monal/opensource.html
+++ b/Monal/opensource.html
@@ -36,7 +36,14 @@
         Parts of the WebRTC Demo by Stasel<br><br>
         <a href="https://github.com/stasel/WebRTC-iOS">https://github.com/stasel/WebRTC-iOS</a><br>
         <a href="https://github.com/stasel/WebRTC-iOS/blob/main/WebRTC-Demo-App/Sources/Services/WebRTCClient.swift">https://github.com/stasel/WebRTC-iOS/blob/main/WebRTC-Demo-App/Sources/Services/WebRTCClient.swift</a><br>
-        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION<br>
+        <br>
+        <details>
+        <summary>
+           Apache License<br>
+           Version 2.0, January 2004<br>
+        </summary>
+           <a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a><br><br>
+                         TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION<br>
             Definitions.<br>
             <br>
             "License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.<br>
@@ -98,19 +105,29 @@
         same "printed page" as the copyright notice for easier
         identification within third-party archives.<br>
         <br>
+        </details>
+<br>
+        <details>
+        <summary>
         Copyright 2018 Stasel<br>
+        </summary>
         <br>
-        Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <http://www.apache.org/licenses/LICENSE-2.0><br>
+        Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the License. You may obtain a copy of the License at <a href="http://www.apache.org/licenses/LICENSE-2.0">http://www.apache.org/licenses/LICENSE-2.0</a><br>
         <br>
         Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the specific language governing permissions and limitations under the License.<br><br>
+        </details>
         
         <hr>
         SVGView: SVG parser and renderer written in SwiftUI<br>
         <a href="https://github.com/exyte/SVGView">https://github.com/exyte/SVGView</a><br>
+        <br>
+        <details>
+        <summary>
         MIT License<br>
         <br>
         Copyright (c) 2020 exyte &lt;info@exyte.com&gt;<br>
         <br>
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
@@ -129,14 +146,145 @@
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
         SOFTWARE.<br>
         <br>
-        
+        </details>
+
+        <hr>
+        ExyteChat: A SwiftUI Chat UI framework with fully customizable message cells and a built-in media picker<br>
+        <a href="https://github.com/monal-im/ExyteChat">https://github.com/monal-im/ExyteChat</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2019 exyte &lt;info@exyte.com&gt;<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
+        <!--DEPENDENCY-->
+        MediaPicker: Customizable media picker written with SwiftUI<br>
+        <a href="https://github.com/monal-im/MediaPicker">https://github.com/monal-im/MediaPicker</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2019 exyte &lt;info@exyte.com&gt;<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
+        <!--DEPENDENCY-->
+        ActivityIndicatorView: A number of preset loading indicators created with SwiftUI<br>
+        <a href="https://github.com/exyte/ActivityIndicatorView">https://github.com/exyte/ActivityIndicatorView</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2020 exyte &lt;info@exyte.com&gt;<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
+        FLAnimatedImage: Performant animated GIF engine for iOS<br>
+        <a href="https://github.com/Flipboard/FLAnimatedImage">https://github.com/Flipboard/FLAnimatedImage</a><br>
+        <br>
+        <details>
+        <summary>
+        The MIT License (MIT)<br>
+        <br>
+        Copyright (c) 2014-2016 Flipboard<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
         <hr>
         FrameUP: Reframing SwiftUI Views. A collection of tools to help with layout.<br>
         <a href="https://github.com/ryanlintott/FrameUp">https://github.com/ryanlintott/FrameUp</a><br>
+        <br>
+        <details>
+        <summary>
         MIT License<br>
         <br>
         Copyright (c) 2022 Ryan Lintott<br>
         <br>
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
@@ -155,14 +303,112 @@
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
         SOFTWARE.<br>
         <br>
-        
+        </details>
+
+        <hr>
+        ViewExtractor: Extract SwiftUI views from ViewBuilder content.<br>
+        <a href="https://github.com/GeorgeElsham/ViewExtractor">https://github.com/GeorgeElsham/ViewExtractor</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2021 George Elsham<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
+        ASN1Decoder: ASN1 DER Decoder for X.509 Certificate<br>
+        <a href="https://github.com/filom/ASN1Decoder">https://github.com/filom/ASN1Decoder</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2017 Filippo<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
+        KSCrash: The Ultimate iOS Crash Reporter<br>
+        <a href="https://github.com/kstenerud/KSCrash">https://github.com/kstenerud/KSCrash</a><br>
+        <br>
+        <details>
+        <summary>
+        MIT License<br>
+        <br>
+        Copyright (c) 2012 Karl Stenerud<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
         <hr>
         PromiseKit: Promises for Swift &amp; ObjC.<br>
         <a href="https://github.com/mxcl/PromiseKit">https://github.com/mxcl/PromiseKit</a><br>
+        <br>
+        <details>
+        <summary>
         MIT License<br>
         <br>
         Copyright 2016-present, Max Howell; mxcl@me.com<br>
         <br>
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
@@ -181,6 +427,7 @@
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
         SOFTWARE.<br>
         <br>
+        </details>
         
         <hr>
         HSLuv-C: Human-friendly HSL<br><br>
@@ -190,6 +437,10 @@
         Copyright (c) 2015 Roger Tallada (Obj-C implementation)<br>
         Copyright (c) 2017 Martin Mitas (C implementation, based on Obj-C implementation)<br><br>
 
+        <details>
+        <summary>
+        MIT License<br><br>
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a
         copy of this software and associated documentation files (the "Software"),
         to deal in the Software without restriction, including without limitation
@@ -207,6 +458,7 @@
         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
         FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
         IN THE SOFTWARE.<br><br>
+        </details>
         
         <hr>
         Macros for metaprogramming<br>
@@ -214,10 +466,14 @@
 
         Copyright (C) 2012 Justin Spahr-Summers<br>
         Released under the MIT license<br><br>
+
         <hr>
         MBProgressHud<br><br>
+        <details>
+        <summary>
+        MIT License<br><br>
         Copyright © 2009-2020 Matej Bukovinski<br><br>
-        
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
@@ -235,10 +491,15 @@
         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         THE SOFTWARE.<br><br>
+        </details>
+
         <hr>
         NotificationBanner<br><br>
+        <details>
+        <summary>
+        MIT License<br><br>
         Copyright (c) 2017-2018 Daltron <daltonhint4@gmail.com><br><br>
-        
+        </summary>
             Permission is hereby granted, free of charge, to any person obtaining a copy
             of this software and associated documentation files (the "Software"), to deal
             in the Software without restriction, including without limitation the rights
@@ -256,13 +517,17 @@
             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
             THE SOFTWARE.<br><br>
+        </details>
+
         <hr>
         CocoaLumberjack<br><br>
+        <details>
+        <summary>
         BSD 3-Clause License<br><br>
 
         Copyright (c) 2010-2020, Deusty, LLC
         All rights reserved.<br><br>
-
+        </summary>
             Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:<br><br>
 
             1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.<br><br>
@@ -272,30 +537,242 @@
             3. Neither the name of Deusty nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission of Deusty, LLC.<br><br>
 
             THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.<br><br>
-        <hr>      
-        <!—DEPENDENCY—><br><br>
-        EARestrictedScrollView<br><br>
-        Copyright (c) 2015-2019 Evgeny Aleksandrov evgeny@aleksandrov.ws<br><br>
+        </details>
 
-            Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:<br><br>
-
-            The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.<br><br>
-
-            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.<br><br>
         <hr>
-        <!—DEPENDENCY—><br><br>
+        <!--DEPENDENCY-->
+        swift-log: A Logging API for Swift<br>
+        <a href="https://github.com/apple/swift-log">https://github.com/apple/swift-log</a><br><br>
+        <details>
+        <summary>
+           Apache License<br><br>
+           Version 2.0, January 2004<br><br>
+        </summary>
+            <a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a><br>
+        <br>
+        TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION<br>
+        <br>
+        1. Definitions.<br>
+        <br>
+          "License" shall mean the terms and conditions for use, reproduction,<br>
+          and distribution as defined by Sections 1 through 9 of this document.<br>
+        <br>
+          "Licensor" shall mean the copyright owner or entity authorized by<br>
+          the copyright owner that is granting the License.<br>
+        <br>
+          "Legal Entity" shall mean the union of the acting entity and all<br>
+          other entities that control, are controlled by, or are under common<br>
+          control with that entity. For the purposes of this definition,<br>
+          "control" means (i) the power, direct or indirect, to cause the<br>
+          direction or management of such entity, whether by contract or<br>
+          otherwise, or (ii) ownership of fifty percent (50%) or more of the<br>
+          outstanding shares, or (iii) beneficial ownership of such entity.<br>
+        <br>
+          "You" (or "Your") shall mean an individual or Legal Entity<br>
+          exercising permissions granted by this License.<br>
+        <br>
+          "Source" form shall mean the preferred form for making modifications,<br>
+          including but not limited to software source code, documentation<br>
+          source, and configuration files.<br>
+        <br>
+          "Object" form shall mean any form resulting from mechanical<br>
+          transformation or translation of a Source form, including but<br>
+          not limited to compiled object code, generated documentation,<br>
+          and conversions to other media types.<br>
+        <br>
+          "Work" shall mean the work of authorship, whether in Source or<br>
+          Object form, made available under the License, as indicated by a<br>
+          copyright notice that is included in or attached to the work<br>
+          (an example is provided in the Appendix below).<br>
+        <br>
+          "Derivative Works" shall mean any work, whether in Source or Object<br>
+          form, that is based on (or derived from) the Work and for which the<br>
+          editorial revisions, annotations, elaborations, or other modifications<br>
+          represent, as a whole, an original work of authorship. For the purposes<br>
+          of this License, Derivative Works shall not include works that remain<br>
+          separable from, or merely link (or bind by name) to the interfaces of,<br>
+          the Work and Derivative Works thereof.<br>
+        <br>
+          "Contribution" shall mean any work of authorship, including<br>
+          the original version of the Work and any modifications or additions<br>
+          to that Work or Derivative Works thereof, that is intentionally<br>
+          submitted to Licensor for inclusion in the Work by the copyright owner<br>
+          or by an individual or Legal Entity authorized to submit on behalf of<br>
+          the copyright owner. For the purposes of this definition, "submitted"<br>
+          means any form of electronic, verbal, or written communication sent<br>
+          to the Licensor or its representatives, including but not limited to<br>
+          communication on electronic mailing lists, source code control systems,<br>
+          and issue tracking systems that are managed by, or on behalf of, the<br>
+          Licensor for the purpose of discussing and improving the Work, but<br>
+          excluding communication that is conspicuously marked or otherwise<br>
+          designated in writing by the copyright owner as "Not a Contribution."<br>
+        <br>
+          "Contributor" shall mean Licensor and any individual or Legal Entity<br>
+          on behalf of whom a Contribution has been received by Licensor and<br>
+          subsequently incorporated within the Work.<br>
+        <br>
+        2. Grant of Copyright License. Subject to the terms and conditions of<br>
+          this License, each Contributor hereby grants to You a perpetual,<br>
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable<br>
+          copyright license to reproduce, prepare Derivative Works of,<br>
+          publicly display, publicly perform, sublicense, and distribute the<br>
+          Work and such Derivative Works in Source or Object form.<br>
+        <br>
+        3. Grant of Patent License. Subject to the terms and conditions of<br>
+          this License, each Contributor hereby grants to You a perpetual,<br>
+          worldwide, non-exclusive, no-charge, royalty-free, irrevocable<br>
+          (except as stated in this section) patent license to make, have made,<br>
+          use, offer to sell, sell, import, and otherwise transfer the Work,<br>
+          where such license applies only to those patent claims licensable<br>
+          by such Contributor that are necessarily infringed by their<br>
+          Contribution(s) alone or by combination of their Contribution(s)<br>
+          with the Work to which such Contribution(s) was submitted. If You<br>
+          institute patent litigation against any entity (including a<br>
+          cross-claim or counterclaim in a lawsuit) alleging that the Work<br>
+          or a Contribution incorporated within the Work constitutes direct<br>
+          or contributory patent infringement, then any patent licenses<br>
+          granted to You under this License for that Work shall terminate<br>
+          as of the date such litigation is filed.<br>
+        <br>
+        4. Redistribution. You may reproduce and distribute copies of the<br>
+          Work or Derivative Works thereof in any medium, with or without<br>
+          modifications, and in Source or Object form, provided that You<br>
+          meet the following conditions:<br>
+        <br>
+          (a) You must give any other recipients of the Work or<br>
+              Derivative Works a copy of this License; and<br>
+        <br>
+          (b) You must cause any modified files to carry prominent notices<br>
+              stating that You changed the files; and<br>
+        <br>
+          (c) You must retain, in the Source form of any Derivative Works<br>
+              that You distribute, all copyright, patent, trademark, and<br>
+              attribution notices from the Source form of the Work,<br>
+              excluding those notices that do not pertain to any part of<br>
+              the Derivative Works; and<br>
+        <br>
+          (d) If the Work includes a "NOTICE" text file as part of its<br>
+              distribution, then any Derivative Works that You distribute must<br>
+              include a readable copy of the attribution notices contained<br>
+              within such NOTICE file, excluding those notices that do not<br>
+              pertain to any part of the Derivative Works, in at least one<br>
+              of the following places: within a NOTICE text file distributed<br>
+              as part of the Derivative Works; within the Source form or<br>
+              documentation, if provided along with the Derivative Works; or,<br>
+              within a display generated by the Derivative Works, if and<br>
+              wherever such third-party notices normally appear. The contents<br>
+              of the NOTICE file are for informational purposes only and<br>
+              do not modify the License. You may add Your own attribution<br>
+              notices within Derivative Works that You distribute, alongside<br>
+              or as an addendum to the NOTICE text from the Work, provided<br>
+              that such additional attribution notices cannot be construed<br>
+              as modifying the License.<br>
+        <br>
+          You may add Your own copyright statement to Your modifications and<br>
+          may provide additional or different license terms and conditions<br>
+          for use, reproduction, or distribution of Your modifications, or<br>
+          for any such Derivative Works as a whole, provided Your use,<br>
+          reproduction, and distribution of the Work otherwise complies with<br>
+          the conditions stated in this License.<br>
+        <br>
+        5. Submission of Contributions. Unless You explicitly state otherwise,<br>
+          any Contribution intentionally submitted for inclusion in the Work<br>
+          by You to the Licensor shall be under the terms and conditions of<br>
+          this License, without any additional terms or conditions.<br>
+          Notwithstanding the above, nothing herein shall supersede or modify<br>
+          the terms of any separate license agreement you may have executed<br>
+          with Licensor regarding such Contributions.<br>
+        <br>
+        6. Trademarks. This License does not grant permission to use the trade<br>
+          names, trademarks, service marks, or product names of the Licensor,<br>
+          except as required for reasonable and customary use in describing the<br>
+          origin of the Work and reproducing the content of the NOTICE file.<br>
+        <br>
+        7. Disclaimer of Warranty. Unless required by applicable law or<br>
+          agreed to in writing, Licensor provides the Work (and each<br>
+          Contributor provides its Contributions) on an "AS IS" BASIS,<br>
+          WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or<br>
+          implied, including, without limitation, any warranties or conditions<br>
+          of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A<br>
+          PARTICULAR PURPOSE. You are solely responsible for determining the<br>
+          appropriateness of using or redistributing the Work and assume any<br>
+          risks associated with Your exercise of permissions under this License.<br>
+        <br>
+        8. Limitation of Liability. In no event and under no legal theory,<br>
+          whether in tort (including negligence), contract, or otherwise,<br>
+          unless required by applicable law (such as deliberate and grossly<br>
+          negligent acts) or agreed to in writing, shall any Contributor be<br>
+          liable to You for damages, including any direct, indirect, special,<br>
+          incidental, or consequential damages of any character arising as a<br>
+          result of this License or out of the use or inability to use the<br>
+          Work (including but not limited to damages for loss of goodwill,<br>
+          work stoppage, computer failure or malfunction, or any and all<br>
+          other commercial damages or losses), even if such Contributor<br>
+          has been advised of the possibility of such damages.<br>
+        <br>
+        9. Accepting Warranty or Additional Liability. While redistributing<br>
+          the Work or Derivative Works thereof, You may choose to offer,<br>
+          and charge a fee for, acceptance of support, warranty, indemnity,<br>
+          or other liability obligations and/or rights consistent with this<br>
+          License. However, in accepting such obligations, You may act only<br>
+          on Your own behalf and on Your sole responsibility, not on behalf<br>
+          of any other Contributor, and only if You agree to indemnify,<br>
+          defend, and hold each Contributor harmless for any liability<br>
+          incurred by, or claims asserted against, such Contributor by reason<br>
+          of your accepting any such warranty or additional liability.<br>
+        <br>
+        END OF TERMS AND CONDITIONS<br>
+        <br>
+        APPENDIX: How to apply the Apache License to your work.<br>
+        <br>
+          To apply the Apache License to your work, attach the following<br>
+          boilerplate notice, with the fields enclosed by brackets "[]"<br>
+          replaced with your own identifying information. (Don't include<br>
+          the brackets!)  The text should be enclosed in the appropriate<br>
+          comment syntax for the file format. We also recommend that a<br>
+          file or class name and description of purpose be included on the<br>
+          same "printed page" as the copyright notice for easier<br>
+          identification within third-party archives.<br>
+        <br>
+        Copyright [yyyy] [name of copyright owner]<br>
+        <br>
+        Licensed under the Apache License, Version 2.0 (the "License");<br>
+        you may not use this file except in compliance with the License.<br>
+        You may obtain a copy of the License at<br>
+        <br>
+           http://www.apache.org/licenses/LICENSE-2.0<br>
+        <br>
+        Unless required by applicable law or agreed to in writing, software<br>
+        distributed under the License is distributed on an "AS IS" BASIS,<br>
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.<br>
+        See the License for the specific language governing permissions and<br>
+        limitations under the License.<br>
+        <br>
+        </details>
+
+        <hr>
+        <!--DEPENDENCY-->
         MarqueeLabel<br><br>
+        <details>
+        <summary>
+        MIT License<br><br>
         Copyright (c) 2011-2017 Charles Powell<br><br>
-
+        </summary>
             Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:<br><br>
 
             The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.<br><br>
 
             THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.<br><br>
-        <hr>
-        SnapKit<br><br>
-        Copyright (c) 2011-Present SnapKit Team - <a href="https://github.com/SnapKit">https://github.com/SnapKit</a><br><br>
+        </details>
 
+        <hr>
+        <!--DEPENDENCY-->
+        SnapKit<br><br>
+        <details>
+        <summary>
+        MIT License<br><br>
+        Copyright (c) 2011-Present SnapKit Team - <a href="https://github.com/SnapKit">https://github.com/SnapKit</a><br><br>
+        </summary>
             Permission is hereby granted, free of charge, to any person obtaining a copy
             of this software and associated documentation files (the "Software"), to deal
             in the Software without restriction, including without limitation the rights
@@ -313,19 +790,24 @@
             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
             THE SOFTWARE.<br><br>
+        </details>
         <hr>
+
         SDWebImage<br><br>
-        Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com
- 
+        <details>
+        <summary>
+        MIT License<br><br>
+        Copyright (c) 2009-2020 Olivier Poitrey rs@dailymotion.com<br><br>
+        </summary>
         Permission is hereby granted, free of charge, to any person obtaining a copy
         of this software and associated documentation files (the "Software"), to deal
         in the Software without restriction, including without limitation the rights
         to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
         copies of the Software, and to permit persons to whom the Software is furnished
-        to do so, subject to the following conditions:
+        to do so, subject to the following conditions:<br><br>
         
         The above copyright notice and this permission notice shall be included in all
-        copies or substantial portions of the Software.
+        copies or substantial portions of the Software.<br><br>
         
         THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
         IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
@@ -334,30 +816,15 @@
         LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
         OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
         THE SOFTWARE.<br><br>
+        </details>
+
         <hr>
-        PSTCollectionView<br><br>
-        Copyright (c) 2012-2013 Peter Steinberger <steipete@gmail.com><br><br>
-            
-            Permission is hereby granted, free of charge, to any person obtaining a copy
-            of this software and associated documentation files (the "Software"), to deal
-            in the Software without restriction, including without limitation the rights
-            to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-            copies of the Software, and to permit persons to whom the Software is furnished
-            to do so, subject to the following conditions:<br><br>
-            
-            The above copyright notice and this permission notice shall be included in all
-            copies or substantial portions of the Software.<br><br>
-            
-            THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-            IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-            FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-            AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-            LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-            OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-            THE SOFTWARE.<br><br>
-            <hr>
-            SAMKeychain<br><br>
-            Copyright (c) 2010-2016 Sam Soffes, http://soff.es<br><br>
+        SAMKeychain<br><br>
+        <details>
+        <summary>
+        MIT License<br><br>
+        Copyright (c) 2010-2016 Sam Soffes, http://soff.es<br><br>
+        </summary>
             
             Permission is hereby granted, free of charge, to any person obtaining
             a copy of this software and associated documentation files (the
@@ -377,21 +844,29 @@
             LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
             OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
             WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.<br><br>
-            <hr>
+        </details>
+
         <hr>
         DZNEmptyDataSet<br><br>
+        <details>
+        <summary>
+        The MIT License (MIT)<br><br>
         Copyright (c) 2016 Ignacio Romero Zurbuchen iromero@dzen.cl<br><br>
-
+        </summary>
             Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the 'Software'), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:<br><br>
 
             The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.<br><br>
 
             THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.<br><br>
+        </details>
+
         <hr>
         SignalProtocolObjC<br><br>
+        <details>
+        <summary>
         GNU GENERAL PUBLIC LICENSE<br><br>
         Version 3, 29 June 2007<br><br>
-
+        </summary>
             Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
             Everyone is permitted to copy and distribute verbatim copies
             of this license document, but changing it is not allowed.<br><br>
@@ -1063,11 +1538,14 @@
             the library.  If this is what you want to do, use the GNU Lesser General
             Public License instead of this License.  But first, please read
             <http://www.gnu.org/philosophy/why-not-lgpl.html>.<br><br>
+        </details>
         <hr>
         SignalProtocolC<br><br>
+        <details>
+        <summary>
         GNU GENERAL PUBLIC LICENSE<br><br>
         Version 3, 29 June 2007<br><br>
-
+        </summary>
             Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
             Everyone is permitted to copy and distribute verbatim copies
             of this license document, but changing it is not allowed.<br><br>
@@ -1739,12 +2217,15 @@
             the library.  If this is what you want to do, use the GNU Lesser General
             Public License instead of this License.  But first, please read
             <http://www.gnu.org/philosophy/why-not-lgpl.html>.<br><br>
+        </details>
+
         <hr>
             TOCropViewController<br><br>
+            <details>
+            <summary>
             The MIT License (MIT)<br><br>
-
             Copyright (c) 2015-2019 Tim Oliver<br><br>
-
+            </summary>
             Permission is hereby granted, free of charge, to any person obtaining a copy
             of this software and associated documentation files (the "Software"), to deal
             in the Software without restriction, including without limitation the rights
@@ -1762,8 +2243,14 @@
             LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
             OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
             SOFTWARE.<br><br>
+            </details>
+
         <hr>
             WebRTC<br><br>
+            <details>
+            <summary>
+            BSD 3-Clause License<br><br>
+            </summary>
             BSD 3-Clause License Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:<br><br>
 
             Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.<br><br>
@@ -1785,6 +2272,7 @@
             Neither the name of Google nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.<br><br>
 
             THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.<br><br>
+            </details>
         <hr>
     </body>
 </html>


### PR DESCRIPTION
Use the `<details>` HTML element to hide license texts by default.

Remove EARestrictedScrollView and PSTCollectionView, as they're no longer used.

Add the licenses and copyright notices of the following dependencies:
- ExyteChat (chat UI framework)
- MediaPicker (dependency of ExyteChat)
- ActivityIndicatorView (dependency of ExyteChat)
- KSCrash (crash reporter)
- ASN1Decoder (ASN1 DER Decoder for X.509 Certificate)
- FLAnimatedImagea (animated GIF engine)
- swift-log (dependency of CocoaLumberjack)
- ViewExtractor