### PR TITLE
 Fix contact avatar and nickname changes being ignored (oldstable/6.4-line backport)

### DIFF
--- a/Monal/Classes/MLPubSubProcessor.m
+++ b/Monal/Classes/MLPubSubProcessor.m
@@ -63,7 +63,7 @@ $$
 
 $$class_handler(avatarHandler, $$ID(xmpp*, account), $$ID(NSString*, jid), $$ID(NSString*, type), $_ID((NSDictionary<NSString*, MLXMLNode*>*), data))
     MLContact* contact = [MLContact createContactFromJid:jid andAccountNo:account.accountNo];
-    if(contact.isSubscribedTo)
+    if(!contact.isSubscribedTo)
     {
         DDLogWarn(@"Ignoring incoming avatar update of user we are not subscribed to: %@", contact);
         return;
@@ -183,7 +183,7 @@ $$
 
 $$class_handler(rosterNameHandler, $$ID(xmpp*, account), $$ID(NSString*, jid), $$ID(NSString*, type), $_ID((NSDictionary<NSString*, MLXMLNode*>*), data))
     MLContact* contact = [MLContact createContactFromJid:jid andAccountNo:account.accountNo];
-    if(contact.isSubscribedTo)
+    if(!contact.isSubscribedTo)
     {
         DDLogWarn(@"Ignoring incoming XEP-0172 nick update of user we are not subscribed to: %@", contact);
         return;


### PR DESCRIPTION
This is a backport of #1537 to the oldstable/6.4-line branch