### PR TITLE
Fix the handling of stanzaId updates in MLMessage

### DIFF
--- a/Monal/Classes/MLMessage.m
+++ b/Monal/Classes/MLMessage.m
@@ -180,15 +180,20 @@ static NSMutableDictionary* _singletonCache;
         MLAssert(correctedText != nil, @"Message correction notification without the corrected text");
         self.messageText = correctedText;
     }
-    else if(reactionsUpdate.boolValue)
+
+    if(reactionsUpdate.boolValue)
     {
+        // Reactions update
         MLAssert(data[@"reactions"] != nil, @"Reactions updates MUST contain a reactions dictionary!");
         self.reactions = data[@"reactions"];
     }
-    
-    // MUC reflection and everything else
-    DDLogDebug(@"Updating stanzaid of %p: %@", self, data[@"stanzaId"]);
-    self.stanzaId = data[@"stanzaId"];
+
+    if(data[@"stanzaId"])
+    {
+        // MUC reflection
+        DDLogDebug(@"Updating stanzaid of %p: %@", self, data[@"stanzaId"]);
+        self.stanzaId = data[@"stanzaId"];
+    }
 }
 
 // Handle message retraction and moderation


### PR DESCRIPTION
Update the `stanzaId` property only if a `stanzaId` was provided in the notification.
This prevents the `stanzaId` property from wrongly becoming `nil` while handling message update notifications that don't contain a `stanzaId` update.