### PR TITLE
6.4.14-b2

### DIFF
--- a/.github/workflows/develop-push.yml
+++ b/.github/workflows/develop-push.yml
@@ -92,16 +92,16 @@ jobs:
          name: monal-ios
          path: "Monal/build/ipa/Monal.alpha.ipa"
          if-no-files-found: error
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #    name: monal-catalyst-dsym
-      #    path: Monal/build/macos_Monal.xcarchive/dSYMs
-      #    if-no-files-found: error
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #    name: monal-ios-dsym
-      #    path: Monal/build/ios_Monal.xcarchive/dSYMs
-      #    if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+         name: monal-catalyst-dsym
+         path: Monal/build/macos_Monal.Alpha.xcarchive/dSYMs
+         if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+         name: monal-ios-dsym
+         path: Monal/build/ios_Monal.Alpha.xcarchive/dSYMs
+         if-no-files-found: error
       # - name: Update translations
       #   run: |
       #     chmod +x ./scripts/updateLocalization.sh

--- a/.github/workflows/quicksy.build-push.yml
+++ b/.github/workflows/quicksy.build-push.yml
@@ -126,11 +126,11 @@ jobs:
           name: monal-ios
           path: Monal/build/ipa/Quicksy.ipa
           if-no-files-found: error
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: monal-ios-dsym
-      #     path: Monal/build/ios_Monal.xcarchive/dSYMs
-      #     if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: monal-ios-dsym
+          path: Monal/build/ios_Monal.xcarchive/dSYMs
+          if-no-files-found: error
       - name: validate ios app
         run: xcrun altool --validate-app --file ./Monal/build/ipa/Quicksy.ipa --type ios -u $(cat /Users/ci/apple_connect_upload_mail.txt) -p "$(cat /Users/ci/apple_connect_upload_secret.txt)"
       - name: push tag to stable repo

--- a/.github/workflows/stable.build-push.yml
+++ b/.github/workflows/stable.build-push.yml
@@ -121,16 +121,16 @@ jobs:
           name: monal-ios
           path: Monal/build/ipa/Monal.ipa
           if-no-files-found: error
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: monal-catalyst-dsym
-      #     path: Monal/build/macos_Monal.xcarchive/dSYMs
-      #     if-no-files-found: error
-      # - uses: actions/upload-artifact@v4
-      #   with:
-      #     name: monal-ios-dsym
-      #     path: Monal/build/ios_Monal.xcarchive/dSYMs
-      #     if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: monal-catalyst-dsym
+          path: Monal/build/macos_Monal.xcarchive/dSYMs
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: monal-ios-dsym
+          path: Monal/build/ios_Monal.xcarchive/dSYMs
+          if-no-files-found: error
       - name: validate ios app
         run: xcrun altool --validate-app --file ./Monal/build/ipa/Monal.ipa --type ios -u $(cat /Users/ci/apple_connect_upload_mail.txt) -p "$(cat /Users/ci/apple_connect_upload_secret.txt)"
       - name: push tag to stable repo

--- a/Monal/Classes/ActiveChatsViewController.m
+++ b/Monal/Classes/ActiveChatsViewController.m
@@ -800,7 +800,7 @@ static NSMutableSet* _pushWarningDisplayed;
             @throw [NSException exceptionWithName:@"RuntimeException" reason:@"Connected xmpp* object for accountNo is nil!" userInfo:accountDict];
         
         prependToViewQueue((^(PMKResolver resolve) {
-            if(![_mamWarningDisplayed containsObject:accountNo] && account.accountState >= kStateBound && account.connectionProperties.accountDiscoDone)
+            if(![_mamWarningDisplayed containsObject:accountNo] && account.accountState >= kStateInitStarted && account.connectionProperties.accountDiscoDone)
             {
                 if(![account.connectionProperties.accountDiscoFeatures containsObject:@"urn:xmpp:mam:2"])
                 {
@@ -825,7 +825,7 @@ static NSMutableSet* _pushWarningDisplayed;
         }));
         
         prependToViewQueue((^(PMKResolver resolve) {
-            if(![_smacksWarningDisplayed containsObject:accountNo] && account.accountState >= kStateBound)
+            if(![_smacksWarningDisplayed containsObject:accountNo] && account.accountState >= kStateInitStarted)
             {
                 if(!account.connectionProperties.supportsSM3)
                 {
@@ -850,7 +850,7 @@ static NSMutableSet* _pushWarningDisplayed;
         }));
         
         prependToViewQueue((^(PMKResolver resolve) {
-            if(![_pushWarningDisplayed containsObject:accountNo] && account.accountState >= kStateBound && account.connectionProperties.accountDiscoDone)
+            if(![_pushWarningDisplayed containsObject:accountNo] && account.accountState >= kStateInitStarted && account.connectionProperties.accountDiscoDone)
             {
                 if(![account.connectionProperties.accountDiscoFeatures containsObject:@"urn:xmpp:push:0"])
                 {

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -223,10 +223,17 @@
 -(void) setSpeaker:(BOOL) speaker
 {
     @synchronized(self) {
+        DDLogError(@"*** setSpeaker:%@ called...", bool2str(speaker));
         if(self.webRTCClient == nil || self.audioSession == nil)
+        {
+            DDLogError(@"*** setSpeaker: not ready: %@, %@", self.webRTCClient, self.audioSession);
             return;
+        }
         if(_speaker == speaker)
+        {
+            DDLogError(@"*** setSpeaker: called but identical...");
             return;
+        }
         _speaker = speaker;
         if(_speaker)
             [self.webRTCClient speakerOn];
@@ -476,7 +483,10 @@
     [[RTCAudioSession sharedInstance] setIsAudioEnabled:YES];
     [[RTCAudioSession sharedInstance] unlockForConfiguration];
     if(self.callType == MLCallTypeVideo)
+    {
+        DDLogError(@"*** Activating speaker...");
         self.speaker = YES;
+    }
 }
 
 -(void) didDeactivateAudioSession:(AVAudioSession*) audioSession
@@ -1699,15 +1709,15 @@
 {
     DDLogVerbose(@"Audio route changed: %@", notification);
     DDLogVerbose(@"Current audio route: %@", self.audioSession.currentRoute);
-    BOOL speaker = NO;
-    for(AVAudioSessionPortDescription* port in self.audioSession.currentRoute.outputs)
-        if(port.portType == AVAudioSessionPortBuiltInSpeaker)
-            speaker = YES;
-    
-    if(speaker)
-        self.speaker = YES;
-    else
-        self.speaker = NO;
+//     BOOL speaker = NO;
+//     for(AVAudioSessionPortDescription* port in self.audioSession.currentRoute.outputs)
+//         if(port.portType == AVAudioSessionPortBuiltInSpeaker)
+//             speaker = YES;
+//     
+//     if(speaker)
+//         self.speaker = YES;
+//     else
+//         self.speaker = NO;
 }
 
 -(MLCallEncryptionState) encryptionTypeForDeviceid:(NSNumber* _Nonnull) deviceid

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -475,6 +475,8 @@
     [[RTCAudioSession sharedInstance] audioSessionDidActivate:audioSession];
     [[RTCAudioSession sharedInstance] setIsAudioEnabled:YES];
     [[RTCAudioSession sharedInstance] unlockForConfiguration];
+    if(self.callType == MLCallTypeVideo)
+        self.speaker = YES;
 }
 
 -(void) didDeactivateAudioSession:(AVAudioSession*) audioSession

--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -169,6 +169,7 @@ static inline NSString* _Nonnull LocalizationNotNeeded(NSString* _Nonnull s)
 
 #define kMLIsLoggedInNotice @"kMLIsLoggedInNotice"
 #define kMLResourceBoundNotice @"kMLResourceBoundNotice"
+#define kMLSessionInitNotice @"kMLSessionInitNotice"
 #define kMonalFinishedCatchup @"kMonalFinishedCatchup"
 #define kMonalFinishedOmemoBundleFetch @"kMonalFinishedOmemoBundleFetch"
 #define kMonalOmemoStateUpdated @"kMonalOmemoStateUpdated"

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -265,9 +265,11 @@ $$class_handler(handleBind, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode))
     accountDict[kResource] = account.connectionProperties.identity.resource;
     [[DataLayer sharedInstance] updateAccounWithDictionary:accountDict];
     
+    [account earlyInitSession];
+    
     if(account.connectionProperties.supportsSM3)
     {
-        MLXMLNode *enableNode = [[MLXMLNode alloc]
+        MLXMLNode* enableNode = [[MLXMLNode alloc]
             initWithElement:@"enable"
             andNamespace:@"urn:xmpp:sm:3"
             withAttributes:@{@"resume": @"true"}

--- a/Monal/Classes/MLLogFileManager.m
+++ b/Monal/Classes/MLLogFileManager.m
@@ -80,4 +80,9 @@ static NSString* appName = @"Monal";
     return (hasProperPrefix && hasProperSuffix);
 }
 
+-(BOOL) shouldLockLogFile:(NSString*) filePath
+{
+    return YES;
+}
+
 @end

--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -88,7 +88,6 @@ static NSDictionary* _optionalGroupConfigOptions;
     _hasFetchedBookmarks = NO;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleResourceBound:) name:kMLResourceBoundNotice object:nil];
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleSessionInit:) name:kMLSessionInitNotice object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleCatchupDone:) name:kMonalFinishedCatchup object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleSentMessage:) name:kMonalSentMessageNotice object:nil];
     return self;
@@ -172,18 +171,6 @@ static NSDictionary* _optionalGroupConfigOptions;
             //load all bookmarks 2 items as soon as our catchup is done (+notify only provides one/the last item)
             _hasFetchedBookmarks = NO;
         }
-    }
-}
-
--(void) handleSessionInit:(NSNotification*) notification
-{
-    //this event will be called as soon as we are starting to initialize our session, but BEFORE mam catchup happens
-    //NOTE: this event won't be called for smacks resumes!
-    if(_account == ((xmpp*)notification.object))
-    {
-        //join MUCs from (current) muc_favorites db, the pending bookmarks fetch will join the remaining currently unknown mucs
-        for(NSString* room in [[DataLayer sharedInstance] listMucsForAccount:_account.accountNo])
-            [self join:room];
     }
 }
 

--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -23,7 +23,7 @@
 #import "MLOMEMO.h"
 #import "MLImageManager.h"
 
-#define CURRENT_MUC_STATE_VERSION @9
+#define CURRENT_MUC_STATE_VERSION @10
 
 @interface MLMucProcessor()
 {
@@ -33,6 +33,7 @@
     NSMutableDictionary* _roomFeatures;
     NSMutableDictionary* _creating;
     NSMutableDictionary* _joining;
+    NSMutableSet* _joined;
     NSMutableSet* _destroying;
     NSMutableSet* _firstJoin;
     NSMutableDictionary* _changingName;
@@ -77,6 +78,7 @@ static NSDictionary* _optionalGroupConfigOptions;
     _roomFeatures = [NSMutableDictionary new];
     _creating = [NSMutableDictionary new];
     _joining = [NSMutableDictionary new];
+    _joined = [NSMutableSet new];
     _destroying = [NSMutableSet new];
     _firstJoin = [NSMutableSet new];
     _changingName = [NSMutableDictionary new];
@@ -112,6 +114,7 @@ static NSDictionary* _optionalGroupConfigOptions;
         _roomFeatures = [state[@"roomFeatures"] mutableCopy];
         _creating = [state[@"creating"] mutableCopy];
         _joining = [state[@"joining"] mutableCopy];
+        _joined = [state[@"joined"] mutableCopy];
         _destroying = [state[@"destroying"] mutableCopy];
         _firstJoin = [state[@"firstJoin"] mutableCopy];
         _changingName = [state[@"changingName"] mutableCopy];
@@ -129,6 +132,7 @@ static NSDictionary* _optionalGroupConfigOptions;
             @"roomFeatures": [_roomFeatures copy],
             @"creating": [_creating copy],
             @"joining": [_joining copy],
+            @"joined": [_joined copy],
             @"destroying": [_destroying copy],
             @"firstJoin": [_firstJoin copy],
             @"changingName": [_changingName copy],
@@ -148,6 +152,7 @@ static NSDictionary* _optionalGroupConfigOptions;
     if(_account == ((xmpp*)notification.object))
     {
         @synchronized(_stateLockObject) {
+            _joined = [NSMutableSet new];
             _roomFeatures = [NSMutableDictionary new];
             _destroying = [NSMutableSet new];
             _changingName = [NSMutableDictionary new];
@@ -212,6 +217,13 @@ static NSDictionary* _optionalGroupConfigOptions;
 {
     @synchronized(_stateLockObject) {
         return _joining[room] != nil;
+    }
+}
+
+-(BOOL) isJoined:(NSString*) room
+{
+    @synchronized(_stateLockObject) {
+        return [_joined containsObject:room];
     }
 }
 
@@ -282,7 +294,7 @@ static NSDictionary* _optionalGroupConfigOptions;
     }
     
     //check for all other errors (these can happen if the muc is discoverable but joining somehow fails nonetheless like with biboumi)
-    if([presenceNode check:@"/<type=error>/error<type=wait>"])
+    if([presenceNode check:@"/<type=error>/error<type=wait>"] && ([self isJoining:presenceNode.fromUser] || [self isJoined:presenceNode.fromUser]))
     {
         DDLogError(@"Got transient muc error presence of %@: %@", presenceNode.fromUser, [presenceNode findFirst:@"error"]);
         [self removeRoomFromJoining:presenceNode.fromUser];
@@ -297,7 +309,7 @@ static NSDictionary* _optionalGroupConfigOptions;
         [self handleError:[NSString stringWithFormat:NSLocalizedString(@"Temporary failure to enter Group/Channel: %@", @""), presenceNode.fromUser] forMuc:presenceNode.fromUser withNode:presenceNode andIsSevere:NO];
         return;
     }
-    else if([presenceNode check:@"/<type=error>"])
+    else if([presenceNode check:@"/<type=error>"] && ([self isJoining:presenceNode.fromUser] || [self isJoined:presenceNode.fromUser]))
     {
         DDLogError(@"Got permanent muc error presence of %@: %@", presenceNode.fromUser, [presenceNode findFirst:@"error"]);
         [self removeRoomFromJoining:presenceNode.fromUser];
@@ -849,8 +861,11 @@ $$
             {
                 DDLogInfo(@"Successfully joined muc %@...", node.fromUser);
                 
-                //we are joined now, remove from joining list
-                [self removeRoomFromJoining:node.fromUser];
+                //we are joined now, remove from joining list and add to joined list
+                @synchronized(_stateLockObject) {
+                    [self removeRoomFromJoining:node.fromUser];
+                    [_joined addObject:node.fromUser];
+                }
                 
                 //we joined successfully --> add muc to our favorites (this will use the already up to date nick from buddylist db table)
                 //and update bookmarks if this was the first time we joined this muc

--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -88,6 +88,7 @@ static NSDictionary* _optionalGroupConfigOptions;
     _hasFetchedBookmarks = NO;
     
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleResourceBound:) name:kMLResourceBoundNotice object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleSessionInit:) name:kMLSessionInitNotice object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleCatchupDone:) name:kMonalFinishedCatchup object:nil];
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleSentMessage:) name:kMonalSentMessageNotice object:nil];
     return self;
@@ -151,6 +152,7 @@ static NSDictionary* _optionalGroupConfigOptions;
     //NOTE: this event won't be called for smacks resumes!
     if(_account == ((xmpp*)notification.object))
     {
+        //reset our state
         @synchronized(_stateLockObject) {
             _joined = [NSMutableSet new];
             _roomFeatures = [NSMutableDictionary new];
@@ -170,7 +172,15 @@ static NSDictionary* _optionalGroupConfigOptions;
             //load all bookmarks 2 items as soon as our catchup is done (+notify only provides one/the last item)
             _hasFetchedBookmarks = NO;
         }
-            
+    }
+}
+
+-(void) handleSessionInit:(NSNotification*) notification
+{
+    //this event will be called as soon as we are starting to initialize our session, but BEFORE mam catchup happens
+    //NOTE: this event won't be called for smacks resumes!
+    if(_account == ((xmpp*)notification.object))
+    {
         //join MUCs from (current) muc_favorites db, the pending bookmarks fetch will join the remaining currently unknown mucs
         for(NSString* room in [[DataLayer sharedInstance] listMucsForAccount:_account.accountNo])
             [self join:room];

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -26,7 +26,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-static const size_t MIN_OMEMO_KEYS = 90;
+static const size_t MIN_OMEMO_KEYS = 80;
 static const size_t MAX_OMEMO_KEYS = 100;
 static const int KEY_SIZE = 16;
 

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -173,7 +173,7 @@ static const int KEY_SIZE = 16;
 #ifndef DISABLE_OMEMO
     if(self.account.accountNo.intValue == ((xmpp*)notification.object).accountNo.intValue)
     {
-        DDLogInfo(@"We did a non-smacks-resume reconnect, resetting some of our state...");
+        DDLogInfo(@"We did a non-smacks-resume reconnect, resetting some of our state (MLOMEMO instance=%@)...", self);
         DDLogVerbose(@"Current state: %@", self.state);
         
         //we bound a new xmpp session --> reset our whole state

--- a/Monal/Classes/MLPubSub.m
+++ b/Monal/Classes/MLPubSub.m
@@ -96,7 +96,7 @@ $$
     DDLogInfo(@"Fetching node '%@' at jid '%@' using callback %@...", node, jid, handler);
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedFetchNodeHandler, handleFetchInvalidation, $ID(node), $ID(jid), $ID(itemsList), $HANDLER(handler))];
@@ -144,7 +144,7 @@ $$
     DDLogInfo(@"Subscribing to node '%@' at jid '%@' using callback %@...", node, jid, handler);
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedSubscribeToNodeHandler, handleSubscribeInvalidation, $ID(node), $ID(jid), $HANDLER(handler))];
@@ -227,7 +227,7 @@ $$
 {
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedConfigureNodeHandler, handleConfigFormResultInvalidation, $ID(node), $ID(configOptions), $HANDLER(handler))];
@@ -304,7 +304,7 @@ $$
 {
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedRetractItemWithIdHandler, handleRetractResultInvalidation, $ID(itemId), $ID(node), $HANDLER(handler))];
@@ -341,7 +341,7 @@ $$
 {
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedPurgeNodeNodeHandler, handlePurgeOrDeleteResultInvalidation, $ID(node), $HANDLER(handler))];
@@ -375,7 +375,7 @@ $$
 {
     xmpp* account = _account;
     
-    if(account.accountState < kStateBound || !account.connectionProperties.accountDiscoDone)
+    if(account.accountState < kStateInitStarted || !account.connectionProperties.accountDiscoDone)
     {
         DDLogWarn(@"Queueing pubsub call until account disco is resolved...");
         [_queue addObject:$newHandlerWithInvalidation(self, queuedDeleteNodeHandler, handlePurgeOrDeleteResultInvalidation, $ID(node), $HANDLER(handler))];

--- a/Monal/Classes/MLPubSubProcessor.m
+++ b/Monal/Classes/MLPubSubProcessor.m
@@ -476,6 +476,11 @@ $$class_handler(bookmarks2Retracted, $$ID(xmpp*, account), $$ID(NSString*, room)
     
     if(!success)
     {
+        if([errorIq check:@"/<type=error>/error<type=cancel>/{urn:ietf:params:xml:ns:xmpp-stanzas}item-not-found"])
+        {
+            DDLogDebug(@"Ignoring item-not-found error while retracting bookmark for muc '%@' from pep", room);
+            return;
+        }
         DDLogWarn(@"Could not retract bookmark for muc '%@' from pep!", room);
         [self handleErrorWithDescription:[NSString stringWithFormat:NSLocalizedString(@"Failed to remove bookmark for Group/Channel: %@", @""), room] andAccount:account andErrorIq:errorIq andErrorReason:errorReason andIsSevere:YES];
         return;

--- a/Monal/Classes/MLVoIPProcessor.m
+++ b/Monal/Classes/MLVoIPProcessor.m
@@ -338,7 +338,7 @@ static NSMutableDictionary* _pendingCalls;
                 //wait for our account to connect before initializing webrtc using XEP-0215 iq stanzas
                 //if the user proceeds the call before we are bound, the outgoing proceed message stanza will be queued and sent once we are bound
                 //outgoing iq messages are not queued in all cases (e.g. non-smacks reconnect), hence this waiting loop
-                while(call.account.accountState < kStateBound)
+                while(call.account.accountState < kStateInitStarted)
                     [NSThread sleepForTimeInterval:0.250];
                 
                 DDLogDebug(@"Account is connected, now really initialize WebRTC...");

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -253,7 +253,8 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
     dispatch_source_set_event_handler(_pinger, ^{
         for(xmpp* xmppAccount in [self connectedXMPP])
         {
-            if(xmppAccount.accountState>=kStateBound) {
+            if(xmppAccount.accountState >= kStateInitStarted)
+            {
                 DDLogInfo(@"began a idle ping");
                 [xmppAccount sendPing:LONG_PING];        //long ping timeout because this is a background/interval ping
             }
@@ -444,7 +445,8 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
 -(BOOL) isAccountForIdConnected:(NSNumber*) accountNo
 {
     xmpp* account = [self getConnectedAccountForID:accountNo];
-    if(account.accountState>=kStateBound) return YES;
+    if(account.accountState >= kStateInitStarted)
+        return YES;
     return NO;
 }
 
@@ -810,7 +812,7 @@ $$
     if(account)
     {
         //queue remove contact for execution once bound (e.g. on catchup done)
-        if(account.accountState < kStateBound)
+        if(account.accountState < kStateInitStarted)
         {
             [account addReconnectionHandler:$newHandler(self, handleRemoveContact, $ID(contact))];
             return;
@@ -847,7 +849,7 @@ $$
     if(account)
     {
         //queue add contact for execution once bound (e.g. on catchup done)
-        if(account.accountState < kStateBound)
+        if(account.accountState < kStateInitStarted)
         {
             [account addReconnectionHandler:$newHandler(self, handleAddContact, $ID(contact), $ID(preauthToken))];
             return;

--- a/Monal/Classes/Quicksy_RegisterAccount.swift
+++ b/Monal/Classes/Quicksy_RegisterAccount.swift
@@ -450,7 +450,7 @@ struct Quicksy_RegisterAccount: View {
                 }
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLResourceBoundNotice")).receive(on: RunLoop.main)) { notification in
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLSessionInitNotice")).receive(on: RunLoop.main)) { notification in
             if let xmppAccount = notification.object as? xmpp, let newAccountNo : NSNumber = self.newAccountNo {
                 if(xmppAccount.accountNo.intValue == newAccountNo.intValue) {
                     DispatchQueue.main.async {

--- a/Monal/Classes/RegisterAccount.swift
+++ b/Monal/Classes/RegisterAccount.swift
@@ -458,7 +458,7 @@ struct RegisterAccount: View {
                 }
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLResourceBoundNotice")).receive(on: RunLoop.main)) { notification in
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLSessionInitNotice")).receive(on: RunLoop.main)) { notification in
             if(self.registerComplete == true) {
                 return
             }

--- a/Monal/Classes/SCRAM.h
+++ b/Monal/Classes/SCRAM.h
@@ -29,7 +29,7 @@ typedef NS_ENUM(NSUInteger, MLScramStatus) {
 -(instancetype) initWithUsername:(NSString*) username password:(NSString*) password andMethod:(NSString*) method;
 -(void) setSSDPMechanisms:(NSArray<NSString*>*) mechanisms andChannelBindingTypes:(NSArray<NSString*>* _Nullable) cbTypes;
 
--(NSString*) clientFirstMessageWithChannelBinding:(NSString* _Nullable) channelBindingType;
+-(NSString*) clientFirstMessageWithNoMatchingChannelBindingFound:(BOOL) noMatchingChannelBindingFound andChannelBinding:(NSString* _Nullable) channelBindingType;
 -(MLScramStatus) parseServerFirstMessage:(NSString*) str;
 -(NSString*) clientFinalMessageWithChannelBindingData:(NSData* _Nullable) channelBindingData;
 -(MLScramStatus) parseServerFinalMessage:(NSString*) str;

--- a/Monal/Classes/SCRAM.m
+++ b/Monal/Classes/SCRAM.m
@@ -60,6 +60,7 @@
     _ssdpString = nil;
     _serverFirstMessageParsed = NO;
     _finishedSuccessfully = NO;
+    _ssdpSupported = NO;
     return self;
 }
 
@@ -79,16 +80,24 @@
     DDLogVerbose(@"SDDP string is now: %@", _ssdpString);
 }
 
--(NSString*) clientFirstMessageWithChannelBinding:(NSString* _Nullable) channelBindingType
+-(NSString*) clientFirstMessageWithNoMatchingChannelBindingFound:(BOOL) noMatchingChannelBindingFound andChannelBinding:(NSString* _Nullable) channelBindingType
 {
     MLAssert(!_finishedSuccessfully, @"SCRAM handler finished already!");
     MLAssert(!_serverFirstMessageParsed, @"SCRAM handler already parsed server-first-message!");
-    if(channelBindingType == nil)
-        _gssHeader = @"n,,";                                                                //not supported by us
-    else if(!_usingChannelBinding)
-        _gssHeader = @"y,,";                                                                //supported by us BUT NOT advertised by the server
+    //no matching channel binding could be found, but server advertised channel-binding capability
+    //--> tell the server we DON'T support channel-binding and abort the authentication later on,
+    //    if the server doesn't support SSDP to sign this fact
+    //NOTE: XEP-0440 makes tls-server-end-point mandatory and we support this
+    //NOTE: ==> not having a match almost always means a MITM attacker tampered with the XEP-0440 list
+    if(noMatchingChannelBindingFound)
+        _gssHeader = @"n,,";
+    //supported by us BUT NOT advertised by the server
+    //--> mark this fact so that the server can abort authentication, if this isn't true
+    else if(channelBindingType == nil)
+        _gssHeader = @"y,,";
+    //supported by us AND advertised by the server
     else
-        _gssHeader = [NSString stringWithFormat:@"p=%@,,", channelBindingType];             //supported by us AND advertised by the server
+        _gssHeader = [NSString stringWithFormat:@"p=%@,,", channelBindingType];
     //the g attribute is a random grease to check if servers are rfc compliant (e.g. accept optional attributes)
     _clientFirstMessageBare = [NSString stringWithFormat:@"n=%@,r=%@,g=%@", [self quote:_username], _nonce, [NSUUID UUID].UUIDString];
     return [NSString stringWithFormat:@"%@%@", _gssHeader, _clientFirstMessageBare];
@@ -133,7 +142,7 @@
     //calculate gss header with optional channel binding data
     NSMutableData* gssHeaderWithChannelBindingData = [NSMutableData new];
     [gssHeaderWithChannelBindingData appendData:[_gssHeader dataUsingEncoding:NSUTF8StringEncoding]];
-    if(channelBindingData != nil)
+    if(_usingChannelBinding && channelBindingData != nil)
         [gssHeaderWithChannelBindingData appendData:channelBindingData];
     
     NSData* saltedPassword = [self hashPasswordWithSalt:_salt andIterationCount:_iterationCount];

--- a/Monal/Classes/WelcomeLogIn.swift
+++ b/Monal/Classes/WelcomeLogIn.swift
@@ -249,7 +249,7 @@ struct WelcomeLogIn: View {
                 }
             }
         }
-        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLResourceBoundNotice")).receive(on: RunLoop.main)) { notification in
+        .onReceive(NotificationCenter.default.publisher(for: NSNotification.Name("kMLSessionInitNotice")).receive(on: RunLoop.main)) { notification in
             if let xmppAccount = notification.object as? xmpp, let newAccountNo : NSNumber = self.newAccountNo {
                 if(xmppAccount.accountNo.intValue == newAccountNo.intValue) {
                     DispatchQueue.main.async {

--- a/Monal/Classes/XMPPEdit.m
+++ b/Monal/Classes/XMPPEdit.m
@@ -482,7 +482,7 @@ enum DummySettingsRows {
 -(IBAction) deleteAccountClicked:(id) sender
 {
     xmpp* xmppAccount = [[MLXMPPManager sharedInstance] getConnectedAccountForID:self.accountNo];
-    if(xmppAccount.accountState < kStateBound)
+    if(xmppAccount.accountState < kStateInitStarted)
     {
         UIAlertController* alert = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Error Removing Account", @"")
                                                                         message:NSLocalizedString(@"Your account must be enabled and connected, to be removed from the server!", @"") preferredStyle:UIAlertControllerStyleAlert];

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -27,7 +27,8 @@ typedef NS_ENUM (NSInteger, xmppState) {
     kStateLoggedIn,
     kStateBinding,
     kStateBound,
-    kStateInitStarted,		//is operating normally
+    kStateInitStarted,		//initializing session (smacks resume and non-smacks resume)
+    kStateCatchupDone,		//is operating normally
 };
 
 typedef NS_ENUM (NSInteger, xmppRegistrationState) {

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -26,7 +26,8 @@ typedef NS_ENUM (NSInteger, xmppState) {
     kStateHasStream,
     kStateLoggedIn,
     kStateBinding,
-    kStateBound		//is operating normally
+    kStateBound,
+    kStateInitStarted,		//is operating normally
 };
 
 typedef NS_ENUM (NSInteger, xmppRegistrationState) {
@@ -230,6 +231,7 @@ typedef void (^monal_iq_handler_t)(XMPPIQ* _Nullable);
 -(void) addMessageToMamPageArray:(NSDictionary*) messageDictionary;
 -(NSMutableArray*) getOrderedMamPageFor:(NSString*) mamQueryId;
 -(void) bindResource:(NSString*) resource;
+-(void) earlyInitSession;
 -(void) initSession;
 -(void) sendDisplayMarkerForMessages:(NSArray<MLMessage*>*) unread;
 -(void) publishAvatar:(UIImage*) image;

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1882,7 +1882,7 @@ NSString* const kStanza = @"stanza";
                 [self requestSMAck:NO];                 //request ack again (will only happen if queue is not empty)
             }
         }
-        else if([parsedStanza check:@"/{jabber:client}presence"])
+        else if([parsedStanza check:@"/{jabber:client}presence"] && self.accountState >= kStateInitStarted)
         {
             XMPPPresence* presenceNode = (XMPPPresence*)parsedStanza;
             
@@ -2095,7 +2095,7 @@ NSString* const kStanza = @"stanza";
             //only mark stanza as handled *after* processing it
             [self incrementLastHandledStanzaWithDelayedReplay:delayedReplay];
         }
-        else if([parsedStanza check:@"/{jabber:client}message"])
+        else if([parsedStanza check:@"/{jabber:client}message"] && self.accountState >= kStateInitStarted)
         {
             //outerMessageNode and messageNode are the same for messages not carrying a carbon copy or mam result
             XMPPMessage* originalParsedStanza = (XMPPMessage*)[parsedStanza copy];
@@ -2287,6 +2287,9 @@ NSString* const kStanza = @"stanza";
             //only mark stanza as handled *after* processing it
             [self incrementLastHandledStanzaWithDelayedReplay:delayedReplay];
         }
+        //nearly all iqs accepted must be a response to something requested
+        //--> no kStateInitStarted, kStateBound or kStateBinding gatekeeping needed
+        //see processUnboundIq:forAccount: in MLIQProcessor.m for more information
         else if([parsedStanza check:@"/{jabber:client}iq"])
         {
             XMPPIQ* iqNode = (XMPPIQ*)parsedStanza;
@@ -2351,7 +2354,7 @@ NSString* const kStanza = @"stanza";
             //only mark stanza as handled *after* processing it
             [self incrementLastHandledStanzaWithDelayedReplay:delayedReplay];
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}enabled"])
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}enabled"] && self.accountState == kStateBound)
         {
             NSMutableArray* stanzas;
             @synchronized(_stateLockObject) {
@@ -2481,7 +2484,7 @@ NSString* const kStanza = @"stanza";
                 [self bindResource:self.connectionProperties.identity.resource];
             }
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState >= kStateBound && !self.resuming)
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState == kStateBound && !self.resuming)
         {
             //we landed here because smacks enable failed
             
@@ -2872,6 +2875,7 @@ NSString* const kStanza = @"stanza";
         }
         else
         {
+            //this includes spurious message/presence errors generated on bind by prosody's *broken smacks module* on and reflected by MUCs
             DDLogWarn(@"Ignoring unhandled top-level xml element <%@>: %@", parsedStanza.element, parsedStanza);
         }
     }

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -3180,8 +3180,7 @@ NSString* const kStanza = @"stanza";
     //check if the server activated SASL2 after previously only upporting SASL1
     else if([[DataLayer sharedInstance] isPlainActivatedForAccount:self.accountNo] && ((NSNumber*)checkProperSasl2Support()).boolValue)
     {
-        DDLogInfo(@"We detected SASL2 SCRAM support, deactivating forced SASL1 PLAIN fallback and retrying using SASL2...");
-        [[DataLayer sharedInstance] deactivatePlainForAccount:self.accountNo];
+        DDLogInfo(@"We detected SASL2 SCRAM support, retrying using SASL2...");
         //try again, this time using sasl2
         return [self handleFeaturesBeforeAuth:parsedStanza withForceSasl2:YES];
     }

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -2599,25 +2599,11 @@ NSString* const kStanza = @"stanza";
             NSString* innerSASLData = [[NSString alloc] initWithData:[parsedStanza findFirst:@"/{urn:xmpp:sasl:2}challenge#|base64"] encoding:NSUTF8StringEncoding];
             switch([self->_scramHandler parseServerFirstMessage:innerSASLData]) {
                 case MLScramStatusSSDPTriggered: deactivate_account = YES; message = NSLocalizedString(@"Detected ongoing MITM attack via SSDP, aborting authentication and disabling account to limit damage. You should try to reenable your account once you are in a clean networking environment again.", @""); break;
-                case MLScramStatusNonceError: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (nonce error), disconnecting!", @"parenthesis should be verbatim"); break;
-                case MLScramStatusUnsupportedMAttribute: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (m-attr error), disconnecting!", @"parenthesis should be verbatim"); break;
-                case MLScramStatusIterationCountInsecure: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (iteration count too low), disconnecting!", @"parenthesis should be verbatim"); break;
+                case MLScramStatusNonceError: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (nonce error), disconnecting!", @"parenthesis should remain in english"); break;
+                case MLScramStatusUnsupportedMAttribute: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (m-attr error), disconnecting!", @"parenthesis should remain in english"); break;
+                case MLScramStatusIterationCountInsecure: deactivate_account = NO; message = NSLocalizedString(@"Error handling SASL challenge of server (iteration count too low), disconnecting!", @"parenthesis should remain in english"); break;
                 case MLScramStatusServerFirstOK: deactivate_account = NO; message = nil; break;        //everything is okay
                 default: unreachable(@"wrong status for scram message!"); break;
-            }
-            
-            //check for incomplete XEP-0440 support (not implementing mandatory tls-server-end-point channel-binding) not mitigated by SSDP
-            //(we allow either support for tls-server-end-point or SSDP signed non-support)
-            if([kServerDoesNotFollowXep0440Error isEqualToString:[self channelBindingToUse]])
-            {
-                MLXMLNode* streamError = [[MLXMLNode alloc] initWithElement:@"stream:error" withAttributes:@{@"type": @"cancel"} andChildren:@[
-                    [[MLXMLNode alloc] initWithElement:@"undefined-condition" andNamespace:@"urn:ietf:params:xml:ns:xmpp-streams" withAttributes:@{} andChildren:@[] andData:nil],
-                    [[MLXMLNode alloc] initWithElement:@"text" andNamespace:@"urn:ietf:params:xml:ns:xmpp-streams" withAttributes:@{} andChildren:@[] andData:kServerDoesNotFollowXep0440Error],
-                ] andData:nil];
-                [self disconnectWithStreamError:streamError andExplicitLogout:YES];
-                
-                //make sure this error is reported, even if there are other SRV records left (we disconnect here and won't try again)
-                [HelperTools postError:NSLocalizedString(@"Either this is a man-in-the-middle attack OR your server neither implements XEP-0474 nor does it fully implement XEP-0440 which mandates support for tls-server-end-point channel-binding. In either case you should inform your server admin! Account disabled now.", @"") withNode:nil andAccount:self andIsSevere:YES andDisableAccount:YES];
             }
             
             if(message != nil)
@@ -2647,7 +2633,32 @@ NSString* const kStanza = @"stanza";
                 return;
             }
             
+            // we allow one of these three cases:
+            // 1. we allow non-support of channel-binding altogether (no -PLUS methods and no XEP-0440 list advertised by server)
+            //    in this case, we send a "y,," gss-header indicating we would have used channel-binding if the server
+            //    would have advertised support
+            //    --> the server will abort authentication, if it did advertise support, but a MITM stripped it off
+            // 2. we allow an SSDP signed XEP-0440 list not containing tls-server-end-point
+            //    --> since this is signed by SSDP, it cannot have been caused by a MITM attacker
+            // 3. we allow a XEP-0440 list containing tls-server-end-point. support for this cb-type this is mandatory via XEP-0440.
+            //    --> non-support for tls-server-end-point is likely caused by a MITM attacker (SSDP isn't supported to authenticate this!)
+            // ==> abort authentication if cb-types were anounced, but the list doesn't contain tls-server-end-point and this wasn't
+            //     signed by SSDP (the check for SSDP is done in [self channelBindingToUse].
+            if(_supportedChannelBindings != nil && [kServerDoesNotFollowXep0440Error isEqualToString:[self channelBindingToUse]])
+            {
+                MLXMLNode* streamError = [[MLXMLNode alloc] initWithElement:@"stream:error" withAttributes:@{@"type": @"cancel"} andChildren:@[
+                    [[MLXMLNode alloc] initWithElement:@"undefined-condition" andNamespace:@"urn:ietf:params:xml:ns:xmpp-streams" withAttributes:@{} andChildren:@[] andData:nil],
+                    [[MLXMLNode alloc] initWithElement:@"text" andNamespace:@"urn:ietf:params:xml:ns:xmpp-streams" withAttributes:@{} andChildren:@[] andData:kServerDoesNotFollowXep0440Error],
+                ] andData:nil];
+                [self disconnectWithStreamError:streamError andExplicitLogout:YES];
+                
+                //make sure this error is reported, even if there are other SRV records left (we disconnect here and won't try again)
+                [HelperTools postError:NSLocalizedString(@"Either this is a man-in-the-middle attack OR your server neither implements XEP-0474 nor does it fully implement XEP-0440 which mandates support for tls-server-end-point channel-binding. In either case you should inform your server admin! Account disabled now.", @"") withNode:nil andAccount:self andIsSevere:YES andDisableAccount:YES];
+            }
+            
             NSData* channelBindingData = nil;
+            //this can only be the case if it was closed shortly before handling this stanza (race condition)
+            //in this case we'll abort the auth after handling the challenge, so not adding cb-data is fine here
             if([((MLStream*)self->_oStream) streamStatus] == NSStreamStatusOpen)
                 channelBindingData = [((MLStream*)self->_oStream) channelBindingDataForType:[self channelBindingToUse]];
             MLXMLNode* responseXML = [[MLXMLNode alloc] initWithElement:@"response" andNamespace:@"urn:xmpp:sasl:2" withAttributes:@{} andChildren:@[] andData:[HelperTools encodeBase64WithString:[self->_scramHandler clientFinalMessageWithChannelBindingData:channelBindingData]]];
@@ -3091,6 +3102,8 @@ NSString* const kStanza = @"stanza";
     else if([parsedStanza check:@"{urn:xmpp:sasl:2}authentication/mechanism"] && (![[DataLayer sharedInstance] isPlainActivatedForAccount:self.accountNo] || forceSasl2))
     {
         DDLogDebug(@"Trying SASL2...");
+        __block BOOL supportsScram = NO;
+        __block BOOL supportsPlus = NO;
         
         weakify(self);
         _blockToCallOnTCPOpen = ^{
@@ -3098,6 +3111,24 @@ NSString* const kStanza = @"stanza";
             
             if([self->_supportedSaslMechanisms containsObject:@"PLAIN"])
                 DDLogWarn(@"Server supports SASL2 PLAIN, ignoring because this is insecure!");
+            
+            //no channel-bindings were announced using XEP-0440, but the server offered -PLUS methods
+            //--> this is an implementation bug because XEP-0388 demands XEP-440 support
+            if(self->_supportedChannelBindings == nil && supportsPlus)
+            {
+                clearPipelineCacheOrReportSevereError(NSLocalizedString(@"Your server offered SCRAM-PLUS methods, but did not announce any channel-binding types using XEP-0440 which is mandatory by XEP-0388. This is either an ongoing man-in-the-middle attack or a server misconfiguration, disabling account!", @""));
+                return;
+            }
+            
+            //the server announced channel-bindings but did not offer any SCRAM-PLUS methods
+            //--> this is likely a MITM, because announcing cb-methods but not offering any -PLUS methods is moot
+            if(self->_supportedChannelBindings != nil && !supportsPlus)
+            {
+                clearPipelineCacheOrReportSevereError(NSLocalizedString(@"Your server announced channel-binding types but did not offer any SCRAM-PLUS methods. This is likely an ongoing man-in-the-middle attack (but could also be a server misconfiguration), disabling account!", @""));
+                return;
+            }
+            
+            BOOL noMatchingChannelBindingFound = self->_supportedChannelBindings!=nil && ([self channelBindingToUse]==nil || [kServerDoesNotFollowXep0440Error isEqualToString:[self channelBindingToUse]]);
             
             //create list of upgradable scram mechanisms and pick the first one (highest security) the server and we support
             //but only do so, if we are using channel-binding for additional security
@@ -3127,7 +3158,7 @@ NSString* const kStanza = @"stanza";
                         andNamespace:@"urn:xmpp:sasl:2"
                         withAttributes:@{@"mechanism": mechanism}
                         andChildren:@[
-                            [[MLXMLNode alloc] initWithElement:@"initial-response" andData:[HelperTools encodeBase64WithString:[self->_scramHandler clientFirstMessageWithChannelBinding:[self channelBindingToUse]]]],
+                            [[MLXMLNode alloc] initWithElement:@"initial-response" andData:[HelperTools encodeBase64WithString:[self->_scramHandler clientFirstMessageWithNoMatchingChannelBindingFound:noMatchingChannelBindingFound andChannelBinding:[self channelBindingToUse]]]],
                             [[MLXMLNode alloc] initWithElement:@"user-agent" withAttributes:@{
                                 @"id":[[[UIDevice currentDevice] identifierForVendor] UUIDString],
                             } andChildren:@[
@@ -3152,16 +3183,18 @@ NSString* const kStanza = @"stanza";
         _supportedSaslMechanisms = [NSSet setWithArray:[parsedStanza find:@"{urn:xmpp:sasl:2}authentication/mechanism#"]];
         
         //extract supported channel-binding types
-        if([parsedStanza check:@"{urn:xmpp:sasl-cb:0}sasl-channel-binding"])
-            _supportedChannelBindings = [NSSet setWithArray:[parsedStanza find:@"{urn:xmpp:sasl-cb:0}sasl-channel-binding/channel-binding@type"]];
-        else
+        _supportedChannelBindings = [NSSet setWithArray:[parsedStanza find:@"{urn:xmpp:sasl-cb:0}sasl-channel-binding/channel-binding@type"]];
+        if([_supportedChannelBindings count] == 0)
             _supportedChannelBindings = nil;
         
         //check if the server supports *any* scram method and wait for TLS connection establishment if so
-        BOOL supportsScram = NO;
         for(NSString* mechanism in [SCRAM supportedMechanismsIncludingChannelBinding:YES])
             if([_supportedSaslMechanisms containsObject:mechanism])
+            {
                 supportsScram = YES;
+                if(mechanism.length > 5 && [@"-PLUS" isEqualToString:[mechanism substringFromIndex:mechanism.length-5]])
+                    supportsPlus = YES;
+            }
         
         //directly call our continuation block if SCRAM is not supported, because _blockToCallOnTCPOpen() will throw an error then
         //(we currently only support SCRAM for SASL2)
@@ -3331,11 +3364,16 @@ NSString* const kStanza = @"stanza";
     //if our scram handshake finished without negotiating a mutually supported channel-binding and this was not backed by SSDP --> report error
     if(self->_scramHandler.serverFirstMessageParsed && !self->_scramHandler.ssdpSupported)
     {
-        DDLogWarn(@"Could not find any supported channel-binding type, this MUST be a mitm attack, because tls-server-end-point is mandatory via XEP-0440!");
-        return kServerDoesNotFollowXep0440Error;     //this will trigger a disconnect
+        if(_supportedChannelBindings != nil)
+            DDLogWarn(@"Could not find any supported channel-binding type and non-matching cb-list wasn't signed by XEP-0474 (SSDP) --> this MUST be a MITM attack, because tls-server-end-point is mandatory via XEP-0440!");
+        else
+            DDLogWarn(@"No channel-binding types were announced and this wasnt signed by XEP-0474 (SSDP) --> this MAY be a MITM attack that will be mitigated by the 'y,,' gss header!");
+        return kServerDoesNotFollowXep0440Error;
     }
-    if(!self->_scramHandler.serverFirstMessageParsed)
-        DDLogWarn(@"Could not find any supported channel-binding type, this COULD be a mitm attack (check via XEP-0474 pending)!");
+    else if(!self->_scramHandler.serverFirstMessageParsed)
+        DDLogWarn(@"Could not find any supported channel-binding type, this COULD be a mitm attack (check via XEP-0474 (SSDP) pending)!");
+    else if(self->_scramHandler.ssdpSupported)
+        DDLogInfo(@"XEP-0474 (SSDP) signed non-matching cb-list found, this is allowed and NOT a MITM attack");
     return nil;
 }
 

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -335,7 +335,7 @@ NSString* const kStanza = @"stanza";
         DDLogInfo(@"New caps hash: %@", hash);
         _capsHash = hash;
         //broadcast new version hash (will be ignored if we are not bound)
-        if(_accountState >= kStateBound)
+        if(_accountState >= kStateInitStarted)
             [self sendPresence];
     }
 }
@@ -1099,7 +1099,7 @@ NSString* const kStanza = @"stanza";
             DDLogInfo(@"doing explicit logout (xmpp stream close)");
             self->_reconnectBackoffTime = 0.0;
             [self unfreezeSendQueue];      //make sure the queue is operational again
-            if(self.accountState>=kStateBound)
+            if(self.accountState >= kStateInitStarted)
                 [self->_sendQueue addOperations: @[[NSBlockOperation blockOperationWithBlock:^{
                     //disable push for this node
                     if([self.connectionProperties.accountDiscoFeatures containsObject:@"urn:xmpp:push:0"])
@@ -1174,7 +1174,7 @@ NSString* const kStanza = @"stanza";
             else
             {
                 //send one last ack before closing the stream (xep version 1.5.2)
-                if(self.accountState>=kStateBound)
+                if(self.accountState >= kStateInitStarted)
                 {
                     [self->_sendQueue addOperations:@[[NSBlockOperation blockOperationWithBlock:^{
                         [self sendLastAck];
@@ -1433,7 +1433,7 @@ NSString* const kStanza = @"stanza";
                 }]] waitUntilFinished:YES];
             //we have to wait for the stanza/nonza to be handled before parsing the next one to not introduce race conditions
             //between the response to our pipelined stream restart and the parser reset in the sasl success handler
-            }]] waitUntilFinished:(self->_accountState < kStateBound ? YES : NO)];
+            }]] waitUntilFinished:(self->_accountState < kStateInitStarted ? YES : NO)];
         }];
     }
     else
@@ -1530,7 +1530,7 @@ NSString* const kStanza = @"stanza";
             return;
         }
         
-        if(self.accountState<kStateBound)
+        if(self.accountState < kStateInitStarted)
         {
             DDLogInfo(@"ping attempted before logged in and bound, ignoring ping.");
             return;
@@ -1563,8 +1563,8 @@ NSString* const kStanza = @"stanza";
                 self->_pingTimer = nil;
                 [self dispatchAsyncOnReceiveQueue: ^{
                     //check if someone already called reconnect or disconnect while we were waiting for the ping
-                    //(which was called while we still were >= kStateBound)
-                    if(self.accountState<kStateBound)
+                    //(which was called while we still were >= kStateInitStarted)
+                    if(self.accountState < kStateInitStarted)
                         DDLogInfo(@"ping took too long, but reconnect or disconnect already in progress, ignoring");
                     else
                     {
@@ -1802,7 +1802,7 @@ NSString* const kStanza = @"stanza";
     MLXMLNode* rNode;
     @synchronized(_stateLockObject) {
         unsigned long unackedCount = (unsigned long)[self.unAckedStanzas count];
-        if(self.accountState>=kStateBound && self.connectionProperties.supportsSM3 &&
+        if(self.accountState >= kStateInitStarted && self.connectionProperties.supportsSM3 &&
             ((!self.smacksRequestInFlight && unackedCount>0) || force)
         ) {
             DDLogVerbose(@"requesting smacks ack...");
@@ -1828,8 +1828,8 @@ NSString* const kStanza = @"stanza";
 
 -(void) sendSMAck:(BOOL) queuedSend
 {
-    //don't send anything before a resource is bound
-    if(self.accountState<kStateBound || !self.connectionProperties.supportsSM3)
+    //don't send anything before a resource is bound and smacks was enabled
+    if(self.accountState < kStateInitStarted || !self.connectionProperties.supportsSM3)
         return;
     
     NSDictionary* dic;
@@ -1864,11 +1864,11 @@ NSString* const kStanza = @"stanza";
     //only process most stanzas/nonzas after having a secure context
     if(self.connectionProperties.server.isDirectTLS || self->_startTLSComplete)
     {
-        if([parsedStanza check:@"/{urn:xmpp:sm:3}r"] && self.connectionProperties.supportsSM3 && self.accountState>=kStateBound)
+        if([parsedStanza check:@"/{urn:xmpp:sm:3}r"] && self.connectionProperties.supportsSM3 && self.accountState >= kStateInitStarted)
         {
             [self sendSMAck:YES];
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}a"] && self.connectionProperties.supportsSM3 && self.accountState>=kStateBound)
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}a"] && self.connectionProperties.supportsSM3 && self.accountState >= kStateInitStarted)
         {
             NSNumber* h = [parsedStanza findFirst:@"/@h|int"];
             if(h==nil)
@@ -2380,7 +2380,7 @@ NSString* const kStanza = @"stanza";
             //message duplicates are possible in this scenario, but that's better than dropping messages
             [self resendUnackedMessageStanzasOnly:stanzas];
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}resumed"] && self.connectionProperties.supportsSM3 && self.accountState<kStateBound)
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}resumed"] && self.connectionProperties.supportsSM3 && self.accountState < kStateBound)
         {
             NSNumber* h = [parsedStanza findFirst:@"/@h|int"];
             if(h==nil)
@@ -2388,10 +2388,12 @@ NSString* const kStanza = @"stanza";
             self.resuming = NO;
             self.isDoingFullReconnect = NO;
 
-            //now we are bound again
-            _accountState = kStateBound;
+            //now we are initialized again (the following block is *largely* taken from earlyInitSession
+            DDLogInfo(@"Session resumed, initializing state...");
+            self.isDoingFullReconnect = YES;
             _connectedTime = [NSDate date];
             _reconnectBackoffTime = 0;
+            _accountState = kStateInitStarted;
             [self accountStatusChanged];
 
             @synchronized(_stateLockObject) {
@@ -2454,7 +2456,7 @@ NSString* const kStanza = @"stanza";
             //initialize stanza counter for statistics
             [self initCatchupStats];
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState<kStateBound && self.resuming)
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState < kStateBound && self.resuming)
         {
             //we landed here because smacks resume failed
             
@@ -2479,7 +2481,7 @@ NSString* const kStanza = @"stanza";
                 [self bindResource:self.connectionProperties.identity.resource];
             }
         }
-        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState>=kStateBound && !self.resuming)
+        else if([parsedStanza check:@"/{urn:xmpp:sm:3}failed"] && self.connectionProperties.supportsSM3 && self.accountState >= kStateBound && !self.resuming)
         {
             //we landed here because smacks enable failed
             
@@ -2918,7 +2920,7 @@ NSString* const kStanza = @"stanza";
                 [_xmlParser abortParsing];
                 _xmlParser = nil;
                 //throw away all parsed but not processed stanzas (we aborted the parser right now)
-                //the xml parser will fill the parse queue synchronously while < kStateBound
+                //the xml parser will fill the parse queue synchronously while < kStateInitStarted
                 //--> no stanzas/nonzas will leak into the parse queue after resetting the parser and clearing the parse queue
                 [_parseQueue cancelAllOperations];
             }
@@ -3401,13 +3403,13 @@ NSString* const kStanza = @"stanza";
             }
         }
         
-        //only send nonzas if we are >kStateDisconnected and stanzas if we are >=kStateBound
+        //only send nonzas if we are >kStateDisconnected and stanzas if we are >=kStateInitStarted
         //only exceptions: an outgoing bind request or jabber:iq:register stanza (this is allowed before binding a resource)
         BOOL isBindRequest = [stanza isKindOfClass:[XMPPIQ class]] && [stanza check:@"{urn:ietf:params:xml:ns:xmpp-bind}bind/resource"];
         BOOL isRegisterRequest = [stanza isKindOfClass:[XMPPIQ class]] && [stanza check:@"{jabber:iq:register}query"];
         BOOL isPreauthRegisterRequest = [stanza isKindOfClass:[XMPPIQ class]] && [stanza check:@"/<type=set>/{urn:xmpp:pars:0}preauth"];
         if(
-            self.accountState>=kStateBound ||
+            self.accountState>=kStateInitStarted ||
             (self.accountState>kStateDisconnected && (![stanza isKindOfClass:[XMPPStanza class]] || isBindRequest || isRegisterRequest || isPreauthRegisterRequest))
         )
         {
@@ -3553,7 +3555,7 @@ NSString* const kStanza = @"stanza";
 
 -(void) sendChatState:(BOOL) isTyping toContact:(nonnull MLContact*) contact
 {
-    if(self.accountState < kStateBound)
+    if(self.accountState < kStateInitStarted)
         return;
 
     XMPPMessage* messageNode = [[XMPPMessage alloc] initToContact:contact];
@@ -3939,7 +3941,7 @@ NSString* const kStanza = @"stanza";
         {
             //this will count any stanza between our bind result and smacks enable result but gets reset to sane values
             //once the smacks enable result surfaces (e.g. the wrong counting will be ignored later)
-            if(self.accountState>=kStateBound)
+            if(self.accountState >= kStateInitStarted)
                 self.lastHandledInboundStanza = [NSNumber numberWithInteger:[self.lastHandledInboundStanza integerValue] + 1];
         }
         [self persistState];        //make sure we persist our state, even if smacks is not supported
@@ -4108,8 +4110,8 @@ NSString* const kStanza = @"stanza";
 
 -(void) sendPresence
 {
-    //don't send presences if we are not bound
-    if(_accountState < kStateBound)
+    //don't send presences if we are not bound and smacks enabled
+    if(_accountState < kStateInitStarted)
         return;
     
     XMPPPresence* presence = [[XMPPPresence alloc] initWithHash:_capsHash];
@@ -4134,9 +4136,9 @@ NSString* const kStanza = @"stanza";
     [self sendIq:roster withHandler:$newHandler(MLIQProcessor, handleRoster)];
 }
 
--(void) initSession
+-(void) earlyInitSession
 {
-    DDLogInfo(@"Now bound, initializing new xmpp session");
+    DDLogInfo(@"Now bound, resetting state...");
     self.isDoingFullReconnect = YES;
     
     //we are now bound
@@ -4148,6 +4150,18 @@ NSString* const kStanza = @"stanza";
     
     //inform other parts of monal about our new state
     [[MLNotificationQueue currentQueue] postNotificationName:kMLResourceBoundNotice object:self];
+    [self accountStatusChanged];
+}
+
+-(void) initSession
+{
+    DDLogInfo(@"Now bound and past smacks enable, initializing new xmpp session...");
+    
+    //indicate we are bound and smacks enabled now
+    _accountState = kStateInitStarted;
+    
+    //inform other parts of monal about our new state
+    [[MLNotificationQueue currentQueue] postNotificationName:kMLSessionInitNotice object:self];
     [self accountStatusChanged];
     
     //now fetch roster, request disco and send initial presence
@@ -4358,9 +4372,9 @@ NSString* const kStanza = @"stanza";
 {
     [self dispatchOnReceiveQueue: ^{
         //don't send anything before a resource is bound
-        if(self.accountState<kStateBound || ![self.connectionProperties.serverFeatures check:@"{urn:xmpp:csi:0}csi"])
+        if(self.accountState < kStateInitStarted || ![self.connectionProperties.serverFeatures check:@"{urn:xmpp:csi:0}csi"])
         {
-            DDLogVerbose(@"NOT sending csi state, because we are not bound yet (or csi is not supported)");
+            DDLogVerbose(@"NOT sending csi state, because we are not bound and smacks enabled yet (or csi is not supported)");
             return;
         }
         
@@ -5018,7 +5032,7 @@ NSString* const kStanza = @"stanza";
         //*after* processing an incoming burst of stanzas (which is potentially causing an outgoing burst of stanzas)
         //this reduces the requests to an absolute minimum while still maintaining the rule to request an ack
         //for every stanza (e.g. until the smacks queue is empty) and not sending an ack if one is already in flight
-        if(_accountState>=kStateBound)
+        if(_accountState >= kStateInitStarted)
             [_parseQueue addOperations:@[[NSBlockOperation blockOperationWithBlock:^{
                 [self requestSMAck:NO];
             }]] waitUntilFinished:NO];
@@ -5135,7 +5149,7 @@ NSString* const kStanza = @"stanza";
 #else
     NSString* pushToken = [MLXMPPManager sharedInstance].pushToken;
     NSString* selectedPushServer = [[HelperTools defaultsDB] objectForKey:@"selectedPushServer"];
-    if(pushToken == nil || [pushToken length] == 0 || selectedPushServer == nil || self.accountState < kStateBound)
+    if(pushToken == nil || [pushToken length] == 0 || selectedPushServer == nil || self.accountState < kStateInitStarted)
     {
         DDLogInfo(@"NOT registering and enabling push: %@ token: %@ (accountState: %ld, supportsPush: %@)", selectedPushServer, pushToken, (long)self.accountState, bool2str([self.connectionProperties.accountDiscoFeatures containsObject:@"urn:xmpp:push:0"]));
         return;
@@ -5230,7 +5244,7 @@ NSString* const kStanza = @"stanza";
 {
     //only handle iq timeouts while the parseQueue is almost empty
     //(a long backlog in the parse queue could trigger spurious iq timeouts for iqs we already received an answer to, but didn't process it yet)
-    if([_parseQueue operationCount] > 4 || _accountState < kStateBound || !_catchupDone)
+    if([_parseQueue operationCount] > 4 || _accountState < kStateInitStarted || !_catchupDone)
         return;
     
     //update idle timers, too
@@ -5318,9 +5332,9 @@ NSString* const kStanza = @"stanza";
 //this method is needed to not have a retain cycle (happens when using a block instead of this method in mamFinishedFor:)
 -(void) _handleInternalMamFinishedFor:(NSString*) archiveJid
 {
-    if(self.accountState < kStateBound)
+    if(self.accountState < kStateInitStarted)
     {
-        DDLogWarn(@"Aborting delayed replay because not >= kStateBound anymore! Remaining stanzas will be kept in DB and be handled after next smacks reconnect.");
+        DDLogWarn(@"Aborting delayed replay because not >= kStateInitStarted anymore! Remaining stanzas will be kept in DB and be handled after next smacks reconnect.");
         return;
     }
     

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1696,11 +1696,23 @@ NSString* const kStanza = @"stanza";
 {
     NSMutableArray* ackHandlerToCall = [[NSMutableArray alloc] initWithCapacity:[_smacksAckHandler count]];
     @synchronized(_stateLockObject) {
+        //sanity check
+        MLAssert(([self.unAckedStanzas count]+[self.lastHandledOutboundStanza unsignedIntValue])==[self.lastOutboundStanza unsignedIntValue], @"Calculated outgoing stanza count and counted one differ!", (@{
+            @"calculated:unAckedStanzas+lastHandledOutboundStanza": @([self.unAckedStanzas count] + [self.lastHandledOutboundStanza unsignedIntValue]),
+            @"counted:lastOutboundStanza": self.lastOutboundStanza,
+        }));
         //stanza counting bugs on the server are fatal
         if(([hvalue unsignedIntValue] - [self.lastHandledOutboundStanza unsignedIntValue]) > [self.unAckedStanzas count])
         {
             self.streamID = nil;        //we don't ever want to resume this
-            NSString* message = @"Server acknowledged more stanzas than sent by client";
+            NSString* message = [NSString stringWithFormat:
+                @"Server acknowledged more stanzas (%@) than sent by client (%@, %@), %@ still waiting to be acked, %@ acked last time",
+                hvalue,
+                @([self.unAckedStanzas count] + [self.lastHandledOutboundStanza unsignedIntValue]),
+                self.lastHandledOutboundStanza,
+                @([self.unAckedStanzas count]),
+                self.lastHandledOutboundStanza
+            ];
             DDLogError(@"Stream error: %@", message);
             [self postError:message withIsSevere:NO];
             MLXMLNode* streamError = [[MLXMLNode alloc] initWithElement:@"stream:error" withAttributes:@{@"type": @"cancel"} andChildren:@[
@@ -1718,7 +1730,7 @@ NSString* const kStanza = @"stanza";
         if([hvalue unsignedIntValue] < [self.lastHandledOutboundStanza unsignedIntValue])
         {
             self.streamID = nil;        //we don't ever want to resume this
-            NSString* message = @"Server acknowledged less stanzas than last time";
+            NSString* message = [NSString stringWithFormat:@"Server acknowledged less stanzas (%@) than last time (%@)", hvalue, self.lastHandledOutboundStanza];
             DDLogError(@"Stream error: %@", message);
             [self postError:message withIsSevere:NO];
             MLXMLNode* streamError = [[MLXMLNode alloc] initWithElement:@"stream:error" withAttributes:@{@"type": @"cancel"} andChildren:@[

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -48,7 +48,7 @@
 
 @import AVFoundation;
 
-#define STATE_VERSION 18
+#define STATE_VERSION 604019
 #define CONNECT_TIMEOUT 7.0
 #define IQ_TIMEOUT 60.0
 NSString* const kQueueID = @"queueID";
@@ -924,6 +924,7 @@ NSString* const kStanza = @"stanza";
         
         //mark this account as currently connecting
         self->_accountState = kStateReconnecting;
+        [self accountStatusChanged];
         
         //only proceed with connection if not concurrent with other processes
         DDLogVerbose(@"Checking remote process lock...");
@@ -936,6 +937,7 @@ NSString* const kStanza = @"stanza";
         {
             DDLogInfo(@"MainApp is running, not connecting (this should transition us into idle state again which will terminate this extension)");
             self->_accountState = kStateDisconnected;
+            [self accountStatusChanged];
             return;
         }
         
@@ -955,6 +957,7 @@ NSString* const kStanza = @"stanza";
         {
             DDLogError(@"Server disallows xmpp connections for account '%@', ignoring login", self.accountNo);
             self->_accountState = kStateDisconnected;
+            [self accountStatusChanged];
             return;
         }
         
@@ -1239,6 +1242,8 @@ NSString* const kStanza = @"stanza";
         //we don't throw away operations in the receive queue because they could be more than just stanzas
         //(for example outgoing messages that should be written to the smacks queue instead of just vanishing in a void)
         //all incoming stanzas in the receive queue will honor the _accountState being lower than kStateReconnecting and be dropped
+        
+        [self accountStatusChanged];
     }];
 }
 
@@ -2391,12 +2396,13 @@ NSString* const kStanza = @"stanza";
             self.resuming = NO;
             self.isDoingFullReconnect = NO;
 
-            //now we are initialized again (the following block is *largely* taken from earlyInitSession
+            //now we are initialized again (the following block is *largely* taken from earlyInitSession)
             DDLogInfo(@"Session resumed, initializing state...");
             self.isDoingFullReconnect = YES;
             _connectedTime = [NSDate date];
             _reconnectBackoffTime = 0;
             _accountState = kStateInitStarted;
+            [[MLNotificationQueue currentQueue] postNotificationName:kMLSessionInitNotice object:self];
             [self accountStatusChanged];
 
             @synchronized(_stateLockObject) {
@@ -2549,6 +2555,7 @@ NSString* const kStanza = @"stanza";
             
             self->_accountState = kStateLoggedIn;
             [[MLNotificationQueue currentQueue] postNotificationName:kMLIsLoggedInNotice object:self];
+            [self accountStatusChanged];
             
             _usableServersList = [NSMutableArray new];       //reset list to start again with the highest SRV priority on next connect
             if(_loginTimer)
@@ -2780,6 +2787,8 @@ NSString* const kStanza = @"stanza";
             //NOTE: we don't have any stream restart when using SASL2
             //NOTE: we don't need to pipeline anything here, because SASL2 sends out the new stream features immediately without a stream restart
             _cachedStreamFeaturesAfterAuth = nil;       //make sure we don't accidentally try to do pipelining
+            
+            [self accountStatusChanged];
         }
         else if([parsedStanza check:@"/{urn:xmpp:sasl:2}continue"])
         {
@@ -2830,7 +2839,10 @@ NSString* const kStanza = @"stanza";
         {
             //prevent reconnect attempt
             if(_accountState < kStateHasStream)
+            {
                 _accountState = kStateHasStream;
+                [self accountStatusChanged];
+            }
             
             //perform logic to handle stream
             if(self.accountState < kStateLoggedIn)
@@ -2854,7 +2866,7 @@ NSString* const kStanza = @"stanza";
                     [self handleFeaturesAfterAuth:parsedStanza];
                 }
                 else
-                    DDLogDebug(@"Stream features (after auth) already read from cache, ignoring incoming stream features (but refreshing cache).\n Cached: %@\nIncoming: %@", _cachedStreamFeaturesAfterAuth, parsedStanza);
+                    DDLogDebug(@"Stream features (after auth) already read from cache, ignoring incoming stream features (but refreshing cache).\nCached: %@\nIncoming: %@", _cachedStreamFeaturesAfterAuth, parsedStanza);
                 _cachedStreamFeaturesAfterAuth = parsedStanza;
             }
         }
@@ -3671,7 +3683,7 @@ NSString* const kStanza = @"stanza";
             [[DataLayer sharedInstance] persistState:values forAccount:self.accountNo];
 
             //debug output
-            DDLogVerbose(@"%@ --> persistState(saved at %@):\n\tisDoingFullReconnect=%@,\n\tlastHandledInboundStanza=%@,\n\tlastHandledOutboundStanza=%@,\n\tlastOutboundStanza=%@,\n\t#unAckedStanzas=%lu%s,\n\tstreamID=%@\n\tlastInteractionDate=%@\n\tpersistentIqHandlers=%@\n\tsupportsHttpUpload=%d\n\tpushEnabled=%d\n\tsupportsPubSub=%d\n\tsupportsModernPubSub=%d\n\tsupportsPubSubMax=%d\n\tsupportsBookmarksCompat=%d\n\taccountDiscoDone=%d\n\t_inCatchup=%@\n\tomemo.state=%@\n\thasSeenOmemoDeviceListAfterOwnDeviceid=%@\n",
+            DDLogVerbose(@"%@ --> persistState(saved at %@):\n\tisDoingFullReconnect=%@,\n\tlastHandledInboundStanza=%@,\n\tlastHandledOutboundStanza=%@,\n\tlastOutboundStanza=%@,\n\t#unAckedStanzas=%lu%s,\n\tstreamID=%@\n\tlastInteractionDate=%@\n\tpersistentIqHandlers=%@\n\tsupportsHttpUpload=%d\n\tpushEnabled=%d\n\tsupportsPubSub=%d\n\tsupportsModernPubSub=%d\n\tsupportsPubSubMax=%d\n\tsupportsBookmarksCompat=%d\n\taccountDiscoDone=%d\n\t_inCatchup=%@\n\tomemo.state=%@\n\thasSeenOmemoDeviceListAfterOwnDeviceid=%@\n\t_cachedStreamFeaturesBeforeAuth=%@\n\t_cachedStreamFeaturesAfterAuth=%@\n",
                 self.accountNo,
                 values[@"stateSavedAt"],
                 bool2str(self.isDoingFullReconnect),
@@ -3691,7 +3703,9 @@ NSString* const kStanza = @"stanza";
                 self.connectionProperties.accountDiscoDone,
                 self->_inCatchup,
                 self.omemo.state,
-                bool2str(self.hasSeenOmemoDeviceListAfterOwnDeviceid)
+                bool2str(self.hasSeenOmemoDeviceListAfterOwnDeviceid),
+                bool2str(self->_cachedStreamFeaturesBeforeAuth!=nil),
+                bool2str(self->_cachedStreamFeaturesAfterAuth!=nil)
             );
             DDLogVerbose(@"%@ --> realPersistState after: used/available memory: %.3fMiB / %.3fMiB)...", self.accountNo, [HelperTools report_memory], (CGFloat)os_proc_available_memory() / 1048576);
         }
@@ -3872,7 +3886,7 @@ NSString* const kStanza = @"stanza";
             }
             
             //debug output
-            DDLogVerbose(@"%@ --> readState(saved at %@):\n\tisDoingFullReconnect=%@,\n\tlastHandledInboundStanza=%@,\n\tlastHandledOutboundStanza=%@,\n\tlastOutboundStanza=%@,\n\t#unAckedStanzas=%lu%s,\n\tstreamID=%@,\n\tlastInteractionDate=%@\n\tpersistentIqHandlers=%@\n\tsupportsHttpUpload=%d\n\tpushEnabled=%d\n\tsupportsPubSub=%d\n\tsupportsModernPubSub=%d\n\tsupportsPubSubMax=%d\n\tsupportsBookmarksCompat=%d\n\taccountDiscoDone=%d\n\t_inCatchup=%@\n\tomemo.state=%@\n\thasSeenOmemoDeviceListAfterOwnDeviceid=%@\n",
+            DDLogVerbose(@"%@ --> readState(saved at %@):\n\tisDoingFullReconnect=%@,\n\tlastHandledInboundStanza=%@,\n\tlastHandledOutboundStanza=%@,\n\tlastOutboundStanza=%@,\n\t#unAckedStanzas=%lu%s,\n\tstreamID=%@,\n\tlastInteractionDate=%@\n\tpersistentIqHandlers=%@\n\tsupportsHttpUpload=%d\n\tpushEnabled=%d\n\tsupportsPubSub=%d\n\tsupportsModernPubSub=%d\n\tsupportsPubSubMax=%d\n\tsupportsBookmarksCompat=%d\n\taccountDiscoDone=%d\n\t_inCatchup=%@\n\tomemo.state=%@\n\thasSeenOmemoDeviceListAfterOwnDeviceid=%@\n\t_cachedStreamFeaturesBeforeAuth=%@\n\t_cachedStreamFeaturesAfterAuth=%@\n",
                 self.accountNo,
                 dic[@"stateSavedAt"],
                 bool2str(self.isDoingFullReconnect),
@@ -3892,7 +3906,9 @@ NSString* const kStanza = @"stanza";
                 self.connectionProperties.accountDiscoDone,
                 self->_inCatchup,
                 self.omemo.state,
-                bool2str(self.hasSeenOmemoDeviceListAfterOwnDeviceid)
+                bool2str(self.hasSeenOmemoDeviceListAfterOwnDeviceid),
+                bool2str(self->_cachedStreamFeaturesBeforeAuth!=nil),
+                bool2str(self->_cachedStreamFeaturesAfterAuth!=nil)
             );
             if(self.unAckedStanzas)
                 for(NSDictionary* dic in self.unAckedStanzas)
@@ -3978,6 +3994,7 @@ NSString* const kStanza = @"stanza";
     
     self.isDoingFullReconnect = YES;
     _accountState = kStateBinding;
+    [self accountStatusChanged];
     
     //delete old resources because we get new presences once we're done initializing the session
     [[DataLayer sharedInstance] resetContactsForAccount:self.accountNo];
@@ -4201,6 +4218,10 @@ NSString* const kStanza = @"stanza";
     
     //fetch current mds state
     [self.pubsub fetchNode:@"urn:xmpp:mds:displayed:0" from:self.connectionProperties.identity.jid withItemsList:nil andHandler:$newHandler(MLPubSubProcessor, handleMdsFetchResult)];
+    
+    //join MUCs from (current) muc_favorites db, the pending bookmarks fetch will join the remaining currently unknown mucs
+    for(NSString* room in [[DataLayer sharedInstance] listMucsForAccount:self.accountID])
+        [self.mucProcessor join:room];
     
     //NOTE: mam query will be done in MLIQProcessor once the disco result for our own jid/account returns
     
@@ -4849,6 +4870,7 @@ NSString* const kStanza = @"stanza";
                         self->_blockToCallOnTCPOpen();
                         self->_blockToCallOnTCPOpen = nil;     //don't call this twice
                     }
+                    [self accountStatusChanged];
                 }];
             }
             break;
@@ -5438,8 +5460,10 @@ NSString* const kStanza = @"stanza";
     }
     [self persistState];
     
+    _accountState = kStateCatchupDone;
     //don't queue this notification because it should be handled INLINE inside the receive queue
     [[NSNotificationCenter defaultCenter] postNotificationName:kMonalFinishedCatchup object:self userInfo:nil];
+    [self accountStatusChanged];
 }
 
 -(void) updateMdsData:(NSDictionary*) mdsData


### PR DESCRIPTION
- Ignore transient MUC errors from prosody
IOS_ONLY - Fix automatic speaker activation in video calls
- Allow SASL2 without channel-binding and SSDP