### PR TITLE
Bump SwiftPM dependencies

### DIFF
--- a/Monal/Classes/ChannelMemberList.swift
+++ b/Monal/Classes/ChannelMemberList.swift
@@ -14,6 +14,7 @@ struct ChannelMemberList: View {
     @State private var ownRole: String;
     @StateObject var channel: ObservableKVOWrapper<MLContact>
     @State private var participants: OrderedDictionary<String, [String:String]>
+    @StateObject private var overlay = LoadingOverlayState()
 
     init(mucContact: ObservableKVOWrapper<MLContact>) {
         account = mucContact.obj.account! as xmpp
@@ -50,6 +51,18 @@ struct ChannelMemberList: View {
     
 
     var body: some View {
+        if ownRole == kMucRoleVisitor {
+            HStack {
+                Spacer().frame(width:20)
+                Button("Request Voice") {
+                    showPromisingLoadingOverlay(overlay, headline:"Requesting Voice") {
+                        Guarantee { $0(account.mucProcessor.requestVoice(inMuc:channel.contactJid)) }
+                    }
+                }
+                .foregroundStyle(Color.green)
+                Spacer()
+            }
+        }
         List {
             Section(header: Text("\(self.channel.contactDisplayName as String) (affiliation: \(mucAffiliationToString(ownAffiliation, ownRole)))")) {
                 ForEach(participants.keys, id: \.self) { participant_key in
@@ -63,6 +76,7 @@ struct ChannelMemberList: View {
                 }
             }
         }
+        .addLoadingOverlay(overlay)
         .navigationBarTitle(Text("Channel Participants"), displayMode: .inline)
         .onAppear {
             updateParticipantList()

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -50,7 +50,7 @@ struct ContactDetails: View {
             self.ownRole = DataLayer.sharedInstance().getOwnRole(inGroupOrChannel: contact.obj) ?? kMucRoleNone
             self.ownAffiliation = DataLayer.sharedInstance().getOwnAffiliation(inGroupOrChannel:contact.obj) ?? kMucAffiliationNone
         } else {
-            self.ownRole = kMucRoleParticipant
+            self.ownRole = kMucRoleNone
             self.ownAffiliation = kMucAffiliationNone
         }
     }
@@ -260,6 +260,15 @@ struct ContactDetails: View {
             
             // info/nondestructive buttons
             Section {
+                if ownRole == kMucRoleVisitor {
+                    Button("Request Voice") {
+                        showPromisingLoadingOverlay(overlay, headline:"Requesting Voice") {
+                            Guarantee { $0(account.mucProcessor.requestVoice(inMuc:contact.obj.contactJid)) }
+                        }
+                    }
+                    .foregroundStyle(Color.green)
+                }
+                
                 if !contact.isSelf {
                     Button {
                         if contact.isMuc {

--- a/Monal/Classes/MLMucProcessor.h
+++ b/Monal/Classes/MLMucProcessor.h
@@ -31,6 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 -(void) destroyRoom:(NSString*) room;
 -(void) changeNameOfMuc:(NSString*) room to:(NSString*) name;
 -(void) changeSubjectOfMuc:(NSString*) room to:(NSString*) subject;
+-(void) requestVoiceInMuc:(NSString*) roomJid;
 -(AnyPromise*) publishAvatar:(UIImage* _Nullable) image forMuc:(NSString*) room;
 -(void) setAffiliation:(NSString*) affiliation ofUser:(NSString*) jid inMuc:(NSString*) roomJid;
 -(void) inviteUser:(NSString*) jid inMuc:(NSString*) roomJid;

--- a/Monal/Classes/MLMucProcessor.m
+++ b/Monal/Classes/MLMucProcessor.m
@@ -1285,6 +1285,16 @@ $$instance_handler(handleAffiliationUpdateResult, account.mucProcessor, $$ID(xmp
     [self callSuccessUIHandlerForMuc:iqNode.fromUser];
 $$
 
+-(void) requestVoiceInMuc:(NSString*) roomJid
+{
+    DDLogInfo(@"Requesting voice in '%@'...", roomJid);
+    XMPPMessage* msg = [[XMPPMessage alloc] initWithType:kMessageNormalType to:roomJid];
+    [msg addChildNode:[[XMPPDataForm alloc] initWithType:@"submit" formType:@"http://jabber.org/protocol/muc#request" andDictionary:@{
+        @"muc#role": @"participant",
+    }]];
+    [_account send:msg];
+}
+
 -(void) changeNameOfMuc:(NSString*) room to:(NSString*) name
 {
     [self incrementNameChange:room];

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/monal-im/ExyteChat",
         "state": {
           "branch": "main",
-          "revision": "3b4b41202fc656443b599935a60be431d571f9b6",
+          "revision": "9852f899cea836194c67597fe5e2a1d9e72797c7",
           "version": null
         }
       },


### PR DESCRIPTION
This updates our ExyteChat fork with two things:
- It fixes a crash in the audio recorder that affects small-screen devices. I already opened a PR in the upstream ExyteChat with this fix.
- It fixes the displayed time in the audio recorder not getting updated unless the user presses one of the buttons.
It turns out this is caused by our switch from struct to class for `Recording`.
And since we're not extending `Recording` in Monal, I switched it back to a struct.
See https://github.com/monal-im/ExyteChat/commit/9852f899cea836194c67597fe5e2a1d9e72797c7
I don't think we'll need to extend it in the future (it's a very simple struct), but should the need ever arise, we can then reverse this change and look for a fix that keeps `Recording` a class

A demonstration of the second fixed issue:
Before:

https://github.com/user-attachments/assets/b0178c0d-7635-43c5-9878-ee33642cd5e2

After:

https://github.com/user-attachments/assets/0116621f-e5e3-48cd-822d-43174e04cfb9

