### PR TITLE
Don't hardcode macOS and Xcode versions for automated tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ permissions: {}
 
 jobs:
   run_tests:
-    runs-on: macos-14
+    runs-on: macos-latest
     name: Run automated tests
     steps:
       - uses: actions/checkout@v4
@@ -27,8 +27,6 @@ jobs:
           lfs: true
       - name: Checkout submodules
         run: git submodule update -f --init --remote
-      - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_16.2.app/Contents/Developer'
       - name: Build rust
         run: bash ./rust/build-rust.sh
       - name: Install pods


### PR DESCRIPTION
The CI failures we had when Github switched macos-latest from macos-14 to macos-15 were due to the Xcode version being hardcoded to 16.2

Don't hardcode the Xcode version, and switch back to the macos-latest image (which is macos-15, and its default Xcode version is 16.4)

This reverts commits abb21500c9f91573d4706408b9598aa2bed36f06 and 24e220411b9741da41d4871fa7ff4e0b759d0ee6.