### PR TITLE
Don't crash when an attachment's mimeType can't be guessed from its file extension

### DIFF
--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1195,7 +1195,10 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
             }
             
             //try to generate video thumbnail
-            [self generateVideoThumbnailFromFile:url.path havingMimeType:[UTType typeWithFilenameExtension:url.pathExtension].preferredMIMEType andFileExtension:url.pathExtension].then(^(UIImage* image) {
+            NSString* mimeType = [UTType typeWithFilenameExtension:url.pathExtension].preferredMIMEType;
+            if(!mimeType)
+                mimeType = @"application/octet-stream";
+            [self generateVideoThumbnailFromFile:url.path havingMimeType:mimeType andFileExtension:url.pathExtension].then(^(UIImage* image) {
                 payload[@"preview"] = image;
                 DDLogVerbose(@"Managed to generate thumbnail for url=%@ using generateVideoThumbnailFromFile: %@", url, image);
                 [url stopAccessingSecurityScopedResource];


### PR DESCRIPTION
On macOS, the following statement returns `nil` for .mkv and .patch files:
`[UTType typeWithFilenameExtension:url.pathExtension].preferredMIMEType`

Provide a fallback mimeType to avoid crashing when trying to upload files with these extensions.