### PR TITLE
Bubble up MLMessage changes to ChatViewMessage and from there to the view

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -200,7 +200,7 @@ struct ChatView: View {
             guard let newMLMessage = MLXMPPManager.sharedInstance().sendMessageAndAddToHistory(message: draft.text, havingType: kMessageTypeText, toContact: self.contact.obj, isEncrypted: self.contact.isEncrypted, uploadInfo: nil) else {
                 return
             }
-            messages.append(ChatViewMessage(ObservableKVOWrapper(newMLMessage)))
+            messages.append(ChatViewMessage(newMLMessage))
         } messageBuilder: { message, viewModel, positionInUserGroup, positionInMessagesSection, positionInCommentsGroup, showContextMenuClosure, messageActionClosure, showAttachmentClosure in
             MessageView(message: (message as! ChatViewMessage), viewModel: viewModel, positionInUserGroup: positionInUserGroup, positionInMessagesSection: positionInMessagesSection)
         }
@@ -352,7 +352,7 @@ struct ChatView: View {
             if messages.isEmpty {
                 let dbMessages = DataLayer.sharedInstance().messages(forContact:contact.contactJid, forAccount:contact.accountID) as! [MLMessage]
                 for msg in dbMessages {
-                    messages.append(ChatViewMessage(ObservableKVOWrapper(msg)))
+                    messages.append(ChatViewMessage(msg))
                 }
             }
             ChatViewHelpers.refreshCounter(for: self.contact.obj)
@@ -410,7 +410,7 @@ struct ChatView: View {
             if message.isEqual(to: self.contact.obj) {
                 // Do not insert based on delay timestamp because that
                 // would make it possible to fake history entries.
-                messages.append(ChatViewMessage(ObservableKVOWrapper(message)))
+                messages.append(ChatViewMessage(message))
             }
             ChatViewHelpers.refreshCounter(for: self.contact.obj)
         }
@@ -429,8 +429,8 @@ class ChatViewMessage: ExyteChat.Message {
         }
         set {}
     }
-    init(_ message: ObservableKVOWrapper<MLMessage>) {
-        self.innerMessage = message
+    init(_ message: MLMessage) {
+        self.innerMessage = ObservableKVOWrapper(message)
         let user = ExyteChat.User(id: message.senderID, name: message.contactDisplayName, avatarURL: nil, isCurrentUser: !message.inbound)
         // We don't need to initialize the properties that we overrode with computed properties
         super.init(id: message.id, user: user, createdAt: message.timestamp, text: "")

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -202,7 +202,7 @@ struct ChatView: View {
             }
             messages.append(ChatViewMessage(ObservableKVOWrapper(newMLMessage)))
         } messageBuilder: { message, viewModel, positionInUserGroup, positionInMessagesSection, positionInCommentsGroup, showContextMenuClosure, messageActionClosure, showAttachmentClosure in
-            MessageView(message: (message as! ChatViewMessage).message, viewModel: viewModel, positionInUserGroup: positionInUserGroup, positionInMessagesSection: positionInMessagesSection)
+            MessageView(message: (message as! ChatViewMessage), viewModel: viewModel, positionInUserGroup: positionInUserGroup, positionInMessagesSection: positionInMessagesSection)
         }
         .showNetworkConnectionProblem(false)
 //         .enableLoadMore(pageSize: 3) { message in
@@ -421,13 +421,26 @@ struct ChatView: View {
 }
 
 class ChatViewMessage: ExyteChat.Message {
-    let message: ObservableKVOWrapper<MLMessage>
-
+    let innerMessage: ObservableKVOWrapper<MLMessage>
+    private var subscriptions: Set<AnyCancellable> = Set()
+    override var text: String {
+        get {
+            return innerMessage.retracted ? "This message got retracted" : innerMessage.messageText
+        }
+        set {}
+    }
     init(_ message: ObservableKVOWrapper<MLMessage>) {
-        self.message = message
-        let messageText = message.retracted ? NSLocalizedString("This message got retracted", comment: "") : message.messageText
+        self.innerMessage = message
         let user = ExyteChat.User(id: message.senderID, name: message.contactDisplayName, avatarURL: nil, isCurrentUser: !message.inbound)
-        super.init(id: message.id, user: user, createdAt: message.timestamp, text: messageText)
+        // We don't need to initialize the properties that we overrode with computed properties
+        super.init(id: message.id, user: user, createdAt: message.timestamp, text: "")
+
+        // Forward innerMessage changes as ChatViewMessage changes
+        innerMessage.objectWillChange
+            .sink { [weak self] _ in
+                self?.objectWillChange.send()
+            }
+            .store(in: &subscriptions)
     }
 }
 
@@ -484,12 +497,13 @@ public extension ExyteChat.MessageView {
 //         }
     }
 }*/
+
 struct MessageView: View {
-    @StateObject var message: ObservableKVOWrapper<MLMessage>
+    @StateObject var message: ChatViewMessage
     @ObservedObject var viewModel: ExyteChat.ChatViewModel
     let positionInUserGroup: PositionInUserGroup
     let positionInMessagesSection: PositionInMessagesSection
-    init(message: ObservableKVOWrapper<MLMessage>, viewModel: ChatViewModel, positionInUserGroup: PositionInUserGroup, positionInMessagesSection: PositionInMessagesSection) {
+    init(message: ChatViewMessage, viewModel: ChatViewModel, positionInUserGroup: PositionInUserGroup, positionInMessagesSection: PositionInMessagesSection) {
         _message = StateObject(wrappedValue: message)
         self.viewModel = viewModel
         self.positionInUserGroup = positionInUserGroup
@@ -498,7 +512,7 @@ struct MessageView: View {
     var body: some View {
         ExyteChat.MessageView(
             viewModel: viewModel,
-            message: ChatViewMessage(message),
+            message: message,
             positionInUserGroup: positionInUserGroup,
             positionInMessagesSection: positionInMessagesSection,
             chatType: .conversation,

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/monal-im/ExyteChat",
         "state": {
           "branch": "main",
-          "revision": "120f7d960e67d36f7f411a03cca9ad5344c26021",
+          "revision": "5fc74bbfca31413706b8f5812531d58c8cc677b3",
           "version": null
         }
       },


### PR DESCRIPTION
Quoting #1462:

> We want to be able to do something like this:
> 
>1. A view using an `@StateObject` to a class named `ChatViewMessage` and using its `text` property in the view body
> 
>2. The `ChatViewMessage` class being a child of the ExyteChat `open class Message: ObservableObject, Identifiable`
> 
>3. The `ChatViewMessage` class having a property `innerMessage` of type `ObservableKVOWrapper<MLMessage>`
> 
>4. The `ChatViewMessage` class having an `@Published` computed property of type `String` named `text`, that always returns the `innerMessage.messageText` value. This property overwrites the `@Published public var text: String` property of the base class
> 
> 
> Unfortunately, step 4 is a problem here, apparently you cannot overwrite a stored property with a computed one :(

Actually, it turns out you can override a stored property with a computed one: you need to provide both a getter and a setter when overriding, and the setter can be empty.

So, I did the steps quoted above. But I ran into [The Nested Observables Problem in SwiftUI](https://developer.apple.com/forums/thread/761399):
> Basically, when a parent object holds a child object that is also an ObservableObject SwiftUI does not automatically update the view to reflect changes in the child object.

The solution was to either use the iOS17+ `@Observable` macro (both in Monal and ExyteChat), or to manually listen for changes to `MLMessage` in `ChatViewMessage` and call `objectWillChange.send()`

I chose the latter solution, as it's only a few lines of code, and we can easily migrate to `@Observable` later.

This fixes #1462 (without introducing a new protocol)