### PR TITLE
6.4.15-b1

### DIFF
--- a/.github/workflows/beta.build-push.yml
+++ b/.github/workflows/beta.build-push.yml
@@ -124,7 +124,11 @@ jobs:
           echo "******************************"
           echo "* Updating changelog strings *"
           echo "******************************"
+          echo "$changelog"
           echo -n "$changelog" | scripts/update_changelog_repo.py --base-json "./Monal-localization-changelog/translations/changelog/en-US.json" --version "$buildVersion"
+          echo "New basefile:"
+          cat "./Monal-localization-changelog/translations/changelog/en-US.json"
+          echo ""
           cd Monal-localization-changelog
           git diff
           git add -u
@@ -203,12 +207,10 @@ jobs:
         id: appinfo
         run: |
           build_appinfo_entry() {
-            local escaped_name=$(cat ./appstore_metadata/$2/$1/name.txt | jq -sRr @json)
-            local escaped_subtitle=$(cat ./appstore_metadata/$2/$1/subtitle.txt | jq -sRr @json)
             local escaped_marketing_url=$(cat ./appstore_metadata/$2/$1/marketing_url.txt | jq -sRr @json)
             local escaped_privacy_policy_url=$(cat ./appstore_metadata/$2/$1/privacy_url.txt | jq -sRr @json)
             local escaped_description=$(cat ./appstore_metadata/$2/$1/description.txt | jq -sRr @json)
-            local json="{\"name\": $escaped_name, \"subtitle\": $escaped_subtitle, \"feedback_email\": \"info@monal-im.org\", \"marketing_url\": $escaped_marketing_url, \"privacy_policy_url\": $escaped_privacy_policy_url, \"description\": $escaped_description}"
+            local json="{\"feedback_email\": \"info@monal-im.org\", \"marketing_url\": $escaped_marketing_url, \"privacy_policy_url\": $escaped_privacy_policy_url, \"description\": $escaped_description}"
             echo "$json"
           }
           

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1781,7 +1781,7 @@ void swizzle(Class c, SEL orig, SEL new)
                     }
                     DDLogWarn(@"Posting syncError notification for %@...", account.connectionProperties.identity.jid);
                     UNMutableNotificationContent* content = [UNMutableNotificationContent new];
-                    content.title = NSLocalizedString(@"Could not synchronize", @"");
+                    content.title = NSLocalizedString(@"Connectivity issues", @"");
                     content.subtitle = account.connectionProperties.identity.jid;
                     content.body = NSLocalizedString(@"Some messages might wait to be retrieved or sent. Please open the app to retry.", @"");
                     content.sound = [UNNotificationSound defaultSound];


### PR DESCRIPTION
- Add Telugo translations
- Add Czech appstore translation
- Make Appstore metadata translatable via Weblate
- Make Appstore changelog entries translatable via Weblate
- Improve MAM error messages
- Show additional confirmation dialog before sharing location in a chat