### PR TITLE
Dynamically load more history when scrolling up

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -91,6 +91,7 @@ struct ChatView: View {
     @StateObject private var overlay = LoadingOverlayState()
     @State var messages: [ChatViewMessage] = []
     private var account: xmpp
+    @State private var isLoadingMamHistory = false
     
     init(contact: ObservableKVOWrapper<MLContact>) {
         _contact = StateObject(wrappedValue: contact)
@@ -194,7 +195,85 @@ struct ChatView: View {
         }
 #endif
     }
-    
+
+    private func findOldestStanzaId() -> String? {
+        //not all messages in history db have a stanzaId (messages sent by this monal instance won't have one for example)
+        //--> search for the oldest message having a stanzaId and use that one
+        for msg in self.messages {
+            if !msg.innerMessage.obj.stanzaId.isEmpty {
+                DDLogVerbose("Found oldest stanzaId in currently displayed messages: \(msg.innerMessage.obj.stanzaId)")
+                return msg.innerMessage.stanzaId
+            }
+        }
+
+        //history database for this contact is completely empty, use global last stanza id for this mam archive
+        if self.contact.isMuc {
+            return DataLayer.sharedInstance().lastStanzaId(forMuc:self.contact.contactJid, andAccount:self.account.accountID)
+        }
+        else {
+            return DataLayer.sharedInstance().lastStanzaId(forAccount:self.account.accountID);
+        }
+    }
+
+    private func loadHistory() {
+        guard !self.isLoadingMamHistory else {
+            DDLogDebug("Not going to load more history because a backscrolling mam query is ongoing for this chat")
+            // Don't allow concurrent backscrolling mam fetches.
+            // And don't allow loading history from the DB while an mam query is ongoing;
+            // this prevents potential message duplication: if a DB history fetch is triggered after the mam query
+            // has written some messages to the DB but before it has returned the results, those messages will be
+            // inserted twice in the ChatView.
+            return
+        }
+        var beforeId: NSNumber? = nil
+        if !messages.isEmpty {
+            beforeId = messages[0].innerMessage.messageDBId
+        }
+        let oldMessages: [ChatViewMessage] = (DataLayer.sharedInstance().messages(forContact:contact.contactJid, forAccount:contact.accountID, beforeMsgHistoryID:beforeId) as! [MLMessage]).map {ChatViewMessage($0)}
+        //insert what we got from the db
+        if !oldMessages.isEmpty {
+            messages.insert(contentsOf: oldMessages, at:0)
+        }
+
+        // if we didn't get enough (or any) messages from the DB, try to get some from MAM
+        if oldMessages.count < kMonalBackscrollingMsgCount && !contact.hasReachedMamArchiveTop {
+            self.isLoadingMamHistory = true
+
+            guard let oldestStanzaId = self.findOldestStanzaId() else {
+                DDLogError("Couldn't find a stanzaId to perform a mam query with! (oldestStanzaId is nil)")
+                return
+            }
+            // now try to load more (older) messages from mam
+            DDLogVerbose("Loading more messages from mam before stanzaId \(oldestStanzaId)")
+            firstly {
+                self.account.setMAMQueryMostRecentFor(self.contact.obj, before: oldestStanzaId)
+            }
+            .done { returnedMessages in
+                let returnedMessages = returnedMessages as! [MLMessage]
+                if returnedMessages.isEmpty {
+                    DDLogVerbose("Reached the top of the mam archive for \(self.contact.obj.contactJid)")
+                    // Don't block the main thread while writing to the db
+                    DispatchQueue.global(qos: .default).async {
+                        contact.obj.markReachedMamArchiveTop()
+                    }
+                } else {
+                    DDLogVerbose("Got backscrolling mam response: \(returnedMessages.count) messages")
+                    self.messages.insert(contentsOf: returnedMessages.map {ChatViewMessage($0)}, at: 0)
+                }
+            }
+            .catch { error in
+                alertPrompt = AlertPrompt(
+                    title: Text("Could not fetch messages"),
+                    message: Text(error.localizedDescription),
+                    dismissLabel: Text("Close")
+                )
+            }
+            .finally {
+                self.isLoadingMamHistory = false
+            }
+        }
+    }
+
     var body: some View {
         ExyteChatView(messages: messages, chatType: .conversation, replyMode: .quote) { draft in
             guard let newMLMessage = MLXMPPManager.sharedInstance().sendMessageAndAddToHistory(message: draft.text, havingType: kMessageTypeText, toContact: self.contact.obj, isEncrypted: self.contact.isEncrypted, uploadInfo: nil) else {
@@ -205,9 +284,11 @@ struct ChatView: View {
             MessageView(message: (message as! ChatViewMessage), viewModel: viewModel, positionInUserGroup: positionInUserGroup, positionInMessagesSection: positionInMessagesSection)
         }
         .showNetworkConnectionProblem(false)
-//         .enableLoadMore(pageSize: 3) { message in
-//             print("load more messages before: \(String(describing:message))")
-//         }
+        .enableLoadMore(pageSize: 10) { message in
+            await MainActor.run {
+                loadHistory()
+            }
+        }
 //         .messageUseMarkdown(messageUseMarkdown: true)
         .sheet(item: $selectedContactForContactDetails) { selectedContact in
             AnyView(AddTopLevelNavigation(withDelegate:nil, to:ContactDetails(delegate:nil, contact:selectedContact)))
@@ -270,6 +351,9 @@ struct ChatView: View {
             }
             
             ToolbarItemGroup(placement: .topBarTrailing) {
+                ProgressView()
+                    .opacity(isLoadingMamHistory ? 1 : 0)
+
                 if !(contact.isMuc || contact.isSelfChat) {
                     let activeChats = (UIApplication.shared.delegate as! MonalAppDelegate).activeChats!
                     let voipProcessor = (UIApplication.shared.delegate as! MonalAppDelegate).voipProcessor!
@@ -346,15 +430,7 @@ struct ChatView: View {
             MLNotificationManager.sharedInstance().currentContact = self.contact.obj
 
             checkOmemoSupport(withAlert:false)
-            
-            //TODO: load messages from db
-            // In some scenarios, onAppear can be executed more than once without the state variables being cleared.
-            if messages.isEmpty {
-                let dbMessages = DataLayer.sharedInstance().messages(forContact:contact.contactJid, forAccount:contact.accountID) as! [MLMessage]
-                for msg in dbMessages {
-                    messages.append(ChatViewMessage(msg))
-                }
-            }
+            loadHistory()
             ChatViewHelpers.refreshCounter(for: self.contact.obj)
 //             messages = [
 //                 ExyteChat.Message(

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -477,7 +477,7 @@ struct ChatView: View {
             }
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name(kMonalNewMessageNotice)).receive(on: RunLoop.main)) { notification in
-            DDLogVerbose("chat view got new message notice \(String(describing:notification.userInfo))")
+            DDLogVerbose("ChatView got new message notice \(String(describing:notification.userInfo))")
 
             guard let message = notification.userInfo?["message"] as? MLMessage else {
                 DDLogError("Notification without message");
@@ -492,6 +492,16 @@ struct ChatView: View {
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name(kMonalRefresh)).receive(on: RunLoop.main)) { notification in
             ChatViewHelpers.refreshCounter(for: self.contact.obj)
+        }
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name(kMonalContactHistoryCleared)).receive(on: RunLoop.main)) { notification in
+            DDLogVerbose("ChatView got history cleared notice \(String(describing:notification.userInfo))")
+            guard let contact = notification.userInfo?["contact"] as? MLContact else {
+                MLAssert(false, "Notification without contact")
+                return
+            }
+            if contact.isEqual(to: self.contact.obj) {
+                self.messages = []
+            }
         }
     }
 }

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -136,64 +136,64 @@ struct ChatView: View {
     
     private func checkOmemoSupport(withAlert showWarning: Bool) {
 #if !DISABLE_OMEMO
-    if DataLayer.sharedInstance().isAccountEnabled(contact.accountID) {
-        var omemoDeviceForContactFound = false
-        if !contact.isMuc {
-            omemoDeviceForContactFound = account.omemo.knownDevices(forAddressName:contact.contactJid).count > 0
-        } else {
-            omemoDeviceForContactFound = false
-            for participant in DataLayer.sharedInstance().getMembersAndParticipants(ofMuc:contact.contactJid, forAccountID:contact.accountID) {
-                if let participant_jid = participant["participant_jid"] as? String {
-                    omemoDeviceForContactFound = omemoDeviceForContactFound || account.omemo.knownDevices(forAddressName:participant_jid).count > 0
-                } else if let participant_jid = participant["member_jid"] as? String {
-                    omemoDeviceForContactFound = omemoDeviceForContactFound || account.omemo.knownDevices(forAddressName:participant_jid).count > 0
-                }
-                if omemoDeviceForContactFound {
-                    break
+        if DataLayer.sharedInstance().isAccountEnabled(contact.accountID) {
+            var omemoDeviceForContactFound = false
+            if !contact.isMuc {
+                omemoDeviceForContactFound = account.omemo.knownDevices(forAddressName:contact.contactJid).count > 0
+            } else {
+                omemoDeviceForContactFound = false
+                for participant in DataLayer.sharedInstance().getMembersAndParticipants(ofMuc:contact.contactJid, forAccountID:contact.accountID) {
+                    if let participant_jid = participant["participant_jid"] as? String {
+                        omemoDeviceForContactFound = omemoDeviceForContactFound || account.omemo.knownDevices(forAddressName:participant_jid).count > 0
+                    } else if let participant_jid = participant["member_jid"] as? String {
+                        omemoDeviceForContactFound = omemoDeviceForContactFound || account.omemo.knownDevices(forAddressName:participant_jid).count > 0
+                    }
+                    if omemoDeviceForContactFound {
+                        break
+                    }
                 }
             }
-        }
-        if !omemoDeviceForContactFound && contact.isEncrypted {
-            if HelperTools.isContactBlacklistedForEncryption(contact.obj) {
-                // this contact was blacklisted for encryption
-                // --> disable it
-                contact.isEncrypted = false
-                DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
-            } else if contact.isMuc && contact.mucType != kMucTypeGroup {
-                // a channel type muc has OMEMO encryption enabled, but channels don't support encryption
-                // --> disable it
-                contact.isEncrypted = false
-                DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
-            } else if !contact.isMuc || (contact.isMuc && contact.mucType == kMucTypeGroup) {
+            if !omemoDeviceForContactFound && contact.isEncrypted {
+                if HelperTools.isContactBlacklistedForEncryption(contact.obj) {
+                    // this contact was blacklisted for encryption
+                    // --> disable it
+                    contact.isEncrypted = false
+                    DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
+                } else if contact.isMuc && contact.mucType != kMucTypeGroup {
+                    // a channel type muc has OMEMO encryption enabled, but channels don't support encryption
+                    // --> disable it
+                    contact.isEncrypted = false
+                    DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
+                } else if !contact.isMuc || (contact.isMuc && contact.mucType == kMucTypeGroup) {
+                    hideLoadingOverlay(overlay)
+
+                    if showWarning {
+                        DDLogWarn("Showing omemo not supported alert for: \(self.contact)")
+                        alertPrompt = AlertPrompt(
+                            title: Text("No OMEMO keys found"),
+                            message: Text("This contact may not support OMEMO encrypted messages. Please try to enable encryption again in a few seconds, if you think this is wrong."),
+                            dismissLabel: Text("Disable Encryption")
+                        ) {
+                            contact.isEncrypted = false
+                            DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
+                        }
+                    } else {
+                        DDLogInfo("Trying to fetch omemo keys for: \(self.contact)")
+
+                        // we won't do this twice, because the user won't be able to change isEncrypted to YES,
+                        // unless we have omemo devices for that contact
+                        showPromisingLoadingOverlay(overlay, headlineView:Text("Loading OMEMO keys"), descriptionView:Text("")).done {
+                            // request omemo devicelist
+                            account.omemo.subscribeAndFetchDevicelistIfNoSessionExists(forJid:contact.contactJid)
+                        }
+                    }
+                }
+            } else {
                 hideLoadingOverlay(overlay)
-                
-                if showWarning {
-                    DDLogWarn("Showing omemo not supported alert for: \(self.contact)")
-                    alertPrompt = AlertPrompt(
-                        title: Text("No OMEMO keys found"),
-                        message: Text("This contact may not support OMEMO encrypted messages. Please try to enable encryption again in a few seconds, if you think this is wrong."),
-                        dismissLabel: Text("Disable Encryption")
-                    ) {
-                        contact.isEncrypted = false
-                        DataLayer.sharedInstance().disableEncrypt(forJid:contact.contactJid, andAccountID:contact.accountID)
-                    }
-                } else {
-                    DDLogInfo("Trying to fetch omemo keys for: \(self.contact)")
-                    
-                    // we won't do this twice, because the user won't be able to change isEncrypted to YES,
-                    // unless we have omemo devices for that contact
-                    showPromisingLoadingOverlay(overlay, headlineView:Text("Loading OMEMO keys"), descriptionView:Text("")).done {
-                        // request omemo devicelist
-                        account.omemo.subscribeAndFetchDevicelistIfNoSessionExists(forJid:contact.contactJid)
-                    }
-                }
             }
-        } else {
-            hideLoadingOverlay(overlay)
         }
-    }
 #endif
-}
+    }
     
     var body: some View {
         ExyteChatView(messages: messages, chatType: .conversation, replyMode: .quote) { draft in

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -90,8 +90,10 @@ struct ChatView: View {
     @State private var confirmationPrompt: ConfirmationPrompt?
     @StateObject private var overlay = LoadingOverlayState()
     @State var messages: [ChatViewMessage] = []
+    @State var queuedNewMessages: [ChatViewMessage] = []
     private var account: xmpp
     @State private var isLoadingMamHistory = false
+    @State private var messageInsertionTimer: Timer?
     
     init(contact: ObservableKVOWrapper<MLContact>) {
         _contact = StateObject(wrappedValue: contact)
@@ -463,6 +465,7 @@ struct ChatView: View {
             if MLNotificationManager.sharedInstance().currentContact == self.contact.obj {
                 MLNotificationManager.sharedInstance().currentContact = nil
             }
+            messageInsertionTimer?.invalidate()
         }
         .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name(kMonalOmemoFetchingStateUpdate)).receive(on: RunLoop.main)) { notification in
             if let xmppAccount = notification.object as? xmpp, let notificationJid = notification.userInfo?["jid"] as? String {
@@ -484,9 +487,17 @@ struct ChatView: View {
                 return
             }
             if message.isEqual(to: self.contact.obj) {
-                // Do not insert based on delay timestamp because that
-                // would make it possible to fake history entries.
-                messages.append(ChatViewMessage(message))
+                // Don't insert based on delay timestamp because that would make it possible to fake history entries.
+                // Insert new messages in batches to work around https://github.com/exyte/Chat/issues/223
+                queuedNewMessages.append(ChatViewMessage(message))
+                if messageInsertionTimer == nil {
+                    messageInsertionTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: false) { _ in
+                        messages.append(contentsOf: queuedNewMessages)
+                        queuedNewMessages.removeAll(keepingCapacity: true)
+                        messageInsertionTimer = nil
+                    }
+                    messageInsertionTimer?.tolerance = 0.04
+                }
             }
             ChatViewHelpers.refreshCounter(for: self.contact.obj)
         }

--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -308,6 +308,7 @@ extern NSString* const kMessageTypeFiletransfer;
 
 -(NSString*) lastUsedPushServerForAccount:(NSNumber*) accountID;
 -(void) updateUsedPushServer:(NSString*) pushServer forAccount:(NSNumber*) accountID;
+-(void) markReachedMamArchiveTopForContact:(MLContact*) contact;
 
 
 

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -439,7 +439,7 @@ static NSDateFormatter* dbFormatter;
         return nil;
 
     return [self.db idReadTransaction:^{
-        NSArray* results = [self.db executeReader:@"SELECT b.buddy_id, b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', encrypt, muted, \
+        NSArray* results = [self.db executeReader:@"SELECT b.buddy_id, b.buddy_name, state, status, b.full_name, b.nick_name, Muc, muc_subject, muc_type, muc_nick, mentionOnly, b.account_id, 0 AS 'count', subscription, ask, IFNULL(pinned, 0) AS 'pinned', encrypt, muted, reached_mam_archive_top, \
             CASE \
                 WHEN a.buddy_name IS NOT NULL THEN 1 \
                 ELSE 0 \
@@ -1470,6 +1470,9 @@ static NSDateFormatter* dbFormatter;
         
         [self.db executeNonQuery:@"DELETE FROM activechats WHERE account_id=?;" andArguments:@[accountID]];
         [self.db executeNonQuery:@"PRAGMA secure_delete=off;"];
+
+        //allow fetching history from MAM again, for chats that fetched the whole archive previously
+        [self.db executeNonQuery:@"UPDATE buddylist SET reached_mam_archive_top=0 WHERE account_id=?;" andArguments:@[accountID]];
     }];
 }
 
@@ -1485,6 +1488,9 @@ static NSDateFormatter* dbFormatter;
         //better UX without deleting the active chat
         //[self.db executeNonQuery:@"DELETE FROM activechats WHERE account_id=? AND buddy_name=?;" andArguments:@[accountID, buddy]];
         [self.db executeNonQuery:@"PRAGMA secure_delete=off;"];
+
+        //allow fetching history from MAM again, in case the whole archive was fetched previously
+        [self.db executeNonQuery:@"UPDATE buddylist SET reached_mam_archive_top=0 WHERE account_id=? AND buddy_name=?;" andArguments:@[accountID, buddy]];
     }];
 }
 
@@ -1998,6 +2004,13 @@ static NSDateFormatter* dbFormatter;
 {
     [self.db voidWriteTransaction:^{
         [self.db executeScalarReader:@"UPDATE account SET registeredPushServer=? WHERE account_id=?;" andArguments:@[pushServer, accountID]];
+    }];
+}
+
+-(void) markReachedMamArchiveTopForContact:(MLContact*) contact
+{
+    [self.db voidWriteTransaction:^{
+        [self.db executeNonQuery:@"UPDATE buddylist SET reached_mam_archive_top=1 WHERE account_id=? AND buddy_name=?;" andArguments:@[contact.accountID, contact.contactJid]];
     }];
 }
 

--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -963,6 +963,10 @@
             );"];
         }];
 
+        // Keep track of when the full MAM archive has been fetched, so we don't query it again
+        [self updateDB:db withDataLayer:dataLayer toVersion:7.001 withBlock:^{
+            [db executeNonQuery:@"ALTER TABLE buddylist ADD COLUMN reached_mam_archive_top BOOL DEFAULT FALSE;"];
+        }];
 
         //check if device id changed and invalidate state, if so
         //but do so only for non-sandbox (e.g. non-development) installs

--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -151,6 +151,7 @@ static inline NSString* _Nonnull LocalizationNotNeeded(NSString* _Nonnull s)
 #define kMonalNewMessageNotice @"kMonalNewMessageNotice"
 #define kMonalUpdatedMessageNotice @"kMonalUpdatedMessageNotice"
 #define kMonalMucSubjectChanged @"kMonalMucSubjectChanged"
+#define kMonalContactHistoryCleared @"kMonalContactHistoryCleared"
 #define kMonalDeletedMessageNotice @"kMonalDeletedMessageNotice"
 #define kMonalDisplayedMessagesNotice @"kMonalDisplayedMessagesNotice"
 #define kMLMessageSentToContact @"kMLMessageSentToContact"

--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -153,7 +153,6 @@ static inline NSString* _Nonnull LocalizationNotNeeded(NSString* _Nonnull s)
 #define kMonalMucSubjectChanged @"kMonalMucSubjectChanged"
 #define kMonalDeletedMessageNotice @"kMonalDeletedMessageNotice"
 #define kMonalDisplayedMessagesNotice @"kMonalDisplayedMessagesNotice"
-#define kMonalHistoryMessagesNotice @"kMonalHistoryMessagesNotice"
 #define kMLMessageSentToContact @"kMLMessageSentToContact"
 #define kMonalSentMessageNotice @"kMonalSentMessageNotice"
 #define kMonalMessageFiletransferUpdateNotice @"kMonalMessageFiletransferUpdateNotice"

--- a/Monal/Classes/MLContact.h
+++ b/Monal/Classes/MLContact.h
@@ -97,6 +97,10 @@ FOUNDATION_EXPORT NSString* const kAskSubscribe;
 @property (nonatomic, readonly) NSString* contactDisplayName;
 @property (nonatomic, readonly) NSString* contactDisplayNameWithoutSelfnotesPrefix;
 
+// This property is used to avoid querying MAM if the top of the archive
+// was already reached in a previous query
+@property (nonatomic, readonly) BOOL hasReachedMamArchiveTop;
+
 -(NSString*) contactDisplayNameWithFallback:(NSString* _Nullable) fallbackName;
 -(NSString*) contactDisplayNameWithFallback:(NSString* _Nullable) fallbackName andSelfnotesPrefix:(BOOL) hasSelfnotesPrefix;
 -(void) updateWithContact:(MLContact*) contact;
@@ -116,6 +120,7 @@ FOUNDATION_EXPORT NSString* const kAskSubscribe;
 -(void) removeFromRoster;
 -(void) addToRoster;
 -(void) clearHistory;
+-(void) markReachedMamArchiveTop;
 -(void) removeShareInteractions;
 
 -(NSUInteger) hash;

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -74,6 +74,7 @@ static NSMutableDictionary* _singletonCache;
 @property (nonatomic, strong) NSString* ask;
 
 @property (nonatomic, strong) NSString* contactDisplayName;
+@property (nonatomic, assign) BOOL hasReachedMamArchiveTop;
 @end
 
 @implementation MLContact
@@ -106,6 +107,7 @@ static NSMutableDictionary* _singletonCache;
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:0],
             @"rosterGroups": [NSSet new],
+            @"reached_mam_archive_top": @NO,
         }];
     }
     else if(type == 2)
@@ -130,6 +132,7 @@ static NSMutableDictionary* _singletonCache;
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640153174],
             @"rosterGroups": [NSSet new],
+            @"reached_mam_archive_top": @NO,
         }];
     }
     else if(type == 3)
@@ -154,6 +157,7 @@ static NSMutableDictionary* _singletonCache;
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640157074],
             @"rosterGroups": [NSSet new],
+            @"reached_mam_archive_top": @NO,
         }];
     }
     else
@@ -177,6 +181,7 @@ static NSMutableDictionary* _singletonCache;
             @"isActiveChat": @YES,
             @"lastInteraction": [[NSDate date] initWithTimeIntervalSince1970:1640157174],
             @"rosterGroups": [NSSet new],
+            @"reached_mam_archive_top": @NO,
         }];
     }
 }
@@ -229,6 +234,7 @@ static NSMutableDictionary* _singletonCache;
             @"isActiveChat": @NO,
             @"lastInteraction": nilWrapper(nil),
             @"rosterGroups": [NSSet set],
+            @"reached_mam_archive_top": @NO,
         }];
     }
     else
@@ -720,6 +726,12 @@ static NSMutableDictionary* _singletonCache;
     [[MLNotificationQueue currentQueue] postNotificationName:kMonalRefresh object:nil userInfo:nil];
 }
 
+-(void) markReachedMamArchiveTop
+{
+    [[DataLayer sharedInstance] markReachedMamArchiveTopForContact:self];
+    self.hasReachedMamArchiveTop = YES;
+}
+
 #pragma mark - NSCoding
 
 -(void) encodeWithCoder:(NSCoder*) coder
@@ -745,6 +757,7 @@ static NSMutableDictionary* _singletonCache;
     [coder encodeBool:self.isMuted forKey:@"isMuted"];
     [coder encodeObject:self.lastInteractionTime forKey:@"lastInteractionTime"];
     [coder encodeObject:self.rosterGroups forKey:@"rosterGroups"];
+    [coder encodeBool:self.hasReachedMamArchiveTop forKey:@"hasReachedMamArchiveTop"];
 }
 
 -(instancetype) initWithCoder:(NSCoder*) coder
@@ -771,6 +784,7 @@ static NSMutableDictionary* _singletonCache;
     self.isMuted = [coder decodeBoolForKey:@"isMuted"];
     self.lastInteractionTime = [coder decodeObjectForKey:@"lastInteractionTime"];
     self.rosterGroups = [coder decodeObjectForKey:@"rosterGroups"];
+    self.hasReachedMamArchiveTop = [coder decodeBoolForKey:@"hasReachedMamArchiveTop"];
     return self;
 }
 
@@ -799,6 +813,7 @@ static NSMutableDictionary* _singletonCache;
     //don't update lastInteractionTime from contact, we dynamically update ourselves by handling kMonalLastInteractionUpdatedNotice
     //updateIfIdNotEqual(self.lastInteractionTime, contact.lastInteractionTime);
     updateIfIdNotEqual(self.rosterGroups, contact.rosterGroups);
+    updateIfPrimitiveNotEqual(self.hasReachedMamArchiveTop, contact.hasReachedMamArchiveTop);
 }
 
 -(BOOL) isEqualToMessage:(MLMessage*) message
@@ -869,6 +884,7 @@ static NSMutableDictionary* _singletonCache;
     // initial value comes from db, all other values get updated by our kMonalLastInteractionUpdatedNotice handler
     contact.lastInteractionTime = nilExtractor([dic objectForKey:@"lastInteraction"]);        //no default needed, already done in DataLayer
     contact.rosterGroups = [dic objectForKey:@"rosterGroups"];
+    contact.hasReachedMamArchiveTop = [[dic objectForKey:@"reached_mam_archive_top"] boolValue];
     contact->_avatar = nil;
 
     MLAssert(contact.rosterGroups != nil, @"rosterGroups must be non-nil (if a user is in no groups, it should be empty set)");

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -723,7 +723,9 @@ static NSMutableDictionary* _singletonCache;
 -(void) clearHistory
 {
     [[DataLayer sharedInstance] clearMessagesWithBuddy:self.contactJid onAccount:self.accountID];
-    [[MLNotificationQueue currentQueue] postNotificationName:kMonalRefresh object:nil userInfo:nil];
+    [[MLNotificationQueue currentQueue] postNotificationName:kMonalContactHistoryCleared object:self.account userInfo:@{
+        @"contact": self,
+    }];
 }
 
 -(void) markReachedMamArchiveTop

--- a/Monal/Classes/MLContact.m
+++ b/Monal/Classes/MLContact.m
@@ -628,6 +628,10 @@ static NSMutableDictionary* _singletonCache;
     self.isMuted = mute;
     if(self.isMuc)
         [self.account.mucProcessor updateBookmarks];
+    // update active chats
+    [[MLNotificationQueue currentQueue] postNotificationName:kMonalContactRefresh object:self.account userInfo:@{
+        @"contact":self,
+    }];
 }
 
 -(void) toggleMentionOnly:(BOOL) mentionOnly
@@ -641,6 +645,10 @@ static NSMutableDictionary* _singletonCache;
     self.isMentionOnly = mentionOnly;
     if(self.isMuc)
         [self.account.mucProcessor updateBookmarks];
+    // update active chats
+    [[MLNotificationQueue currentQueue] postNotificationName:kMonalContactRefresh object:self.account userInfo:@{
+        @"contact":self,
+    }];
 }
 
 -(BOOL) toggleEncryption:(BOOL) encrypt

--- a/Monal/Classes/MLFiletransfer.m
+++ b/Monal/Classes/MLFiletransfer.m
@@ -836,7 +836,7 @@ $$
     
     //inform chatview of error
     [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageErrorNotice object:nil userInfo:@{
-        @"MessageID": msg.messageId,
+        kMessageId: msg.messageId,
         @"jid": msg.buddyName,
         @"errorType": errorType,
         @"errorReason": errorText

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -17,6 +17,7 @@
 #import <monalxmpp/MLNotificationQueue.h>
 #import <monalxmpp/MLContactSoftwareVersionInfo.h>
 #import <monalxmpp/MLOMEMO.h>
+#import "MLMessageProcessor.h"
 
 @import SAMKeychain;
 
@@ -230,6 +231,131 @@ $$class_handler(handleMamResponseWithLatestId, $$ID(xmpp*, account), $$ID(XMPPIQ
     if([iqNode check:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/last#"])
         [[DataLayer sharedInstance] setLastStanzaId:[iqNode findFirst:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/last#"] forAccount:account.accountID];
     [account mamFinishedFor:account.connectionProperties.identity.jid];
+$$
+
+$$class_handler(handleMAMBackscrollingResultInvalidation, $$ID(xmpp*, account), $$ID(MLContact*, contact), $$ID(MLPromise*, promise))
+    DDLogError(@"Got backscrolling mam error for %@", contact.contactJid);
+    NSString* errorMessage = [NSString stringWithFormat:NSLocalizedString(@"Could not fetch more old chat history for '%@' from the server archive. Please try again.", @""), contact.contactJid];
+    NSError* error = [NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+    [promise reject:error];
+$$
+
+$$class_handler(handleMAMBackscrollingResult, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode), $$ID(MLContact*, contact), $_ID(NSArray*, historyIdsOfAlreadyRetreivedMessages), $$ID(MLPromise*, promise))
+    //the promise will be rejected if an error prevented us to get any messages.
+    //it will resolve an empty array, if the upper end of our archive was reached
+    //and it will resolve an array of newly loaded mlmessages in all other cases
+
+    //if we get less than half kMonalBackscrollingMsgCount message bodies,
+    //recursively send another query, passing it the promise and the historyIds of processed messages,
+    //and let the new query resolve the promise.
+    NSUInteger retrievedBodiesOverall = 0;
+    NSUInteger retrievedBodiesInThisQuery = 0;
+    if(historyIdsOfAlreadyRetreivedMessages)
+        retrievedBodiesOverall = historyIdsOfAlreadyRetreivedMessages.count;
+    NSMutableArray* mamPage = [account getOrderedMamPageFor:[iqNode findFirst:@"/@id"]];
+
+    //count new bodies
+    for(NSDictionary* data in mamPage)
+        if([data[@"messageNode"] check:@"body#"])
+            retrievedBodiesInThisQuery++;
+
+    retrievedBodiesOverall += retrievedBodiesInThisQuery;
+
+    // If we had an error but we got some bodies, the promise will resolve the messages containing those bodies.
+    // `item-not-found` means the stanzaId used in the query is unknown to the server, due to its retention policy.
+    // => item-not-found indicates that the top of the mam archive was reached
+    if([iqNode check:@"/<type=error>"] && retrievedBodiesOverall == 0
+        && ![iqNode check:@"error/{urn:ietf:params:xml:ns:xmpp-stanzas}item-not-found"])
+    {
+        NSString* errorMessage = [HelperTools extractXMPPError:iqNode withDescription:NSLocalizedString(@"Could not fetch more old history for this chat from the server archive. Please try again later.", @"")];
+        NSError* error = [NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: errorMessage}];
+        [promise reject:error];
+    }
+    else
+    {
+        if(retrievedBodiesOverall == 0)
+        {
+            //if we did not retrieve any body messages we don't need to process metadata sanzas (if any), but signal we reached the end of our archive
+            DDLogDebug(@"Reached upper end of mam:2 archive");
+            [promise fulfill:@[]];
+            return;
+        }
+
+        NSMutableArray* historyIdList = [NSMutableArray new];
+
+        //ignore all notifications generated while processing the queued stanzas
+        [MLNotificationQueue queueNotificationsInBlock:^{
+            //process received message stanzas and manipulate the db accordingly
+            //if a new message got added to the history db, the message processor will return a MLMessage instance containing the history id of the newly created entry
+            DDLogDebug(@"Handling %lu entries in mam page...", mamPage.count);
+            //the handler is already called inside a db write transaction.
+            //this means we're safe from mam holes if the app crashes while processing messages.
+            //benchmarks reveal that processing 50 message stanzas takes ~58ms.
+            //=> no risk of blocking the main thread for db write access for too long.
+            NSNumber* historyId = @([[[DataLayer sharedInstance] getSmallestHistoryId] integerValue] - (NSInteger)retrievedBodiesInThisQuery);
+            uint32_t entryNo = 0;
+            for(NSDictionary* data in mamPage)
+            {
+                DDLogVerbose(@"Handling mam page entry[%u(%lu)]): %@", entryNo, mamPage.count, data);
+                MLMessage* msg = [MLMessageProcessor processMessage:data[@"messageNode"] andOuterMessage:data[@"outerMessageNode"] forAccount:account withHistoryId:historyId];
+                DDLogVerbose(@"Got message processor result: %@", msg);
+                //add successfully added messages to our display list
+                //stanzas not transporting a body will be processed, too, but the message processor will return nil for these
+                if(msg != nil)
+                {
+                    [historyIdList addObject:msg.messageDBId];      //we only need the history id to fetch a fresh copy later
+                    historyId = @([historyId intValue] + 1);      //calculate next history id
+                }
+                entryNo++;
+            }
+
+            //throw away all queued notifications before leaving this context
+            [(MLNotificationQueue*)[MLNotificationQueue currentQueue] clear];
+        } onQueue:@"MLhistoryIgnoreQueue"];
+
+        DDLogDebug(@"collected mam:2 before-pages now contain %lu messages in summary not already in history", historyIdList.count);
+        MLAssert(historyIdList.count <= retrievedBodiesInThisQuery, @"did add more messages to historydb table than bodies collected!", (@{
+            @"historyIdList": historyIdList,
+            @"retrievedBodies": @(retrievedBodiesInThisQuery),
+        }));
+        if(historyIdList.count < retrievedBodiesInThisQuery)
+            DDLogWarn(@"Got %lu mam history messages already contained in history db, possibly ougoing messages that did not have a stanzaid yet!", retrievedBodiesInThisQuery - historyIdList.count);
+
+        NSArray* overallHistoryIdList;
+        if(historyIdsOfAlreadyRetreivedMessages)
+            overallHistoryIdList = [historyIdList arrayByAddingObjectsFromArray:historyIdsOfAlreadyRetreivedMessages];
+        else
+            overallHistoryIdList = [historyIdList copy];
+
+        //check if we need to load more messages
+        if(retrievedBodiesOverall > kMonalBackscrollingMsgCount / 2)
+        {
+            //query db for the real MLMessage to account for changes in history table by non-body metadata messages received after the body-message
+            [promise fulfill:[[DataLayer sharedInstance] messagesForHistoryIDs:overallHistoryIdList]];
+        }
+        else
+        {
+            if(
+                ![[iqNode findFirst:@"{urn:xmpp:mam:2}fin@complete|bool"] boolValue] &&
+                [iqNode check:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/first#"]
+            )
+            {
+                //page through to get more messages, and pass the current promise and overallHistoryIdList
+                //to the new query's handler
+                DDLogVerbose(@"Going to send another mam backscrolling query because we didn't get enough message bodies. We got %lu bodies in this query and %lu bodies in all the queries since the user scrolled up to fetch more.", retrievedBodiesInThisQuery, retrievedBodiesOverall);
+                NSString* earliestStanzaId = [iqNode findFirst:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/first#"];
+                XMPPIQ* newQuery = [account prepareIQForMAMQueryMostRecentForContact:contact before:earliestStanzaId];
+                [account sendIq:newQuery withHandler:$newHandlerWithInvalidation(MLIQProcessor, handleMAMBackscrollingResult, handleMAMBackscrollingResultInvalidation, $ID(contact), $ID(historyIdsOfAlreadyRetreivedMessages, overallHistoryIdList), $ID(promise))];
+            }
+            else
+            {
+                // Either the top of the mam archive was reached, or we got an error after receiving some bodies.
+
+                //query db for the real MLMessages to account for changes in history table by non-body metadata messages received after the body-message
+                [promise fulfill:[[DataLayer sharedInstance] messagesForHistoryIDs:overallHistoryIdList]];
+            }
+        }
+    }
 $$
 
 $$class_handler(handleCarbonsEnabled, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode))

--- a/Monal/Classes/XMPPEdit.m
+++ b/Monal/Classes/XMPPEdit.m
@@ -16,6 +16,7 @@
 #import <monalxmpp/MLNotificationQueue.h>
 #import "MonalAppDelegate.h"
 #import "ActiveChatsViewController.h"
+#import "MLNotificationManager.h"
 #import "Monal-Swift.h"
 
 @import MobileCoreServices;
@@ -564,6 +565,13 @@ enum DummySettingsRows {
     UIAlertAction *yesAction = [UIAlertAction actionWithTitle:NSLocalizedString(@"Yes", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction* action __unused) {
 
         [self.db clearMessages:self.accountID];
+
+        // display the splitView placeholder, if the currently displayed chat belongs to this account
+        MLContact* currentContact = [MLNotificationManager sharedInstance].currentContact;
+        if (currentContact && currentContact.accountID == self.accountID)
+            [((MonalAppDelegate*)UIApplication.sharedApplication.delegate).activeChats presentSplitPlaceholder];
+
+         // clearing the history of an account deletes entries from ActiveChats
         [[MLNotificationQueue currentQueue] postNotificationName:kMonalRefresh object:nil userInfo:nil];
 
         MBProgressHUD *hud = [MBProgressHUD showHUDAddedTo:self.view animated:YES];

--- a/Monal/Classes/XMPPIQ.m
+++ b/Monal/Classes/XMPPIQ.m
@@ -200,7 +200,7 @@ NSString* const kiqErrorType = @"error";
     } andChildren:@[
         form,
         [[MLXMLNode alloc] initWithElement:@"set" andNamespace:@"http://jabber.org/protocol/rsm" withAttributes:@{} andChildren:@[
-            [[MLXMLNode alloc] initWithElement:@"max" andData:@"50"],
+            [[MLXMLNode alloc] initWithElement:@"max" andData:@(kMonalBackscrollingMsgCount).stringValue],
             [[MLXMLNode alloc] initWithElement:@"before" andData:uid]
         ] andData:nil]
     ] andData:nil];

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -785,6 +785,7 @@ enum msgSentState {
 
     [nc addObserver:self selector:@selector(dismissKeyboard:) name:UIApplicationDidEnterBackgroundNotification object:nil];
     [nc addObserver:self selector:@selector(handleForeGround) name:kMonalRefresh object:nil];
+    [nc addObserver:self selector:@selector(handleForeGround) name:kMonalContactHistoryCleared object:nil];
 
     [nc addObserver:self selector:@selector(keyboardDidShow:) name:UIKeyboardDidShowNotification object:nil];
     [nc addObserver:self selector:@selector(keyboardDidHide:) name:UIKeyboardDidHideNotification object:nil];

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -2699,54 +2699,33 @@ enum msgSentState {
 
         //now load more (older) messages from mam
         DDLogVerbose(@"Loading more messages from mam before stanzaId %@", oldestStanzaId);
-        weakify(self);
-        [self.xmppAccount setMAMQueryMostRecentForContact:self.contact before:oldestStanzaId withCompletion:^(NSArray* _Nullable messages, NSString* _Nullable error) {
-            dispatch_async(dispatch_get_main_queue(), ^{
-                strongify(self);
-                if(!messages && !error)
-                {
-                    //xmpp account got reconnected
-                    DDLogError(@"Got backscrolling mam error: nil (possible reconnect while querying)");
-                    UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Could not fetch messages", @"") message:NSLocalizedString(@"The connection to the server was interrupted and no old messages could be fetched for this chat. Please try again later.", @"") preferredStyle:UIAlertControllerStyleAlert];
-                    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                        [alert dismissViewControllerAnimated:YES completion:nil];
-                    }]];
-                    [self presentViewController:alert animated:YES completion:nil];
-                }
-                else if(!messages)
-                {
-                    NSString* errorText = error;
-                    if(!error)
-                        errorText = NSLocalizedString(@"Unknown error!", @"");
-                    DDLogError(@"Got backscrolling mam error: %@", errorText);
-                    UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Could not fetch messages", @"") message:[NSString stringWithFormat:NSLocalizedString(@"Could not fetch (all) old messages for this chat from your server archive. Please try again later. %@", @""), errorText] preferredStyle:UIAlertControllerStyleAlert];
-                    [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                        [alert dismissViewControllerAnimated:YES completion:nil];
-                    }]];
-                    [self presentViewController:alert animated:YES completion:nil];
-                }
-                else
-                {
-                    DDLogVerbose(@"Got backscrolling mam response: %lu", (unsigned long)[messages count]);
-                    if([messages count] == 0)
-                    {
-                        self.moreMessagesAvailable = NO;
-                        
-                        UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Finished fetching messages", @"") message:NSLocalizedString(@"All messages fetched successfully, there are no more left on the server!", @"") preferredStyle:UIAlertControllerStyleAlert];
-                        [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
-                            [alert dismissViewControllerAnimated:YES completion:nil];
-                        }]];
-                        [self presentViewController:alert animated:YES completion:nil];
-                    }
-                    else
-                        [self insertOldMessages:[[messages reverseObjectEnumerator] allObjects]];
-                }
-                //allow next mam fetch
-                self.isLoadingMam = NO;
-                if(sender)
-                    [(UIRefreshControl*)sender endRefreshing];
-            });
-        }];
+        [self.xmppAccount setMAMQueryMostRecentForContact:self.contact before:oldestStanzaId]
+        .then(^(NSArray<MLMessage*>* messages) {
+            DDLogVerbose(@"Got backscrolling mam response: %lu", (unsigned long)[messages count]);
+            if([messages count] == 0)
+            {
+                self.moreMessagesAvailable = NO;
+                UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Finished fetching messages", @"") message:NSLocalizedString(@"All messages fetched successfully, there are no more left on the server!", @"") preferredStyle:UIAlertControllerStyleAlert];
+                [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                    [alert dismissViewControllerAnimated:YES completion:nil];
+                }]];
+                [self presentViewController:alert animated:YES completion:nil];
+            }
+            else
+                [self insertOldMessages:[[messages reverseObjectEnumerator] allObjects]];
+        }).catch(^(NSError *error) {
+            DDLogError(@"Got backscrolling mam error: %@", error.localizedDescription);
+            UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Could not fetch messages", @"") message:error.localizedDescription preferredStyle:UIAlertControllerStyleAlert];
+            [alert addAction:[UIAlertAction actionWithTitle:NSLocalizedString(@"Close", @"") style:UIAlertActionStyleDefault handler:^(UIAlertAction * _Nonnull action) {
+                [alert dismissViewControllerAnimated:YES completion:nil];
+            }]];
+            [self presentViewController:alert animated:YES completion:nil];
+        }).ensure(^{
+            //allow next mam fetch
+            self.isLoadingMam = NO;
+            if(sender)
+                [(UIRefreshControl*)sender endRefreshing];
+        });
     }
     else if(!self.isLoadingMam && [oldMessages count] >= kMonalBackscrollingMsgCount)
     {

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -192,7 +192,8 @@ typedef void (^monal_iq_handler_t)(XMPPIQ* _Nullable);
  -(void) requestHTTPSlotWithParams:(NSDictionary *)params andCompletion:(void(^)(NSString *url,  NSError *error)) completion;
 
 
--(void) setMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString* _Nullable) uid withCompletion:(void (^)(NSArray* _Nullable, NSString* _Nullable error)) completion;
+-(XMPPIQ*) prepareIQForMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString*) before;
+-(AnyPromise*) setMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString* _Nullable) before;
 -(void) setMAMPrefs:(NSString*) preference;
 -(void) getMAMPrefs;
 

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -4445,151 +4445,32 @@ NSString* const kStanza = @"stanza";
     [self sendIq:query withHandler:$newHandler(MLIQProcessor, handleMamPrefs)];
 }
 
--(void) setMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString*) uid withCompletion:(void (^)(NSArray* _Nullable, NSString* _Nullable error)) completion
+-(XMPPIQ*) prepareIQForMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString*) before
 {
-    //the completion handler will get nil, if an error prevented us toget any messaes, an empty array, if the upper end of our archive was reached or an array
-    //of newly loaded mlmessages in all other cases
-    unsigned int __block retrievedBodies = 0;
-    NSMutableArray* __block pageList = [NSMutableArray new];
-    void __block (^query)(NSString* before);
-    monal_iq_handler_t __block responseHandler;
-    monal_void_block_t callUI = ^{
-        //if we did not retrieve any body messages we don't need to process metadata sanzas (if any), but signal we reached the end of our archive
-        //callUI() will only be called with retrievedBodies == 0 if we reached the upper end of our mam archive, because iq errors have already been
-        //handled in the iq error handler below
-        if(retrievedBodies == 0)
-        {
-            completion(@[], nil);
-            return;
-        }
-        
-        NSMutableArray* __block historyIdList = [NSMutableArray new];
-        NSNumber* __block historyId = [NSNumber numberWithInt:[[[DataLayer sharedInstance] getSmallestHistoryId] intValue] - retrievedBodies];
-        
-        //ignore all notifications generated while processing the queued stanzas
-        [MLNotificationQueue queueNotificationsInBlock:^{
-            uint32_t pageNo = 0;
-            //iterate through all pages and their messages forward in time (pages have already been sorted forward in time internally)
-            DDLogDebug(@"Handling %@ mam pages...", @([pageList count]));
-            for(NSArray* page in [[pageList reverseObjectEnumerator] allObjects])
-            {
-                //process received message stanzas and manipulate the db accordingly
-                //if a new message got added to the history db, the message processor will return a MLMessage instance containing the history id of the newly created entry
-                DDLogDebug(@"Handling %@ entries in mam page...", @([page count]));
-                uint32_t entryNo = 0;
-                for(NSDictionary* data in page)
-                {
-                    //don't write data to our tcp stream while inside this db transaction
-                    //(all effects to the outside world should be transactional, too)
-                    [self freezeSendQueue];
-                    //process all queued mam stanzas in a dedicated db write transaction
-                    [[DataLayer sharedInstance] createTransaction:^{
-                        DDLogVerbose(@"Handling mam page entry[%u(%@).%u(%@)]): %@", pageNo, @([pageList count]), entryNo, @([page count]), data);
-                        MLMessage* msg = [MLMessageProcessor processMessage:data[@"messageNode"] andOuterMessage:data[@"outerMessageNode"] forAccount:self withHistoryId:historyId];
-                        DDLogVerbose(@"Got message processor result: %@", msg);
-                        //add successfully added messages to our display list
-                        //stanzas not transporting a body will be processed, too, but the message processor will return nil for these
-                        if(msg != nil)
-                        {
-                            [historyIdList addObject:msg.messageDBId];      //we only need the history id to fetch a fresh copy later
-                            historyId = [NSNumber numberWithInt:[historyId intValue] + 1];      //calculate next history id
-                        }
-                    }];
-                    [self unfreezeSendQueue];      //this will flush all stanzas added inside the db transaction and now waiting in the send queue
-                    entryNo++;
-                }
-                pageNo++;
-            }
-            
-            //throw away all queued notifications before leaving this context
-            [(MLNotificationQueue*)[MLNotificationQueue currentQueue] clear];
-        } onQueue:@"MLhistoryIgnoreQueue"];
-        
-        DDLogDebug(@"collected mam:2 before-pages now contain %lu messages in summary not already in history", (unsigned long)[historyIdList count]);
-        MLAssert([historyIdList count] <= retrievedBodies, @"did add more messages to historydb table than bodies collected!", (@{
-            @"historyIdList": historyIdList,
-            @"retrievedBodies": @(retrievedBodies),
-        }));
-        if([historyIdList count] < retrievedBodies)
-            DDLogWarn(@"Got %lu mam history messages already contained in history db, possibly ougoing messages that did not have a stanzaid yet!", (unsigned long)(retrievedBodies - [historyIdList count]));
-        //query db (again) for the real MLMessage to account for changes in history table by non-body metadata messages received after the body-message
-        completion([[DataLayer sharedInstance] messagesForHistoryIDs:historyIdList], nil);
-    };
-    responseHandler = ^(XMPPIQ* response) {
-        NSMutableArray* mamPage = [self getOrderedMamPageFor:[response findFirst:@"/@id"]];
-        
-        //count new bodies
-        for(NSDictionary* data in mamPage)
-            if([data[@"messageNode"] check:@"body#"])
-                retrievedBodies++;
-        
-        //add new mam page to page list
-        [pageList addObject:mamPage];
-        
-        //check if we need to load more messages
-        if(retrievedBodies > 25)
-        {
-            //call completion to display all messages saved in db
-            callUI();
-        }
-        //query fo more messages or call completion to display all messages saved in db if we reached the end of our mam archive
-        else
-        {
-            //page through to get more messages (a page possibly contains fewer than 25 messages having a body)
-            //but because we query for 50 stanzas we could easily get more than 25 messages having a body, too
-            if(
-                ![[response findFirst:@"{urn:xmpp:mam:2}fin@complete|bool"] boolValue] &&
-                [response check:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/first#"]
-            )
-            {
-                query([response findFirst:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/first#"]);
-            }
-            else
-            {
-                DDLogDebug(@"Reached upper end of mam:2 archive, returning %lu messages to ui", (unsigned long)retrievedBodies);
-                //can be fewer than 25 messages because we reached the upper end of the mam archive
-                //even zero body-messages could be true
-                callUI();
-            }
-        }
-    };
-    query = ^(NSString* _Nullable before) {
-        XMPPIQ* query = [[XMPPIQ alloc] initWithType:kiqSetType];
-        if(contact.isMuc)
-        {
-            if(!before)
-                before = [[DataLayer sharedInstance] lastStanzaIdForMuc:contact.contactJid andAccount:self.accountID];
-            [query setiqTo:contact.contactJid];
-            [query setMAMQueryLatestMessagesForJid:nil before:before];
-        }
-        else
-        {
-            if(!before)
-                before = [[DataLayer sharedInstance] lastStanzaIdForAccount:self.accountID];
-            [query setMAMQueryLatestMessagesForJid:contact.contactJid before:before];
-        }
-        DDLogDebug(@"Loading (next) mam:2 page before: %@", before);
-        //we always want to use blocks here because we want to make sure we get not interrupted by an app crash/restart
-        //which would make us use incomplete mam pages that would produce holes in history (those are very hard to remove/fill afterwards)
-        [self sendIq:query withResponseHandler:responseHandler andErrorHandler:^(XMPPIQ* error) {
-            DDLogWarn(@"Got mam:2 before-query error, returning %lu messages to ui", (unsigned long)retrievedBodies);
-            if(retrievedBodies == 0)
-            {
-                //call completion with nil, if there was an error or xmpp reconnect that prevented us to get any body-messages
-                //but only for non-item-not-found errors (and internal-server-error errors sent by one of ejabberd or prosody instead [don't know which one it was])
-                if(error == nil || ([error check:@"error/{urn:ietf:params:xml:ns:xmpp-stanzas}internal-server-error"] && [@"item-not-found" isEqualToString:[error findFirst:@"error/{urn:ietf:params:xml:ns:xmpp-stanzas}text#"]]))
-                    completion(nil, nil);
-                else
-                    completion(nil, [HelperTools extractXMPPError:error withDescription:nil]);
-            }
-            else
-            {
-                //we had an error but we did already load some body-messages --> update ui anyways
-                callUI();
-            }
-        }];
-    };
-    query(uid);
+    XMPPIQ* query = [[XMPPIQ alloc] initWithType:kiqSetType];
+    if(contact.isMuc)
+    {
+        if(!before)
+            before = [[DataLayer sharedInstance] lastStanzaIdForMuc:contact.contactJid andAccount:self.accountID];
+        [query setiqTo:contact.contactJid];
+        [query setMAMQueryLatestMessagesForJid:nil before:before];
+    }
+    else
+    {
+        if(!before)
+            before = [[DataLayer sharedInstance] lastStanzaIdForAccount:self.accountID];
+        [query setMAMQueryLatestMessagesForJid:contact.contactJid before:before];
+    }
+    return query;
+}
+
+-(AnyPromise*) setMAMQueryMostRecentForContact:(MLContact*) contact before:(NSString*) before
+{
+    MLPromise* promise = [MLPromise new];
+    XMPPIQ* query = [self prepareIQForMAMQueryMostRecentForContact:contact before:before];
+    DDLogDebug(@"Loading mam:2 page before stanzaId %@", before);
+    [self sendIq:query withHandler:$newHandlerWithInvalidation(MLIQProcessor, handleMAMBackscrollingResult, handleMAMBackscrollingResultInvalidation, $ID(contact), $ID(promise))];
+    return [promise toAnyPromise];
 }
 
 #pragma mark - MUC

--- a/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal Alpha.xcscheme
+++ b/Monal/Monal.xcodeproj/xcshareddata/xcschemes/Monal Alpha.xcscheme
@@ -71,11 +71,6 @@
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption
-            key = "DYLD_INSERT_LIBRARIES"
-            value = "/usr/lib/libgmalloc.dylib"
-            isEnabled = "YES">
-         </AdditionalOption>
-         <AdditionalOption
             key = "NSZombieEnabled"
             value = "YES"
             isEnabled = "YES">


### PR DESCRIPTION
Notes:
The `pages` parameter in ExyteChat's `enableLoadMore` is not taken into consideration. `pages` is hardcoded to `1` in ExyteChat's source code. See Matthew's open PR for more details.

When loading more history from the _db_, I occasionally triggered a bug, which I suspect is a race condition, where the `messages` array gets update but that doesn't result in a SwiftUI re-render. It turns out that ExyteChat has an optimization that says: Only render insertion updates if the view is scrolled to the very top or the very bottom.[[0]](https://github.com/exyte/Chat/blob/18c59301822/README.md?plain=1#L256)   [[1]](https://github.com/exyte/Chat/blob/18c59301822/Sources/ExyteChat/Views/UIList.swift#L192)
So, I disabled that optimization in our fork. The bug doesn't happen anymore, and the experience is smoother.
(Note: when triggering this bug, tapping the top message / date separator makes the new messages show up)

##### Changes from the UIKit backscrolling:
Use a ProgressView() spinner when fetching history from the server, but not from the DB.

History fetching happens automatically when the top message is rendered, rather than on pull-to-refresh. This change is baked into ExyteChat.

Since History fetches will happen when a single message is loaded in the ChatView, I went ahead and enabled automatic fetches when the ChatView is empty as well.

It can be annoying when the alert "finished fetching messages successfully" shows up every time you open a chat with a small number of messages. Therefore:
1- If we reach the beginning of the available MAM history, we disable further MAM queries =>  the ProgressView() doesn't spin anymore when scrolling up => this is not a confusing UX, as this will implicitly tell users that there's no more history to fetch
2- We don't show the "finished fetching messages successfully" alert. Because it is weird when you get that alert immediately after creating a group chat / adding a contact. (remember, we fetch history automatically even when the chatView is empty)

I want your opinion on also disabling the alert / MAM queries when we get a `element-not-found` error. This error happens when the oldest stanzaId in the chat is not known to the server (i.e. it was deleted because of the retention policy). This case should be indistinguishable to users from the "finished fetching messages successfully" case.
 
