### PR TITLE
Fix a Quicksy compilation error

### DIFF
--- a/Monal/Classes/BoardingCards.swift
+++ b/Monal/Classes/BoardingCards.swift
@@ -186,7 +186,9 @@ func createOnboardingView(delegate: SheetDismisserProtocol) -> some View {
             """),
             customView: nil,
             //this is needed because the `#if IS_QUICKSY` blocks the compiler extraction of this LocalizedStringKey based string
-            nextText: NSLocalizedString("Accept and continue", comment:"Quicksy privacy policy")
+            //during runtime, the localized string will be used as a localization key.
+            //no translation will be found. So, the key (which is already a translation) will be used as is.
+            nextText: LocalizedStringKey(stringLiteral: NSLocalizedString("Accept and continue", comment:"Quicksy privacy policy"))
         ),
     ]
 #else

--- a/Monal/Classes/DebugView.swift
+++ b/Monal/Classes/DebugView.swift
@@ -212,7 +212,7 @@ struct DebugView: View {
         .padding()
         .addLoadingOverlay(overlay)
         .navigationBarItems(trailing:Button("Reconnect All") {
-            showLoadingOverlay(overlay, headline: "Reconnecting", description: "Will log out and reconnect all (connected) accounts.") {
+            showLoadingOverlay(overlay, headline: "Reconnecting", description: "Will log out and reconnect all (enabled) accounts.") {
                 MLXMPPManager.sharedInstance().reconnectAll()
                 return after(seconds:3.0)
             }


### PR DESCRIPTION
Note that the source string "Accept and continue" was not already extracted to Weblate. That's why its localization won't work if you test the PR.