### PR TITLE
Improvements and bug fixes

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -882,15 +882,15 @@ class ChatViewMessage: ExyteChat.Message {
                 MLFiletransfer.checkMimeTypeAndSize(forHistoryID: innerMessage.messageDBId)
                 return []
             }
-            let cacheFile = fileInfo.cacheFile as String
-            let attachmentUUID = HelperTools.stringToUUID(cacheFile).uuidString
+            let cacheFilePath = fileInfo.cacheFilePath as String
+            let attachmentUUID = HelperTools.stringToUUID(cacheFilePath).uuidString
             switch fileInfo.mimeType as String {
                 case let mimeType where mimeType.starts(with: "image/"):
-                    let attachment = Attachment(id: attachmentUUID, url: URL(fileURLWithPath: cacheFile), type: .image)
+                    let attachment = Attachment(id: attachmentUUID, url: URL(fileURLWithPath: cacheFilePath), type: .image)
                     return [attachment]
                 case let mimeType where mimeType.starts(with: "video/"):
                     let thumbnail = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
-                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: URL(fileURLWithPath: cacheFile), type: .video, mimeType: mimeType)
+                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: URL(fileURLWithPath: cacheFilePath), type: .video, mimeType: mimeType)
                     return [attachment]
                 default:
                     return []
@@ -910,7 +910,7 @@ class ChatViewMessage: ExyteChat.Message {
             guard (fileInfo.mimeType as String).starts(with: "audio/") else {
                 return nil
             }
-            let fileURL = URL(fileURLWithPath: fileInfo.cacheFile as String)
+            let fileURL = URL(fileURLWithPath: fileInfo.cacheFilePath as String)
             return Recording(duration: fileInfo.mediaDuration, url: fileURL, mimeType: fileInfo.mimeType)
         }
         set {}

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -883,7 +883,8 @@ class ChatViewMessage: ExyteChat.Message {
                 return []
             }
             let cacheFilePath = fileInfo.cacheFilePath as String
-            let attachmentUUID = HelperTools.stringToUUID(cacheFilePath).uuidString
+            let cacheId = fileInfo.cacheId as String
+            let attachmentUUID = HelperTools.stringToUUID(cacheId).uuidString
             switch fileInfo.mimeType as String {
                 case let mimeType where mimeType.starts(with: "image/"):
                     let attachment = Attachment(id: attachmentUUID, url: URL(fileURLWithPath: cacheFilePath), type: .image)

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -809,8 +809,8 @@ class ChatViewMessage: ExyteChat.Message {
                         return """
                         [File transfer; auto-downloading if the settings allow it...]
                         Size: \(humanReadableSize)
-                        MimeType: \(fileInfo.obj.mimeType)
-                        \(innerMessage.obj.encrypted ? "" : "Link: \(fileInfo.url)")
+                        MimeType: \(fileInfo.mimeType as String)
+                        \(innerMessage.encrypted ? "" : "Link: \(fileInfo.url as String)")
                         """
                     case DownloadState.none.rawValue:
                         return "[File transfer; checking the size...]"

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -882,16 +882,16 @@ class ChatViewMessage: ExyteChat.Message {
                 MLFiletransfer.checkMimeTypeAndSize(forHistoryID: innerMessage.messageDBId)
                 return []
             }
-            let cacheFilePath = fileInfo.cacheFilePath as String
+            let fileURL = fileInfo.fileURL as URL
             let cacheId = fileInfo.cacheId as String
             let attachmentUUID = HelperTools.stringToUUID(cacheId).uuidString
             switch fileInfo.mimeType as String {
                 case let mimeType where mimeType.starts(with: "image/"):
-                    let attachment = Attachment(id: attachmentUUID, url: URL(fileURLWithPath: cacheFilePath), type: .image)
+                    let attachment = Attachment(id: attachmentUUID, url: fileURL, type: .image)
                     return [attachment]
                 case let mimeType where mimeType.starts(with: "video/"):
                     let thumbnail = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
-                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: URL(fileURLWithPath: cacheFilePath), type: .video, mimeType: mimeType)
+                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: fileURL, type: .video, mimeType: mimeType)
                     return [attachment]
                 default:
                     return []
@@ -911,7 +911,7 @@ class ChatViewMessage: ExyteChat.Message {
             guard (fileInfo.mimeType as String).starts(with: "audio/") else {
                 return nil
             }
-            let fileURL = URL(fileURLWithPath: fileInfo.cacheFilePath as String)
+            let fileURL = fileInfo.fileURL as URL
             return Recording(duration: fileInfo.mediaDuration, url: fileURL, mimeType: fileInfo.mimeType)
         }
         set {}

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -810,7 +810,7 @@ class ChatViewMessage: ExyteChat.Message {
                         [File transfer; auto-downloading if the settings allow it...]
                         Size: \(humanReadableSize)
                         MimeType: \(fileInfo.mimeType as String)
-                        \(innerMessage.encrypted ? "" : "Link: \(fileInfo.url as String)")
+                        \(innerMessage.encrypted ? "" : "Link: \(fileInfo.downloadURL as String)")
                         """
                     case DownloadState.none.rawValue:
                         return "[File transfer; checking the size...]"

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -519,16 +519,16 @@ struct ChatView: View {
             let mlMessage = (message as! ChatViewMessage).innerMessage.obj
             switch reaction.type {
                 case .emoji(let emoji):
-                    var currentReactions: Set<String> = []
+                    var currentReactions: NSMutableOrderedSet = []
                     for reactionsInfo in mlMessage.reactions {
                         if reactionsInfo.contact.isSelf {
-                            currentReactions = reactionsInfo.reactions
+                            currentReactions = NSMutableOrderedSet(orderedSet: reactionsInfo.reactions)
                         }
                     }
                     if currentReactions.contains(emoji) {
                         currentReactions.remove(emoji)
                     } else {
-                        currentReactions.insert(emoji)
+                        currentReactions.add(emoji)
                     }
                     self.account.sendReactions(currentReactions, for:mlMessage)
             }
@@ -862,7 +862,7 @@ class ChatViewMessage: ExyteChat.Message {
                     retval.append(Reaction(
                         user: ChatViewUser(reactionsInfo.contact as! NSObject&MLContactProtocol),
                         createdAt: reactionsInfo.timestamp,
-                        type: .emoji(reaction),
+                        type: .emoji(reaction as! String),
                         status: .sent
                     ))
                 }

--- a/Monal/Classes/DataLayer.h
+++ b/Monal/Classes/DataLayer.h
@@ -225,7 +225,7 @@ extern NSString* const kMessageTypeFiletransfer;
 -(NSNumber* _Nullable) getRetractionHistoryIDForModeratedStanzaId:(NSString*) stanzaId from:(NSString*) from andAccount:(NSNumber*) accountID;
 
 -(NSNumber* _Nullable) getReactionHistoryIDForMessageIdOrStanzaId:(NSString*) someId inChat:(MLContact*) contact;
--(void) setReactions:(NSSet*) reactions fromJid:(NSString* _Nullable) jid orOccupantId:(NSString* _Nullable) occupantId forHistoryId:(NSNumber*) historyId withDate:(NSDate*) date andActualFrom:(NSString* _Nullable) actualFrom;
+-(void) setReactions:(NSOrderedSet*) reactions fromJid:(NSString* _Nullable) jid orOccupantId:(NSString* _Nullable) occupantId forHistoryId:(NSNumber*) historyId withDate:(NSDate*) date andActualFrom:(NSString* _Nullable) actualFrom;
 -(NSArray<MLReactionsEntry*>*) getReactionsForHistoryId:(NSNumber*) historyId;
 
 -(NSDate* _Nullable) returnTimestampForQuote:(NSNumber*) historyID;

--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -1641,7 +1641,7 @@ static NSDateFormatter* dbFormatter;
     }];
 }
 
--(void) setReactions:(NSSet*) reactions fromJid:(NSString* _Nullable) jid orOccupantId:(NSString* _Nullable) occupantId forHistoryId:(NSNumber*) historyId withDate:(NSDate*) date andActualFrom:(NSString* _Nullable) actualFrom
+-(void) setReactions:(NSOrderedSet*) reactions fromJid:(NSString* _Nullable) jid orOccupantId:(NSString* _Nullable) occupantId forHistoryId:(NSNumber*) historyId withDate:(NSDate*) date andActualFrom:(NSString* _Nullable) actualFrom
 {
     NSString* timestamp = [HelperTools generateDateTimeString:date];
     //user is our primary key (together with message_history_id).
@@ -1649,7 +1649,7 @@ static NSDateFormatter* dbFormatter;
     NSString* user = occupantId;
     if(user == nil)
         user = jid;
-    NSString* reactionsString = [[reactions allObjects] componentsJoinedByString:@""];
+    NSString* reactionsString = [[reactions.set allObjects] componentsJoinedByString:@""];
     MLAssert(user != nil, @"User for reaction should never be nil!");
     return [self.db voidWriteTransaction:^{
         [self.db executeNonQuery:@"INSERT INTO reactions (message_history_id, user, jid, occupant_id, reactions, timestamp, muc_nick) VALUES (?, ?, ?, ?, ?, ?, ?) ON CONFLICT DO UPDATE SET jid=?, occupant_id=?, reactions=?, timestamp=?, muc_nick=?;" andArguments:@[historyId, user, nilWrapper(jid), nilWrapper(occupantId), reactionsString, timestamp, nilWrapper(actualFrom), nilWrapper(jid), nilWrapper(occupantId), reactionsString, timestamp, nilWrapper(actualFrom)]];

--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -219,7 +219,7 @@ void swizzle(Class c, SEL orig, SEL new);
 
 +(NSURL* _Nullable) compressFileAtPath:(NSString*) path withLevel:(NSInteger) level;
 
-+(NSSet*) createReactionsSetFromString:(NSString*) reactions;
++(NSOrderedSet*) createReactionsSetFromString:(NSString*) reactions;
 
 @end
 

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -3463,14 +3463,14 @@ a=%@\r\n", mid, candidate];
     return [NSURL fileURLWithPath:gzipPath];
 }
 
-+(NSSet*) createReactionsSetFromString:(NSString*) reactions
++(NSOrderedSet*) createReactionsSetFromString:(NSString*) reactions
 {
     //remove all vs15 and vs16 modifiers
     reactions = [[reactions componentsSeparatedByString:@"\ufe0e"] componentsJoinedByString:@""];
     reactions = [[reactions componentsSeparatedByString:@"\ufe0f"] componentsJoinedByString:@""];
     
     //"parse" reactions (iterate over grapheme clusters as required in XEP-0444 Business Rules)
-    NSMutableSet* reactionsList = [NSMutableSet new];
+    NSMutableOrderedSet* reactionsList = [NSMutableOrderedSet new];
     [reactions enumerateSubstringsInRange:NSMakeRange(0, [reactions length]) options:NSStringEnumerationByComposedCharacterSequences usingBlock:^(NSString * _Nullable substring, NSRange substringRange __unused, NSRange enclosingRange __unused, BOOL * _Nonnull stop __unused) {
         //add vs16 modifier to every emoji it is allowed
         //see https://www.unicode.org/Public/emoji/latest/emoji-sequences.txt

--- a/Monal/Classes/MLChatImageCell.m
+++ b/Monal/Classes/MLChatImageCell.m
@@ -66,7 +66,7 @@
         {
             self.link = msg.messageText;
             // uses cached file if the file was already downloaded
-            FLAnimatedImage* image = [FLAnimatedImage animatedImageWithGIFData:[NSData dataWithContentsOfFile:info.cacheFile]];
+            FLAnimatedImage* image = [FLAnimatedImage animatedImageWithGIFData:[NSData dataWithContentsOfFile:info.cacheFilePath]];
             if(!image)
                 return;
             _animatedImageView = [FLAnimatedImageView new];
@@ -93,9 +93,9 @@
             AnyPromise* imagePromise = nil;
             // this code already runs in the main queue --> we can't use PMKHang
             if([info.mimeType hasPrefix:@"image/svg"])
-                imagePromise = [HelperTools renderUIImageFromSVGURL:[NSURL fileURLWithPath:info.cacheFile]];
+                imagePromise = [HelperTools renderUIImageFromSVGURL:[NSURL fileURLWithPath:info.cacheFilePath]];
             else
-                imagePromise = [AnyPromise promiseWithValue:[[UIImage alloc] initWithContentsOfFile:info.cacheFile]];
+                imagePromise = [AnyPromise promiseWithValue:[[UIImage alloc] initWithContentsOfFile:info.cacheFilePath]];
             imagePromise.then(^(UIImage* image) {
                 if(!nilExtractor(image))
                     return;

--- a/Monal/Classes/MLContactCell.m
+++ b/Monal/Classes/MLContactCell.m
@@ -70,13 +70,13 @@
             [self showStatusText:NSLocalizedString(@"🔗 A Link", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];
         else if([lastMessage.messageType isEqualToString:kMessageTypeFiletransfer])
         {
-            if([lastMessage.fileInfo.mimeType hasPrefix:@"image/"])
+            if(lastMessage.fileInfo.isImage)
                 [self showStatusText:NSLocalizedString(@"📷 An Image", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];
-            else if([lastMessage.fileInfo.mimeType hasPrefix:@"audio/"])
+            else if(lastMessage.fileInfo.isAudio)
                 [self showStatusText:NSLocalizedString(@"🎵 An Audiomessage", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];
-            else if([lastMessage.fileInfo.mimeType hasPrefix:@"video/"])
+            else if(lastMessage.fileInfo.isVideo)
                 [self showStatusText:NSLocalizedString(@"🎥 A Video", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];
-            else if([lastMessage.fileInfo.mimeType isEqualToString:@"application/pdf"])
+            else if(lastMessage.fileInfo.isPDF)
                 [self showStatusText:NSLocalizedString(@"📄 A Document", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];
             else
                 [self showStatusText:NSLocalizedString(@"📁 A File", @"") inboundDir:lastMessage.inbound fromUser:senderOfLastGroupMsg];

--- a/Monal/Classes/MLFiletransfer.m
+++ b/Monal/Classes/MLFiletransfer.m
@@ -207,7 +207,7 @@ static NSObject* _hardlinkingSyncObject;
             if(!mimeType)
                 mimeType = @"application/octet-stream";
             
-            NSString* cacheFile = [self calculateCacheFileForNewUrl:msg.messageText andMimeType:mimeType];
+            NSString* cacheFilePath = [self calculateCacheFilePathForNewUrl:msg.messageText andMimeType:mimeType];
             
             //encrypted filetransfer
             if([[urlComponents.scheme lowercaseString] isEqualToString:@"aesgcm"])
@@ -237,7 +237,7 @@ static NSObject* _hardlinkingSyncObject;
                         [self markAsComplete:historyId];
                         return;
                     }
-                    [decryptedData writeToFile:cacheFile options:NSDataWritingAtomic error:&error];
+                    [decryptedData writeToFile:cacheFilePath options:NSDataWritingAtomic error:&error];
                     if(error)
                     {
                         DDLogError(@"File download for %@ failed: %@", msg, error);
@@ -245,8 +245,8 @@ static NSObject* _hardlinkingSyncObject;
                         [self markAsComplete:historyId];
                         return;
                     }
-                    MLAssert([_fileManager fileExistsAtPath:cacheFile], @"cache file should be there!", (@{@"cacheFile": cacheFile}));
-                    [HelperTools configureFileProtectionFor:cacheFile];
+                    MLAssert([_fileManager fileExistsAtPath:cacheFilePath], @"cache file should be there!", (@{@"cacheFilePath": cacheFilePath}));
+                    [HelperTools configureFileProtectionFor:cacheFilePath];
                 }
                 else
                 {
@@ -260,8 +260,8 @@ static NSObject* _hardlinkingSyncObject;
             {
                 //hardlink file to our cache directory
                 //it will be removed once this completion returnes, even if moved to a new location (this seems to be a ios16 bug)
-                DDLogInfo(@"Hardlinking downloaded file from '%@' to document cache at '%@'...", [location path], cacheFile);
-                error = [HelperTools hardLinkOrCopyFile:[location path] to:cacheFile];
+                DDLogInfo(@"Hardlinking downloaded file from '%@' to document cache at '%@'...", [location path], cacheFilePath);
+                error = [HelperTools hardLinkOrCopyFile:[location path] to:cacheFilePath];
                 if(error)
                 {
                     DDLogError(@"File download for %@ failed: %@", msg, error);
@@ -269,14 +269,14 @@ static NSObject* _hardlinkingSyncObject;
                     [self markAsComplete:historyId];
                     return;
                 }
-                MLAssert([_fileManager fileExistsAtPath:cacheFile], @"cache file should be there!", (@{@"cacheFile": cacheFile}));
-                [HelperTools configureFileProtectionFor:cacheFile];
+                MLAssert([_fileManager fileExistsAtPath:cacheFilePath], @"cache file should be there!", (@{@"cacheFilePath": cacheFilePath}));
+                [HelperTools configureFileProtectionFor:cacheFilePath];
             }
             
             //hardlink cache file if possible
             [self hardlinkFileForMessage:msg];
             
-            NSNumber* filetransferSize = @([[_fileManager attributesOfItemAtPath:cacheFile error:nil] fileSize]);
+            NSNumber* filetransferSize = @([[_fileManager attributesOfItemAtPath:cacheFilePath error:nil] fileSize]);
             DDLogDebug(@"Updating db and sending out kMonalMessageFiletransferUpdateNotice");
             //update db with content type and size
             [[DataLayer sharedInstance] setFiletransferInfoForHistoryId:historyId withMimeType:mimeType andSize:filetransferSize];
@@ -286,7 +286,7 @@ static NSObject* _hardlinkingSyncObject;
             if(account != nil)      //don't send out update notices for already deleted accounts
                 [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageFiletransferUpdateNotice object:account userInfo:@{ @"message": msg }];
             else
-                [_fileManager removeItemAtPath:cacheFile error:nil];
+                [_fileManager removeItemAtPath:cacheFilePath error:nil];
             
             //download done, remove from "currently checking/downloading list"
             [self markAsComplete:historyId];
@@ -316,28 +316,28 @@ static NSObject* _hardlinkingSyncObject;
 }
 
 
-$$class_handler(handleHardlinking, $$ID(xmpp*, account), $$ID(NSString*, cacheFile), $$ID((NSArray<NSString*>*), hardlinkPathComponents), $$BOOL(direct))
+$$class_handler(handleHardlinking, $$ID(xmpp*, account), $$ID(NSString*, cacheFilePath), $$ID((NSArray<NSString*>*), hardlinkPathComponents), $$BOOL(direct))
     NSError* error;    
     
     if([HelperTools isAppExtension])
     {
-        DDLogWarn(@"NOT hardlinking cache file at '%@' into documents directory at '%@': we STILL are in the appex, rescheduling this to next account connect", cacheFile, [hardlinkPathComponents componentsJoinedByString:@"/"]);
+        DDLogWarn(@"NOT hardlinking cache file at '%@' into documents directory at '%@': we STILL are in the appex, rescheduling this to next account connect", cacheFilePath, [hardlinkPathComponents componentsJoinedByString:@"/"]);
         //the reconnect handler framework will add $ID(account) to the callerArgs, no need to add an accountID etc. here
         //direct=YES is indicating that this hardlinking handler was called directly instead of serializing/unserializing it to/from db
         //AND that we are in the mainapp currently
         //always use direct = NO here, to make sure the file is hardlinkable even if the direct handling depicted above changes and
         //calls from the mainapp are serialized to db, too
         [account addReconnectionHandler:$newHandler(self, handleHardlinking,
-            $ID(cacheFile),
+            $ID(cacheFilePath),
             $ID(hardlinkPathComponents),
             $BOOL(direct, NO)
         )];
         return;
     }
     
-    if(![_fileManager fileExistsAtPath:cacheFile])
+    if(![_fileManager fileExistsAtPath:cacheFilePath])
     {
-        DDLogWarn(@"Could not hardlink cacheFile, file not present: %@", cacheFile);
+        DDLogWarn(@"Could not hardlink cache file, file not present: %@", cacheFilePath);
         return;
     }
     
@@ -346,42 +346,42 @@ $$class_handler(handleHardlinking, $$ID(xmpp*, account), $$ID(NSString*, cacheFi
         //this allows hardlinking later on because now the mainapp owns that file while it had only read/write access before
         if(!direct)
         {
-            NSString* cacheFileTMP = [cacheFile.stringByDeletingLastPathComponent stringByAppendingPathComponent:[NSString stringWithFormat:@"tmp.%@", cacheFile.lastPathComponent]];
-            DDLogInfo(@"Copying appex-created cache file '%@' to '%@' before deleting old file and renaming our copy...", cacheFile, cacheFileTMP);
-            [_fileManager removeItemAtPath:cacheFileTMP error:nil];     //remove tmp file if already present
-            [_fileManager copyItemAtPath:cacheFile toPath:cacheFileTMP error:&error];
+            NSString* cacheFilePathTMP = [cacheFilePath.stringByDeletingLastPathComponent stringByAppendingPathComponent:[NSString stringWithFormat:@"tmp.%@", cacheFilePath.lastPathComponent]];
+            DDLogInfo(@"Copying appex-created cache file '%@' to '%@' before deleting old file and renaming our copy...", cacheFilePath, cacheFilePathTMP);
+            [_fileManager removeItemAtPath:cacheFilePathTMP error:nil];     //remove tmp file if already present
+            [_fileManager copyItemAtPath:cacheFilePath toPath:cacheFilePathTMP error:&error];
             if(error)
             {
                 DDLogError(@"Could not copy cache file to tmp file: %@", error);
 #ifdef DEBUG
                 @throw [NSException exceptionWithName:@"ERROR_WHILE_COPYING_CACHEFILE" reason:@"Could not copy cacheFile!" userInfo:@{
-                    @"cacheFile": cacheFile,
-                    @"cacheFileTMP": cacheFileTMP
+                    @"cacheFilePath": cacheFilePath,
+                    @"cacheFilePathTMP": cacheFilePathTMP
                 }];
 #endif
                 return;
             }
             
-            [_fileManager removeItemAtPath:cacheFile error:&error];
+            [_fileManager removeItemAtPath:cacheFilePath error:&error];
             if(error)
             {
                 DDLogError(@"Could not delete original cache file: %@", error);
 #ifdef DEBUG
                 @throw [NSException exceptionWithName:@"ERROR_WHILE_DELETING_CACHEFILE" reason:@"Could not delete cacheFile!" userInfo:@{
-                    @"cacheFile": cacheFile
+                    @"cacheFilePath": cacheFilePath
                 }];
 #endif
                 return;
             }
             
-            [_fileManager moveItemAtPath:cacheFileTMP toPath:cacheFile error:&error];
+            [_fileManager moveItemAtPath:cacheFilePathTMP toPath:cacheFilePath error:&error];
             if(error)
             {
                 DDLogError(@"Could not rename tmp file to cache file: %@", error);
 #ifdef DEBUG
                 @throw [NSException exceptionWithName:@"ERROR_WHILE_RENAMING_CACHEFILE" reason:@"Could not rename cacheFileTMP to cacheFile!" userInfo:@{
-                    @"cacheFile": cacheFile,
-                    @"cacheFileTMP": cacheFileTMP
+                    @"cacheFilePath": cacheFilePath,
+                    @"cacheFilePathTMP": cacheFilePathTMP
                 }];
 #endif
                 return;
@@ -394,7 +394,7 @@ $$class_handler(handleHardlinking, $$ID(xmpp*, account), $$ID(NSString*, cacheFi
             for(NSString* pathComponent in hardlinkPathComponents)
                 hardLink = [hardLink URLByAppendingPathComponent:pathComponent];
             
-            DDLogInfo(@"Hardlinking cache file at '%@' into documents directory at '%@'...", cacheFile, hardLink);
+            DDLogInfo(@"Hardlinking cache file at '%@' into documents directory at '%@'...", cacheFilePath, hardLink);
             if(![_fileManager fileExistsAtPath:[hardLink.URLByDeletingLastPathComponent path]])
             {
                 DDLogVerbose(@"Creating hardlinking dir struct at '%@'...", hardLink.URLByDeletingLastPathComponent); 
@@ -407,11 +407,11 @@ $$class_handler(handleHardlinking, $$ID(xmpp*, account), $$ID(NSString*, cacheFi
             
             //don't throw any error if the file aready exists, because it could be a rare collision (we only use 16 bit random numbers to keep the file prefix short)
             if([_fileManager fileExistsAtPath:[hardLink path]])
-                DDLogWarn(@"Not hardlinking file '%@' to '%@': file already exists (maybe a rare collision?)...", cacheFile, hardLink);
+                DDLogWarn(@"Not hardlinking file '%@' to '%@': file already exists (maybe a rare collision?)...", cacheFilePath, hardLink);
             else
             {
-                DDLogVerbose(@"Hardlinking cache file '%@' to '%@'...", cacheFile, hardLink);
-                error = [HelperTools hardLinkOrCopyFile:cacheFile to:[hardLink path]];
+                DDLogVerbose(@"Hardlinking cache file '%@' to '%@'...", cacheFilePath, hardLink);
+                error = [HelperTools hardLinkOrCopyFile:cacheFilePath to:[hardLink path]];
                 if(error)
                 {
                     DDLogError(@"Error creating hardlink: %@", error);
@@ -484,12 +484,12 @@ $$
     NSString* fileBasename = [fileInfo.filename stringByDeletingPathExtension];
     [hardlinkPathComponents addObject:[[NSString stringWithFormat:@"%@_%@", fileBasename, randomID] stringByAppendingPathExtension:fileExtension]];
     
-    MLAssert(fileInfo.cacheFile != nil, @"cacheFile should never be empty here!", (@{@"fileInfo": fileInfo}));
+    MLAssert(fileInfo.cacheFilePath != nil, @"cacheFilePath should never be empty here!", (@{@"fileInfo": fileInfo}));
     
-    MLHandler* handler = $newHandler(self, handleHardlinking, $ID(cacheFile, fileInfo.cacheFile), $ID(hardlinkPathComponents), $BOOL(direct, NO));
+    MLHandler* handler = $newHandler(self, handleHardlinking, $ID(cacheFilePath, fileInfo.cacheFilePath), $ID(hardlinkPathComponents), $BOOL(direct, NO));
     if([HelperTools isAppExtension])
     {
-        DDLogWarn(@"NOT hardlinking cache file at '%@' into documents directory at %@: we are in the appex, rescheduling this to next account connect", fileInfo.cacheFile, [hardlinkPathComponents componentsJoinedByString:@"/"]);
+        DDLogWarn(@"NOT hardlinking cache file at '%@' into documents directory at %@: we are in the appex, rescheduling this to next account connect", fileInfo.cacheFilePath, [hardlinkPathComponents componentsJoinedByString:@"/"]);
         [account addReconnectionHandler:handler];       //the reconnect handler framework will add $ID(account) to the callerArgs, no need to add an accountID etc. here
     }
     else
@@ -502,8 +502,8 @@ $$
         return;
     DDLogInfo(@"Deleting file for url %@", msg.messageText);
     MLFiletransferInfo* info = msg.fileInfo;
-    DDLogDebug(@"Deleting file in cache: %@", info.cacheFile);
-    [_fileManager removeItemAtPath:info.cacheFile error:nil];
+    DDLogDebug(@"Deleting file in cache: %@", info.cacheFilePath);
+    [_fileManager removeItemAtPath:info.cacheFilePath error:nil];
     if([info.mimeType hasPrefix:@"video/"])
     {
         DDLogVerbose(@"Deleting video thumbnail stored at %@", msg.fileInfo.thumbnailURL.path);
@@ -635,7 +635,7 @@ $$
 
 #pragma mark - internal methods
 
-+(NSString*) retrieveCacheFileForUrl:(NSString*) url andMimeType:(NSString*) mimeType
++(NSString*) retrieveCacheFilePathForUrl:(NSString*) url andMimeType:(NSString*) mimeType
 {
     NSString* urlPart = [HelperTools hexadecimalString:[HelperTools sha256:[url dataUsingEncoding:NSUTF8StringEncoding]]];
     if(mimeType)
@@ -643,11 +643,11 @@ $$
         NSString* mimePart = [HelperTools hexadecimalString:[mimeType dataUsingEncoding:NSUTF8StringEncoding]];
         
         //the cache filename consists of a hash of the upload url (in hex) followed of the file mimetype (also in hex) as file extension
-        NSString* cacheFile = [_documentCacheDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", urlPart, mimePart]];
+        NSString* cacheFilePath = [_documentCacheDir stringByAppendingPathComponent:[NSString stringWithFormat:@"%@.%@", urlPart, mimePart]];
         
         //file having the supplied mimeType exists
-        if([_fileManager fileExistsAtPath:cacheFile])
-            return cacheFile;
+        if([_fileManager fileExistsAtPath:cacheFilePath])
+            return cacheFilePath;
     }
     
     //check for files having a different mime type but the same base url
@@ -662,7 +662,7 @@ $$
     return nil;
 }
 
-+(NSString*) calculateCacheFileForNewUrl:(NSString*) url andMimeType:(NSString*) mimeType
++(NSString*) calculateCacheFilePathForNewUrl:(NSString*) url andMimeType:(NSString*) mimeType
 {
     //the cache filename consists of a hash of the upload url (in hex) followed of the file mimetype (also in hex) as file extension
     NSString* urlPart = [HelperTools hexadecimalString:[HelperTools sha256:[url dataUsingEncoding:NSUTF8StringEncoding]]];
@@ -695,11 +695,6 @@ $$
     if(type.preferredMIMEType == nil)
         return @"application/octet-stream";
     return type.preferredMIMEType;
-}
-
-+(NSString*) getMimeTypeOfCacheFile:(NSString*) file
-{
-    return [[NSString alloc] initWithData:[HelperTools dataWithHexString:[file pathExtension]] encoding:NSUTF8StringEncoding];
 }
 
 +(void) setErrorType:(NSString*) errorType andErrorText:(NSString*) errorText forMessage:(MLMessage*) msg
@@ -818,9 +813,9 @@ $$class_handler(internalTmpFileUploadHandler, $$ID(NSString*, file), $$ID(NSStri
             }
             
             //move the tempfile to our cache location
-            NSString* cacheFile = [self calculateCacheFileForNewUrl:url andMimeType:mimeType];
-            DDLogInfo(@"Moving (possibly encrypted) file to our document cache at %@", cacheFile);
-            [_fileManager moveItemAtPath:file toPath:cacheFile error:&error];
+            NSString* cacheFilePath = [self calculateCacheFilePathForNewUrl:url andMimeType:mimeType];
+            DDLogInfo(@"Moving (possibly encrypted) file to our document cache at %@", cacheFilePath);
+            [_fileManager moveItemAtPath:file toPath:cacheFilePath error:&error];
             if(error)
             {
                 NSError* error = [NSError errorWithDomain:@"MonalError" code:0 userInfo:@{NSLocalizedDescriptionKey: NSLocalizedString(@"Failed to move uploaded file to file cache directory", @"")}];
@@ -829,7 +824,7 @@ $$class_handler(internalTmpFileUploadHandler, $$ID(NSString*, file), $$ID(NSStri
                 DDLogError(@"File upload failed: %@", error);
                 return completion(nil, nil, nil, error);
             }
-            [HelperTools configureFileProtectionFor:cacheFile];
+            [HelperTools configureFileProtectionFor:cacheFilePath];
             
             [self markAsComplete:file];
             DDLogInfo(@"URL for download: %@", url);

--- a/Monal/Classes/MLFiletransfer.m
+++ b/Monal/Classes/MLFiletransfer.m
@@ -120,12 +120,7 @@ static NSObject* _hardlinkingSyncObject;
             //send out update notification
             xmpp* account = [[MLXMPPManager sharedInstance] getEnabledAccountForID:msg.accountID];
             if(account != nil)      //don't send out update notices for already deleted accounts
-                [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageFiletransferUpdateNotice object:account userInfo:@{
-                    @"message": msg,
-                    @"mimeType": mimeType,
-                    @"size": contentLength,
-                    @"downloadState": @(DownloadStateHeaders),
-                }];
+                [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageFiletransferUpdateNotice object:account userInfo:@{ @"message": msg }];
             else
                 return;             //abort here without autodownloading if account was already deleted
             
@@ -289,13 +284,7 @@ static NSObject* _hardlinkingSyncObject;
             //send out update notification
             xmpp* account = [[MLXMPPManager sharedInstance] getEnabledAccountForID:msg.accountID];
             if(account != nil)      //don't send out update notices for already deleted accounts
-                [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageFiletransferUpdateNotice object:account userInfo:@{
-                    @"message": msg,
-                    @"mimeType": mimeType,
-                    @"size": filetransferSize,
-                    @"downloadState": @(DownloadStateComplete),
-                }];
-
+                [[MLNotificationQueue currentQueue] postNotificationName:kMonalMessageFiletransferUpdateNotice object:account userInfo:@{ @"message": msg }];
             else
                 [_fileManager removeItemAtPath:cacheFile error:nil];
             

--- a/Monal/Classes/MLFiletransfer.m
+++ b/Monal/Classes/MLFiletransfer.m
@@ -452,11 +452,11 @@ $$
     if(msg.inbound)
     {
         //put every mime-type in its own type directory
-        if([fileInfo.mimeType hasPrefix:@"image/"])
+        if(fileInfo.isImage)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Received Images", @"directory for downloaded images")];
-        else if([fileInfo.mimeType hasPrefix:@"video/"])
+        else if(fileInfo.isVideo)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Received Videos", @"directory for downloaded videos")];
-        else if([fileInfo.mimeType hasPrefix:@"audio/"])
+        else if(fileInfo.isAudio)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Received Audios", @"directory for downloaded audios")];
         else
             [hardlinkPathComponents addObject:NSLocalizedString(@"Received Files", @"directory for downloaded files")];
@@ -468,11 +468,11 @@ $$
     else
     {
         //put every mime-type in its own type directory
-        if([fileInfo.mimeType hasPrefix:@"image/"])
+        if(fileInfo.isImage)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Sent Images", @"directory for downloaded images")];
-        else if([fileInfo.mimeType hasPrefix:@"video/"])
+        else if(fileInfo.isVideo)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Sent Videos", @"directory for downloaded videos")];
-        else if([fileInfo.mimeType hasPrefix:@"audio/"])
+        else if(fileInfo.isAudio)
             [hardlinkPathComponents addObject:NSLocalizedString(@"Sent Audios", @"directory for downloaded audios")];
         else
             [hardlinkPathComponents addObject:NSLocalizedString(@"Sent Files", @"directory for downloaded files")];

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -27,7 +27,7 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) double mediaDuration;
 @property (nonatomic, readonly) NSURL* _Nullable thumbnailURL;
 
-@property (nonatomic, readonly) NSString* url;
+@property (nonatomic, readonly) NSString* downloadURL;
 @property (nonatomic, readonly) NSString* filename;
 @property (nonatomic, readonly) NSString* fileExtension;
 @property (nonatomic, readonly) NSString* _Nullable cacheFilePath;

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -32,7 +32,7 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) NSString* fileExtension;
 @property (nonatomic, readonly) NSString* _Nullable cacheFile;
 @property (nonatomic, readonly) NSString* _Nullable cacheId;
-@property (nonatomic, readonly) UTType* _Nullable typeHint;
+@property (nonatomic, readonly) UTType* _Nullable utType;
 
 @property (nonatomic, readonly) BOOL isImage;
 @property (nonatomic, readonly) BOOL isAudio;

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -32,6 +32,7 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) NSString* fileExtension;
 @property (nonatomic, readonly) NSString* _Nullable cacheFilePath;
 @property (nonatomic, readonly) NSString* _Nullable cacheId;
+@property (nonatomic, readonly) NSURL* _Nullable fileURL;
 @property (nonatomic, readonly) UTType* _Nullable utType;
 
 @property (nonatomic, readonly) BOOL isImage;

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -33,6 +33,12 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) NSString* _Nullable cacheFile;
 @property (nonatomic, readonly) NSString* _Nullable cacheId;
 @property (nonatomic, readonly) UTType* _Nullable typeHint;
+
+@property (nonatomic, readonly) BOOL isImage;
+@property (nonatomic, readonly) BOOL isAudio;
+@property (nonatomic, readonly) BOOL isVideo;
+@property (nonatomic, readonly) BOOL isPDF;
+
 @property (nonatomic, readonly) MLMessage* message;
 
 +(MLFiletransferInfo*) createFiletransferInfoForMessage:(MLMessage*) message;

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -30,7 +30,7 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) NSString* url;
 @property (nonatomic, readonly) NSString* filename;
 @property (nonatomic, readonly) NSString* fileExtension;
-@property (nonatomic, readonly) NSString* _Nullable cacheFile;
+@property (nonatomic, readonly) NSString* _Nullable cacheFilePath;
 @property (nonatomic, readonly) NSString* _Nullable cacheId;
 @property (nonatomic, readonly) UTType* _Nullable utType;
 

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -238,6 +238,16 @@ static NSMutableDictionary* _singletonCache;
     return [NSSet setWithObjects:@"mimeType", nil];
 }
 
+-(NSURL* _Nullable) fileURL
+{
+    return [NSURL fileURLWithPath:self.cacheFilePath];
+}
+
++(NSSet*) keyPathsForValuesAffectingFileURL
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(UTType* _Nullable) utType
 {
     if(self.mimeType == nil)

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -195,17 +195,17 @@ static NSMutableDictionary* _singletonCache;
     return _thumbnailURL;
 }
 
-// The url property doesn't emit KVO notifications if it changes (it's not possible to declare
+// downloadURL doesn't emit KVO notifications if it changes (it's not possible to declare
 // it as depending on messageText, because that's only accessible through a computed property).
-// url is not supposed to change. But if it does, those that depend on it won't get notified.
--(NSString*) url
+// downloadURL is not supposed to change. But if it does, those that depend on it won't get notified.
+-(NSString*) downloadURL
 {
     return self.message.messageText;
 }
 
 -(NSString*) filename
 {
-    NSURLComponents* urlComponents = [NSURLComponents componentsWithString:self.url];
+    NSURLComponents* urlComponents = [NSURLComponents componentsWithString:self.downloadURL];
     if(urlComponents != nil && urlComponents.path)
         return [urlComponents.path lastPathComponent];
     else
@@ -220,7 +220,7 @@ static NSMutableDictionary* _singletonCache;
 
 -(NSString* _Nullable) cacheFilePath
 {
-    return [MLFiletransfer retrieveCacheFilePathForUrl:self.url andMimeType:(self.mimeType && ![self.mimeType isEqualToString:@""] ? self.mimeType : nil)];
+    return [MLFiletransfer retrieveCacheFilePathForUrl:self.downloadURL andMimeType:(self.mimeType && ![self.mimeType isEqualToString:@""] ? self.mimeType : nil)];
 }
 
 +(NSSet*) keyPathsForValuesAffectingCacheFilePath

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -89,13 +89,7 @@ static NSMutableDictionary* _singletonCache;
     if(self.historyId.integerValue != message.messageDBId.integerValue)
         return;         //ignore filetransfer updates of other messages
 
-    NSString* mimeType = data[@"mimeType"];
-    NSNumber* size = data[@"size"];
-    NSNumber* downloadState = data[@"downloadState"];
-    MLAssert(mimeType != nil && size != nil && downloadState != nil, @"Notification without mimeType and/or size and/or downloadState");
-    self.mimeType = mimeType;
-    self.size = size;
-    self.downloadState = downloadState.unsignedIntegerValue;
+    [self refresh];
 }
 
 -(void) handleMessageDeletion:(NSNotification*) notification
@@ -110,6 +104,19 @@ static NSMutableDictionary* _singletonCache;
     self.downloadState = DownloadStateUndefined;
     self.mediaDuration = 0.0;
     self.thumbnailURL = nil;
+}
+
+-(void) refresh
+{
+    NSDictionary* dic = [[DataLayer sharedInstance] getFiletransferInfoForHistoryId:self.historyId];
+    if(dic == nil)
+        DDLogError(@"A row in the filetransfer_info db table SHOULD exist for a filetransferInfo object!");
+
+    updateIfIdNotEqual(self.mimeType, [dic objectForKey:@"mime_type"]);
+    updateIfIdNotEqual(self.size, [dic objectForKey:@"size"]);
+    // Reset the cached value of downloadState. This will cause it to be recalculated on next read access
+    // (which will happen soon due to the KVO notification emitted by calling the setter)
+    self.downloadState = DownloadStateUndefined;
 }
 
 -(DownloadState) downloadState

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -234,21 +234,41 @@ static NSMutableDictionary* _singletonCache;
     if(type != nil)
         return type;
 
-    if([self.mimeType hasPrefix:@"image/"])
+    if(self.isImage)
         return UTTypeImage;
-    if([self.mimeType hasPrefix:@"audio/"])
+    if(self.isAudio)
         return UTTypeAudio;
-    if([self.mimeType hasPrefix:@"video/"])
+    if(self.isVideo)
        return UTTypeMovie;
     return nil;
 }
 
+-(BOOL) isImage
+{
+    return [self.mimeType hasPrefix:@"image/"];
+}
+
+-(BOOL) isAudio
+{
+    return [self.mimeType hasPrefix:@"audio/"];
+}
+
+-(BOOL) isVideo
+{
+    return [self.mimeType hasPrefix:@"video/"];
+}
+
+-(BOOL) isPDF
+{
+    return [self.mimeType isEqualToString:@"application/pdf"];
+}
+
+// Needed to not create a retain cycle between MLFiletransferInfo and MLMessage
 -(MLMessage*) message
 {
     return [MLMessage createMessageFromHistoryID:self.historyId];
 }
 
-// Needed to not create a retain cycle between MLFiletransferInfo and MLMessage
 -(NSString*) id
 {
     return [NSString stringWithFormat:@"%@", self.historyId];

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -238,7 +238,7 @@ static NSMutableDictionary* _singletonCache;
     return [NSSet setWithObjects:@"mimeType", nil];
 }
 
--(UTType* _Nullable) typeHint
+-(UTType* _Nullable) utType
 {
     if(self.mimeType == nil)
         return nil;
@@ -256,7 +256,7 @@ static NSMutableDictionary* _singletonCache;
     return nil;
 }
 
-+(NSSet*) keyPathsForValuesAffectingTypeHint
++(NSSet*) keyPathsForValuesAffectingUtType
 {
     return [NSSet setWithObjects:@"mimeType", nil];
 }

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -19,7 +19,7 @@
 static NSMutableDictionary* _singletonCache;
 
 @interface MLFiletransfer ()
-+(NSString*) retrieveCacheFileForUrl:(NSString*) url andMimeType:(NSString*) mimeType;
++(NSString*) retrieveCacheFilePathForUrl:(NSString*) url andMimeType:(NSString*) mimeType;
 @end
 
 @interface MLFiletransferInfo ()
@@ -126,7 +126,7 @@ static NSMutableDictionary* _singletonCache;
         return _downloadState;
 
     DownloadState state;
-    if(self.cacheFile)
+    if(self.cacheFilePath)
         state = DownloadStateComplete;
     else if(self.size && self.mimeType && ![self.mimeType isEqualToString:@""])
         state = DownloadStateHeaders;
@@ -147,7 +147,7 @@ static NSMutableDictionary* _singletonCache;
     // Note that isComputingMediaDuration is not thread safe
     if(!self.isComputingMediaDuration) {
         self.isComputingMediaDuration = YES;
-        [HelperTools computeMediaDurationFromFile:self.cacheFile havingMimeType:self.mimeType andFileExtension:self.fileExtension]
+        [HelperTools computeMediaDurationFromFile:self.cacheFilePath havingMimeType:self.mimeType andFileExtension:self.fileExtension]
         .then(^(NSNumber* duration) {
             // The following instruction triggers a ChatView update
             self.mediaDuration = duration.doubleValue;
@@ -180,7 +180,7 @@ static NSMutableDictionary* _singletonCache;
     if(!self.isGeneratingThumbnail)
     {
         self.isGeneratingThumbnail = YES;
-        [HelperTools generateVideoThumbnailFromFile:self.cacheFile havingMimeType:self.mimeType andFileExtension:self.fileExtension]
+        [HelperTools generateVideoThumbnailFromFile:self.cacheFilePath havingMimeType:self.mimeType andFileExtension:self.fileExtension]
         .then(^(UIImage* image) {
             NSData* imageData = UIImagePNGRepresentation(image);
             // The following instruction triggers a ChatView update
@@ -218,19 +218,19 @@ static NSMutableDictionary* _singletonCache;
     return [self.filename pathExtension];
 }
 
--(NSString* _Nullable) cacheFile
+-(NSString* _Nullable) cacheFilePath
 {
-    return [MLFiletransfer retrieveCacheFileForUrl:self.url andMimeType:(self.mimeType && ![self.mimeType isEqualToString:@""] ? self.mimeType : nil)];
+    return [MLFiletransfer retrieveCacheFilePathForUrl:self.url andMimeType:(self.mimeType && ![self.mimeType isEqualToString:@""] ? self.mimeType : nil)];
 }
 
-+(NSSet*) keyPathsForValuesAffectingCacheFile
++(NSSet*) keyPathsForValuesAffectingCacheFilePath
 {
     return [NSSet setWithObjects:@"mimeType", nil];
 }
 
 -(NSString* _Nullable) cacheId
 {
-    return [self.cacheFile lastPathComponent];
+    return [self.cacheFilePath lastPathComponent];
 }
 
 +(NSSet*) keyPathsForValuesAffectingCacheId

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -195,6 +195,9 @@ static NSMutableDictionary* _singletonCache;
     return _thumbnailURL;
 }
 
+// The url property doesn't emit KVO notifications if it changes (it's not possible to declare
+// it as depending on messageText, because that's only accessible through a computed property).
+// url is not supposed to change. But if it does, those that depend on it won't get notified.
 -(NSString*) url
 {
     return self.message.messageText;
@@ -220,9 +223,19 @@ static NSMutableDictionary* _singletonCache;
     return [MLFiletransfer retrieveCacheFileForUrl:self.url andMimeType:(self.mimeType && ![self.mimeType isEqualToString:@""] ? self.mimeType : nil)];
 }
 
++(NSSet*) keyPathsForValuesAffectingCacheFile
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(NSString* _Nullable) cacheId
 {
     return [self.cacheFile lastPathComponent];
+}
+
++(NSSet*) keyPathsForValuesAffectingCacheId
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
 }
 
 -(UTType* _Nullable) typeHint
@@ -243,9 +256,19 @@ static NSMutableDictionary* _singletonCache;
     return nil;
 }
 
++(NSSet*) keyPathsForValuesAffectingTypeHint
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(BOOL) isImage
 {
     return [self.mimeType hasPrefix:@"image/"];
+}
+
++(NSSet*) keyPathsForValuesAffectingIsImage
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
 }
 
 -(BOOL) isAudio
@@ -253,14 +276,29 @@ static NSMutableDictionary* _singletonCache;
     return [self.mimeType hasPrefix:@"audio/"];
 }
 
++(NSSet*) keyPathsForValuesAffectingIsAudio
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(BOOL) isVideo
 {
     return [self.mimeType hasPrefix:@"video/"];
 }
 
++(NSSet*) keyPathsForValuesAffectingIsVideo
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(BOOL) isPDF
 {
     return [self.mimeType isEqualToString:@"application/pdf"];
+}
+
++(NSSet*) keyPathsForValuesAffectingIsPDF
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
 }
 
 // Needed to not create a retain cycle between MLFiletransferInfo and MLMessage

--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -546,8 +546,8 @@ static NSMutableDictionary* _typingNotifications;
     else if([messageNode check:@"{urn:xmpp:reactions:0}reactions"])
     {
         NSString* reactionId = [messageNode findFirst:@"{urn:xmpp:reactions:0}reactions@id"];
-        NSSet* reactions = [NSSet setWithArray:[messageNode find:@"{urn:xmpp:reactions:0}reactions<id=%@>/reaction#", reactionId]];
-        
+        NSOrderedSet* reactions = [NSOrderedSet orderedSetWithArray:[messageNode find:@"{urn:xmpp:reactions:0}reactions<id=%@>/reaction#", reactionId]];
+
         //we want to either use the jid OR the occupant-id, but never both (even if we are a channel admin)
         NSString* jidToUse = nil;
         NSString* occupantIdToUse = nil;

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -524,8 +524,8 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
                 {
                     if(fileInfo.isAudio)
                     {
-                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:fileInfo.typeHint.identifier]];
-                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, fileInfo.typeHint, audioAttachment);
+                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:fileInfo.utType.identifier]];
+                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, fileInfo.utType, audioAttachment);
                     }
                     UNNotificationAttachment* attachment = [self createNotificationAttachmentForFileInfo:fileInfo];
                     if(attachment)
@@ -863,7 +863,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
 -(UNNotificationAttachment* _Nullable) createNotificationAttachmentForFileInfo:(MLFiletransferInfo*) info
 {
     NSError* error;
-    UTType* typeHint = info.typeHint;
+    UTType* typeHint = info.utType;
     NSString* attachmentDir = [[HelperTools getContainerURLForPathComponents:@[@"documentCache"]] path];
     //use "tmp." prefix to make sure this file will be garbage collected should the ios notification attachment implementation leave it behind
     NSString* attachmentBasename = [NSString stringWithFormat:@"tmp.%@", info.cacheId];

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -524,7 +524,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
                 {
                     if(fileInfo.isAudio)
                     {
-                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:fileInfo.utType.identifier]];
+                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFilePath] filename:fileInfo.filename typeIdentifier:fileInfo.utType.identifier]];
                         DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, fileInfo.utType, audioAttachment);
                     }
                     UNNotificationAttachment* attachment = [self createNotificationAttachmentForFileInfo:fileInfo];
@@ -877,12 +877,12 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if([info.mimeType hasPrefix:@"image/svg"])
     {
         NSString* pngAttachment = [attachmentDir stringByAppendingPathComponent:[attachmentBasename stringByAppendingPathExtensionForType:UTTypePNG]];
-        DDLogVerbose(@"Preparing for notification attachment(%@): converting downloaded file from svg at '%@' to png at '%@'...", typeHint, info.cacheFile, pngAttachment);
+        DDLogVerbose(@"Preparing for notification attachment(%@): converting downloaded file from svg at '%@' to png at '%@'...", typeHint, info.cacheFilePath, pngAttachment);
         //we want our code to run synchronously --> use PMKHang
         //this code should never run in the main queue to not provoke a deadlock
         if([NSThread isMainThread])
             @throw [NSException exceptionWithName:@"InvalidThread" reason:@"PMKHang on renderUIImageFromSVGURL must never be called on the main thread!" userInfo:nil]; 
-        image = (UIImage*)nilExtractor(PMKHang([HelperTools renderUIImageFromSVGURL:[NSURL fileURLWithPath:info.cacheFile]]));
+        image = (UIImage*)nilExtractor(PMKHang([HelperTools renderUIImageFromSVGURL:[NSURL fileURLWithPath:info.cacheFilePath]]));
         if(image != nil)
         {
             [UIImagePNGRepresentation(image) writeToFile:pngAttachment atomically:YES];
@@ -893,8 +893,8 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     //fallback if svg extraction failed OR it wasn't an SVG image in the first place
     if(image == nil)
     {
-        DDLogVerbose(@"Preparing for notification attachment(%@): hardlinking downloaded file from '%@' to '%@'...", typeHint, info.cacheFile, notificationAttachment);
-        error = [HelperTools hardLinkOrCopyFile:info.cacheFile to:notificationAttachment];
+        DDLogVerbose(@"Preparing for notification attachment(%@): hardlinking downloaded file from '%@' to '%@'...", typeHint, info.cacheFilePath, notificationAttachment);
+        error = [HelperTools hardLinkOrCopyFile:info.cacheFilePath to:notificationAttachment];
         if(error)
         {
             DDLogError(@"Could not hardlink cache file to notification image temp file!");

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -522,14 +522,12 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
             {
                 if(fileInfo.isImage || fileInfo.isVideo || fileInfo.isAudio)
                 {
-                    UNNotificationAttachment* attachment;
-                    UTType* typeHint = fileInfo.typeHint;
                     if(fileInfo.isAudio)
                     {
-                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:typeHint.identifier]];
-                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, typeHint, audioAttachment);
+                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:fileInfo.typeHint.identifier]];
+                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, fileInfo.typeHint, audioAttachment);
                     }
-                    attachment = [self createNotificationAttachmentForFileInfo:fileInfo havingTypeHint:typeHint];
+                    UNNotificationAttachment* attachment = [self createNotificationAttachmentForFileInfo:fileInfo];
                     if(attachment)
                         content.attachments = @[attachment];
                 }
@@ -831,10 +829,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
                 UNNotificationAttachment* attachment;
                 if(fileInfo.downloadState == DownloadStateComplete)
                 {
-                    UTType* typeHint = [UTType typeWithMIMEType:fileInfo.mimeType];
-                    if(typeHint == nil)
-                        typeHint = UTTypeImage;
-                    attachment = [self createNotificationAttachmentForFileInfo:fileInfo havingTypeHint:typeHint];
+                    attachment = [self createNotificationAttachmentForFileInfo:fileInfo];
                     if(attachment)
                     {
                         content.attachments = @[attachment];
@@ -865,9 +860,10 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     [self publishNotificationContent:[self updateBadgeForContent:content] withID:idval];
 }
 
--(UNNotificationAttachment* _Nullable) createNotificationAttachmentForFileInfo:(MLFiletransferInfo*) info havingTypeHint:(UTType*) typeHint
+-(UNNotificationAttachment* _Nullable) createNotificationAttachmentForFileInfo:(MLFiletransferInfo*) info
 {
     NSError* error;
+    UTType* typeHint = info.typeHint;
     NSString* attachmentDir = [[HelperTools getContainerURLForPathComponents:@[@"documentCache"]] path];
     //use "tmp." prefix to make sure this file will be garbage collected should the ios notification attachment implementation leave it behind
     NSString* attachmentBasename = [NSString stringWithFormat:@"tmp.%@", info.cacheId];

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -505,32 +505,31 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
         
         if([message.messageType isEqualToString:kMessageTypeFiletransfer])
         {
-            MLFiletransferInfo* info = message.fileInfo;
-            NSString* mimeType = info.mimeType;
+            MLFiletransferInfo* fileInfo = message.fileInfo;
 
-            if([mimeType hasPrefix:@"image/"])
+            if(fileInfo.isImage)
                 msgText = NSLocalizedString(@"📷 An Image", @"");
-            else if([mimeType hasPrefix:@"audio/"])
+            else if(fileInfo.isAudio)
                 msgText = NSLocalizedString(@"🎵 An Audiomessage", @"");
-            else if([mimeType hasPrefix:@"video/"])
+            else if(fileInfo.isVideo)
                 msgText = NSLocalizedString(@"🎥 A Video", @"");
-            else if([mimeType isEqualToString:@"application/pdf"])
+            else if(fileInfo.isPDF)
                 msgText = NSLocalizedString(@"📄 A Document", @"");
             else
                 msgText = NSLocalizedString(@"📁 A File", @"");
 
-            if(info.downloadState == DownloadStateComplete)
+            if(fileInfo.downloadState == DownloadStateComplete)
             {
-                if([mimeType hasPrefix:@"image/"] || [mimeType hasPrefix:@"video/"] || [mimeType hasPrefix:@"audio/"])
+                if(fileInfo.isImage || fileInfo.isVideo || fileInfo.isAudio)
                 {
                     UNNotificationAttachment* attachment;
-                    UTType* typeHint = info.typeHint;
-                    if([mimeType hasPrefix:@"audio/"])
+                    UTType* typeHint = fileInfo.typeHint;
+                    if(fileInfo.isAudio)
                     {
-                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:info.cacheFile] filename:info.filename typeIdentifier:typeHint.identifier]];
-                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", mimeType, typeHint, audioAttachment);
+                        audioAttachment = [INSendMessageAttachment attachmentWithAudioMessageFile:[INFile fileWithFileURL:[NSURL fileURLWithPath:fileInfo.cacheFile] filename:fileInfo.filename typeIdentifier:typeHint.identifier]];
+                        DDLogVerbose(@"Added audio attachment(%@ = %@): %@", fileInfo.mimeType, typeHint, audioAttachment);
                     }
-                    attachment = [self createNotificationAttachmentForFileInfo:info havingTypeHint:typeHint];
+                    attachment = [self createNotificationAttachmentForFileInfo:fileInfo havingTypeHint:typeHint];
                     if(attachment)
                         content.attachments = @[attachment];
                 }
@@ -824,18 +823,18 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
 
         if([message.messageType isEqualToString:kMessageTypeFiletransfer])
         {
-            NSString* mimeType = message.fileInfo.mimeType;
-            if([mimeType hasPrefix:@"image/"])
+            MLFiletransferInfo* fileInfo = message.fileInfo;
+            if(fileInfo.isImage)
             {
                 content.body = NSLocalizedString(@"Sent an Image 📷", @"");
 
                 UNNotificationAttachment* attachment;
-                if(message.fileInfo.downloadState == DownloadStateComplete)
+                if(fileInfo.downloadState == DownloadStateComplete)
                 {
-                    UTType* typeHint = [UTType typeWithMIMEType:mimeType];
+                    UTType* typeHint = [UTType typeWithMIMEType:fileInfo.mimeType];
                     if(typeHint == nil)
                         typeHint = UTTypeImage;
-                    attachment = [self createNotificationAttachmentForFileInfo:message.fileInfo havingTypeHint:typeHint];
+                    attachment = [self createNotificationAttachmentForFileInfo:fileInfo havingTypeHint:typeHint];
                     if(attachment)
                     {
                         content.attachments = @[attachment];
@@ -843,13 +842,13 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
                     }
                 }
             }
-            else if([mimeType hasPrefix:@"image/"])
+            else if(fileInfo.isImage)
                 content.body = NSLocalizedString(@"📷 An Image", @"");
-            else if([mimeType hasPrefix:@"audio/"])
+            else if(fileInfo.isAudio)
                 content.body = NSLocalizedString(@"🎵 An Audiomessage", @"");
-            else if([mimeType hasPrefix:@"video/"])
+            else if(fileInfo.isVideo)
                 content.body = NSLocalizedString(@"🎥 A Video", @"");
-            else if([mimeType isEqualToString:@"application/pdf"])
+            else if(fileInfo.isPDF)
                 content.body = NSLocalizedString(@"📄 A Document", @"");
             else
                 content.body = NSLocalizedString(@"Sent a File 📁", @"");

--- a/Monal/Classes/MLReactionsEntry.h
+++ b/Monal/Classes/MLReactionsEntry.h
@@ -23,7 +23,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, readonly) NSString* _Nullable jid;
 @property (nonatomic, readonly) NSString* _Nullable occupantId;
 @property (nonatomic, readonly) NSString* _Nullable mucNick;
-@property (nonatomic, readonly) NSSet<NSString*>* reactions;
+@property (nonatomic, readonly) NSOrderedSet<NSString*>* reactions;
 @property (nonatomic, readonly) NSDate* timestamp;
 @property (nonatomic, readonly) MLMessage* message;
 @property (nonatomic, readonly) id<MLContactProtocol> contact;

--- a/Monal/Classes/MLReactionsEntry.m
+++ b/Monal/Classes/MLReactionsEntry.m
@@ -19,7 +19,7 @@
 @property (nonatomic) NSString* _Nullable jid;
 @property (nonatomic) NSString* _Nullable occupantId;
 @property (nonatomic) NSString* _Nullable mucNick;
-@property (nonatomic) NSSet<NSString*>* reactions;
+@property (nonatomic) NSOrderedSet<NSString*>* reactions;
 @property (nonatomic) NSDate* timestamp;
 @property (nonatomic) MLMessage* message;
 @property (nonatomic) id<MLContactProtocol> contact;

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -36,9 +36,7 @@ struct MediaGalleryView: View {
     private func fetchDownloadedMediaItems() {
         if let attachments = DataLayer.sharedInstance().allAttachments(fromContact: contact, forAccount: accountID) as? [MLFiletransferInfo] {
             mediaItems = attachments.filter { fileInfo in
-                if let mimeType = fileInfo.mimeType,
-                   fileInfo.downloadState == .complete,
-                   (mimeType.starts(with: "image/") || mimeType.starts(with: "video/")) {
+                if fileInfo.downloadState == .complete, (fileInfo.isImage || fileInfo.isVideo) {
                     return true
                 }
                 return false
@@ -62,13 +60,13 @@ class MediaItem: Identifiable, ObservableObject {
 
     @MainActor
     func generateThumbnail() async {
-        guard let cacheFile = fileInfo.cacheFile, let mimeType = fileInfo.mimeType else {
-            DDLogError("Failed to get cacheFile or mimeType for: \(fileInfo)")
+        guard let cacheFile = fileInfo.cacheFile else {
+            DDLogError("Failed to get cacheFile for: \(fileInfo)")
             self.thumbnail = UIImage(systemName: "exclamationmark.triangle")
             return
         }
 
-        if mimeType.starts(with: "image/") {
+        if fileInfo.isImage {
             if let image = UIImage(contentsOfFile: cacheFile) {
                 self.thumbnail = image
             } else {
@@ -76,7 +74,7 @@ class MediaItem: Identifiable, ObservableObject {
                 self.thumbnail = UIImage(systemName: "photo")
             }
             return
-        } else if mimeType.starts(with: "video/") {
+        } else if fileInfo.isVideo {
             if let thumbnail = await videoPreview(for:fileInfo) {
                 self.thumbnail = thumbnail
             } else {
@@ -86,7 +84,7 @@ class MediaItem: Identifiable, ObservableObject {
             return
         }
 
-        DDLogError("Unsupported mime type: \(mimeType)")
+        DDLogError("Unsupported mime type: \(fileInfo.mimeType ?? "(unknown)")")
         self.thumbnail = UIImage(systemName: "doc")
     }
 
@@ -136,7 +134,7 @@ struct MediaItemView: View {
             .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.gray, lineWidth: 1))
             
             // Add play icon overlay for video files
-            if let mimeType = item.fileInfo.mimeType, mimeType.starts(with: "video/") {
+            if item.fileInfo.isVideo {
                 Image(systemName: "play.circle.fill")
                     .resizable()
                     .frame(width: 30, height: 30)

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -60,14 +60,14 @@ class MediaItem: Identifiable, ObservableObject {
 
     @MainActor
     func generateThumbnail() async {
-        guard let cacheFile = fileInfo.cacheFile else {
-            DDLogError("Failed to get cacheFile for: \(fileInfo)")
+        guard let cacheFilePath = fileInfo.cacheFilePath else {
+            DDLogError("Failed to get cacheFilePath for: \(fileInfo)")
             self.thumbnail = UIImage(systemName: "exclamationmark.triangle")
             return
         }
 
         if fileInfo.isImage {
-            if let image = UIImage(contentsOfFile: cacheFile) {
+            if let image = UIImage(contentsOfFile: cacheFilePath) {
                 self.thumbnail = image
             } else {
                 DDLogError("Failed to generate image thumbnail for: \(fileInfo)")
@@ -90,7 +90,7 @@ class MediaItem: Identifiable, ObservableObject {
 
     @MainActor
     func videoPreview(for fileInfo: MLFiletransferInfo) async -> UIImage? {
-        let moviePath = URL(fileURLWithPath: fileInfo.cacheFile!)
+        let moviePath = URL(fileURLWithPath: fileInfo.cacheFilePath!)
         DDLogInfo("Trying to generate video thumbnail for: \(String(describing:fileInfo))")
         
         let payload: NSDictionary? = try? await HelperTools.addUploadItemPreview(
@@ -100,7 +100,7 @@ class MediaItem: Identifiable, ObservableObject {
         ).toTypedPromise().asyncOnMainActor()
         guard let image = payload?["preview"] as? UIImage else {
             return try? await HelperTools.generateVideoThumbnail(
-                fromFile:fileInfo.cacheFile!,
+                fromFile:fileInfo.cacheFilePath!,
                 havingMimeType:fileInfo.mimeType! ,
                 andFileExtension:fileInfo.fileExtension
             ).toTypedPromise().asyncOnMainActor()
@@ -171,9 +171,9 @@ struct MediaItemSwipeView: View {
 
     init(currentItem: MLFiletransferInfo, allItems: [MLFiletransferInfo]) {
         let index = allItems.firstIndex { item in
-            // Compare using 'cacheFile'
-            if let currentPath = currentItem.cacheFile,
-               let itemPath = item.cacheFile {
+            // Compare using 'cacheFilePath'
+            if let currentPath = currentItem.cacheFilePath,
+               let itemPath = item.cacheFilePath {
                 return currentPath == itemPath
             }
             return false

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -68,15 +68,15 @@ struct ImageViewer: View {
             if info.mimeType!.hasPrefix("image/svg") {
                 VStack {
                     ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
-                        SVGView(contentsOf: URL(fileURLWithPath:info.cacheFile!))
+                        SVGView(contentsOf: URL(fileURLWithPath:info.cacheFilePath!))
                     }
                 }
             } else if info.mimeType!.hasPrefix("image/") {
-                if let image = UIImage(contentsOfFile:info.cacheFile!) {
+                if let image = UIImage(contentsOfFile:info.cacheFilePath!) {
                     VStack {
                         ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
                             if info.mimeType!.hasPrefix("image/gif") {
-                                GIFViewer(data:Binding(get: { try! NSData(contentsOfFile:info.cacheFile!) as Data }, set: { _ in }))
+                                GIFViewer(data:Binding(get: { try! NSData(contentsOfFile:info.cacheFilePath!) as Data }, set: { _ in }))
                                     .scaledToFit()
                             } else {
                                 Image(uiImage: image)
@@ -116,11 +116,11 @@ struct ImageViewer: View {
     
     private func loadPreviewAndConfigurePlayer() async {
         if info.mimeType!.hasPrefix("image/svg") {
-            previewImage = await HelperTools.renderUIImage(fromSVGURL:URL(fileURLWithPath:info.cacheFile!)).toTypedGuarantee().asyncOnMainActor()
+            previewImage = await HelperTools.renderUIImage(fromSVGURL:URL(fileURLWithPath:info.cacheFilePath!)).toTypedGuarantee().asyncOnMainActor()
         } else if info.mimeType!.hasPrefix("image/") {
-            previewImage = UIImage(contentsOfFile:info.cacheFile!)
+            previewImage = UIImage(contentsOfFile:info.cacheFilePath!)
         } else if info.isVideo {
-            if let filePath = info.cacheFile, let mimeType = info.mimeType {
+            if let filePath = info.cacheFilePath, let mimeType = info.mimeType {
                 customPlayer.configurePlayer(filePath: filePath, mimeType: mimeType)
                 isPlayerReady = true
             }
@@ -200,7 +200,7 @@ struct ControlsOverlay: View {
                             if info.mimeType!.hasPrefix("image/svg") {
                                 ShareLink(
                                     item: SVGRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFile!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)
@@ -208,13 +208,13 @@ struct ControlsOverlay: View {
                             } else if info.mimeType!.hasPrefix("image/gif") {
                                 ShareLink(
                                     item: GifRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFile!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)
                                 .foregroundColor(.primary)
                             } else if info.isVideo {
-                                if let fileURL = URL(string: info.cacheFile!) {
+                                if let fileURL = URL(string: info.cacheFilePath!) {
                                     let mediaItem = MediaItem(fileInfo: info)
                                     ShareLink(item: fileURL, preview: SharePreview("Share video", image: Image(uiImage: mediaItem.thumbnail ?? UIImage(systemName: "video")!)))
                                         .labelStyle(.iconOnly)
@@ -223,7 +223,7 @@ struct ControlsOverlay: View {
                             } else {
                                 ShareLink(
                                     item: JpegRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFile!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -88,7 +88,7 @@ struct ImageViewer: View {
                 } else {
                     InvalidFileView()
                 }
-            } else if info.mimeType!.hasPrefix("video/") {
+            } else if info.isVideo {
                 if isPlayerReady, let playerViewController = customPlayer.playerViewController {
                     ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
                         AVPlayerControllerRepresentable(playerViewController: playerViewController)
@@ -119,7 +119,7 @@ struct ImageViewer: View {
             previewImage = await HelperTools.renderUIImage(fromSVGURL:URL(fileURLWithPath:info.cacheFile!)).toTypedGuarantee().asyncOnMainActor()
         } else if info.mimeType!.hasPrefix("image/") {
             previewImage = UIImage(contentsOfFile:info.cacheFile!)
-        } else if info.mimeType!.hasPrefix("video/") {
+        } else if info.isVideo {
             if let filePath = info.cacheFile, let mimeType = info.mimeType {
                 customPlayer.configurePlayer(filePath: filePath, mimeType: mimeType)
                 isPlayerReady = true
@@ -213,7 +213,7 @@ struct ControlsOverlay: View {
                                 )
                                 .labelStyle(.iconOnly)
                                 .foregroundColor(.primary)
-                            } else if info.mimeType!.hasPrefix("video/") {
+                            } else if info.isVideo {
                                 if let fileURL = URL(string: info.cacheFile!) {
                                     let mediaItem = MediaItem(fileInfo: info)
                                     ShareLink(item: fileURL, preview: SharePreview("Share video", image: Image(uiImage: mediaItem.thumbnail ?? UIImage(systemName: "video")!)))

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -68,7 +68,7 @@ struct ImageViewer: View {
             if info.mimeType!.hasPrefix("image/svg") {
                 VStack {
                     ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
-                        SVGView(contentsOf: URL(fileURLWithPath:info.cacheFilePath!))
+                        SVGView(contentsOf: info.fileURL!)
                     }
                 }
             } else if info.mimeType!.hasPrefix("image/") {
@@ -116,7 +116,7 @@ struct ImageViewer: View {
     
     private func loadPreviewAndConfigurePlayer() async {
         if info.mimeType!.hasPrefix("image/svg") {
-            previewImage = await HelperTools.renderUIImage(fromSVGURL:URL(fileURLWithPath:info.cacheFilePath!)).toTypedGuarantee().asyncOnMainActor()
+            previewImage = await HelperTools.renderUIImage(fromSVGURL: info.fileURL!).toTypedGuarantee().asyncOnMainActor()
         } else if info.mimeType!.hasPrefix("image/") {
             previewImage = UIImage(contentsOfFile:info.cacheFilePath!)
         } else if info.isVideo {
@@ -214,7 +214,7 @@ struct ControlsOverlay: View {
                                 .labelStyle(.iconOnly)
                                 .foregroundColor(.primary)
                             } else if info.isVideo {
-                                if let fileURL = URL(string: info.cacheFilePath!) {
+                                if let fileURL = info.fileURL {
                                     let mediaItem = MediaItem(fileInfo: info)
                                     ShareLink(item: fileURL, preview: SharePreview("Share video", image: Image(uiImage: mediaItem.thumbnail ?? UIImage(systemName: "video")!)))
                                         .labelStyle(.iconOnly)

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -2568,7 +2568,7 @@ enum msgSentState {
     if(cell == nil && info.isVideo)
     {
         MLFileTransferVideoCell* videoCell = (MLFileTransferVideoCell*)[self messageTableCellWithIdentifier:@"fileTransferVideo" andInbound:inDirection fromTable:tableView];
-        NSString* videoStr = info.cacheFile;
+        NSString* videoStr = info.cacheFilePath;
         NSString* videoFileName = info.filename;
         [videoCell avplayerConfigWithUrlStr:videoStr andMimeType:info.mimeType fileName:videoFileName andVC:self];
 
@@ -2578,7 +2578,7 @@ enum msgSentState {
     {
         //we may wan to make a new kind later but for now this is perfectly functional
         MLFileTransferVideoCell* audioCell = (MLFileTransferVideoCell*)[self messageTableCellWithIdentifier:@"fileTransferAudio" andInbound:inDirection fromTable:tableView];
-        NSString *audioStr = info.cacheFile;
+        NSString *audioStr = info.cacheFilePath;
         NSString *audioFileName = info.filename;
         [audioCell avplayerConfigWithUrlStr:audioStr andMimeType:info.mimeType fileName:audioFileName andVC:self];
 
@@ -2592,7 +2592,7 @@ enum msgSentState {
         NSString *readableFileSize = [NSByteCountFormatter stringFromByteCount:fileSizeLongLongValue
                                                                     countStyle:NSByteCountFormatterCountStyleFile];
         NSString *hintStr = [NSString stringWithFormat:@"%@ %@", NSLocalizedString(@"Open", @""), info.filename];
-        NSString *fileCacheUrlStr = info.cacheFile;
+        NSString *fileCacheUrlStr = info.cacheFilePath;
         textCell.fileCacheUrlStr = fileCacheUrlStr;
 
         NSUInteger countOfMimtTypeComponent = [info.mimeType componentsSeparatedByString:@";"].count;

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -2354,9 +2354,9 @@ enum msgSentState {
                 dispatch_async(dispatch_get_main_queue(), ^{
                     MLFiletransferInfo* selectedItem = [self.messageList objectAtIndex:indexPath.row].fileInfo;
                     NSMutableArray* allItems = [NSMutableArray new];
-                    for(MLFiletransferInfo* info in [[DataLayer sharedInstance] allAttachmentsFromContact:self.contact.contactJid forAccount:self.contact.accountID])
-                        if(info.downloadState == DownloadStateComplete && ([info.mimeType hasPrefix:@"image/"] || [info.mimeType hasPrefix:@"video/"]))
-                            [allItems addObject:info];
+                    for(MLFiletransferInfo* fileInfo in [[DataLayer sharedInstance] allAttachmentsFromContact:self.contact.contactJid forAccount:self.contact.accountID])
+                        if(fileInfo.downloadState == DownloadStateComplete && (fileInfo.isImage || fileInfo.isVideo))
+                            [allItems addObject:fileInfo];
                     UIViewController* imageViewer = [[SwiftuiInterface new] makeImageViewerForCurrentItem:selectedItem allItems:allItems];
                     imageViewer.modalPresentationStyle = UIModalPresentationOverFullScreen;
                     [self presentViewController:imageViewer animated:YES completion:^{}];
@@ -2559,13 +2559,13 @@ enum msgSentState {
 {
     MLFiletransferInfo* info = message.fileInfo;
     MLBaseCell* cell = nil;
-    if(cell == nil && [info.mimeType hasPrefix:@"image/"])
+    if(cell == nil && info.isImage)
     {
         MLChatImageCell* imageCell = (MLChatImageCell*)[self messageTableCellWithIdentifier:@"image" andInbound:inDirection fromTable:tableView];
         [imageCell initCellWithMLMessage:message];
         cell = imageCell;
     }
-    if(cell == nil && [info.mimeType hasPrefix:@"video/"])
+    if(cell == nil && info.isVideo)
     {
         MLFileTransferVideoCell* videoCell = (MLFileTransferVideoCell*)[self messageTableCellWithIdentifier:@"fileTransferVideo" andInbound:inDirection fromTable:tableView];
         NSString* videoStr = info.cacheFile;
@@ -2574,7 +2574,7 @@ enum msgSentState {
 
         cell = videoCell;
     }
-    if(cell == nil && [info.mimeType hasPrefix:@"audio/"])
+    if(cell == nil && info.isAudio)
     {
         //we may wan to make a new kind later but for now this is perfectly functional
         MLFileTransferVideoCell* audioCell = (MLFileTransferVideoCell*)[self messageTableCellWithIdentifier:@"fileTransferAudio" andInbound:inDirection fromTable:tableView];

--- a/Monal/Classes/xmpp.h
+++ b/Monal/Classes/xmpp.h
@@ -133,7 +133,7 @@ typedef void (^monal_iq_handler_t)(XMPPIQ* _Nullable);
 -(void) sendMessage:(NSString*) message toContact:(MLContact*) contact isEncrypted:(BOOL) encrypt isUpload:(BOOL) isUpload andMessageId:(NSString*) messageId;
 -(void) sendMessage:(NSString*) message toContact:(MLContact*) contact isEncrypted:(BOOL) encrypt isUpload:(BOOL) isUpload andMessageId:(NSString*) messageId withLMCId:(NSString* _Nullable) LMCId;
 -(void) sendChatState:(BOOL) isTyping toContact:(nonnull MLContact*) contact;
--(void) sendReactions:(NSSet*) reactions forMessage:(MLMessage*) message;
+-(void) sendReactions:(NSOrderedSet*) reactions forMessage:(MLMessage*) message;
 
 /**
  crafts a  ping and sends it

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -4048,7 +4048,7 @@ static NSRegularExpression* fastTokenRemovalRegex;
     [self send:messageNode];
 }
 
--(void) sendReactions:(NSSet*) reactions forMessage:(MLMessage*) message
+-(void) sendReactions:(NSOrderedSet*) reactions forMessage:(MLMessage*) message
 {
     DDLogInfo(@"Sending reactions for message %@: %@", message, reactions);
     XMPPMessage* messageNode = [[XMPPMessage alloc] initToContact:message.chatContact];

--- a/Monal/opensource.html
+++ b/Monal/opensource.html
@@ -244,6 +244,38 @@
         </details>
 
         <hr>
+        <!--DEPENDENCY-->
+        Kingfisher: A lightweight, pure-Swift library for downloading and caching images from the web.<br>
+        <a href="https://github.com/onevcat/Kingfisher">https://github.com/onevcat/Kingfisher</a><br>
+        <br>
+        <details>
+        <summary>
+        The MIT License (MIT)<br>
+        <br>
+        Copyright (c) 2019 Wei Wang<br>
+        <br>
+        </summary>
+        Permission is hereby granted, free of charge, to any person obtaining a copy
+        of this software and associated documentation files (the "Software"), to deal
+        in the Software without restriction, including without limitation the rights
+        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+        copies of the Software, and to permit persons to whom the Software is
+        furnished to do so, subject to the following conditions:<br>
+        <br>
+        The above copyright notice and this permission notice shall be included in all
+        copies or substantial portions of the Software.<br>
+        <br>
+        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+        SOFTWARE.<br>
+        <br>
+        </details>
+
+        <hr>
         FLAnimatedImage: Performant animated GIF engine for iOS<br>
         <a href="https://github.com/Flipboard/FLAnimatedImage">https://github.com/Flipboard/FLAnimatedImage</a><br>
         <br>

--- a/monal.doap
+++ b/monal.doap
@@ -539,7 +539,9 @@
     <implements>
       <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0386.html" />
-        <xmpp:status>planned</xmpp:status>
+        <xmpp:status>complete</xmpp:status>
+        <xmpp:version>1.0.1</xmpp:version>
+        <xmpp:since>7.0</xmpp:since>
       </xmpp:SupportedXep>
     </implements>
     <implements>
@@ -608,6 +610,14 @@
       <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0420.html" />
         <xmpp:status>planned</xmpp:status>
+      </xmpp:SupportedXep>
+    </implements>
+    <implements>
+      <xmpp:SupportedXep>
+        <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0421.html" />
+        <xmpp:status>complete</xmpp:status>
+        <xmpp:version>1.0.1</xmpp:version>
+        <xmpp:since>6.4.1</xmpp:since>
       </xmpp:SupportedXep>
     </implements>
     <implements>
@@ -703,7 +713,9 @@
     <implements>
       <xmpp:SupportedXep>
         <xmpp:xep rdf:resource="https://xmpp.org/extensions/xep-0484.html" />
-        <xmpp:status>planned</xmpp:status>
+        <xmpp:status>complete</xmpp:status>
+        <xmpp:version>0.2.0</xmpp:version>
+        <xmpp:since>7.0</xmpp:since>
       </xmpp:SupportedXep>
     </implements>
     <implements>


### PR DESCRIPTION
This PR:
- Fixes the unstable order of reactions from the same user
- Addresses the review feedback given in #1424
- Renames a few properties, and adds a new one

I can squash the #1424 fixes in one commit if you want.

P.S. we have to use `NSMutableOrderedSet` in Swift, because it has no bridged Swift-native equivalent. Yes there is `OrderedSet` in `swift-collections`, but it's not bridged to `NSOrderedSet`. (meaning you can't use it when calling methods defined in objective-C that expect `NSOrderedSet`)

