### PR TITLE
1.17.0

### DIFF
--- a/.github/workflows/quicksy.build-push.yml
+++ b/.github/workflows/quicksy.build-push.yml
@@ -132,8 +132,8 @@ jobs:
           if-no-files-found: error
       - uses: actions/upload-artifact@v4
         with:
-          name: monal-ios-dsym
-          path: Monal/build/ios_Monal.xcarchive/dSYMs
+          name: quicksy-ios-dsym
+          path: Monal/build/ios_Quicksy.xcarchive/dSYMs
           if-no-files-found: error
       - name: validate ios app
         run: xcrun altool --validate-app --file ./Monal/build/ipa/Quicksy.ipa --type ios -u $(cat /Users/ci/apple_connect_upload_mail.txt) -p "$(cat /Users/ci/apple_connect_upload_secret.txt)"


### PR DESCRIPTION
- Fix random black video feed on video calls
- Fix accidental reordering of chats when opening a chat
- Fix automatic speaker activation in video calls
- Don't mirror local camera view in video calls
- Don't play call error sounds indefinitely
- Fix crash on incoming non-spec-conformant LMC
- Improve OMEMO discovery for chats with users not in our contact list
- Update ssdp implementation to version 0.4
- Properly open links in external browser, if configured to do so
- Fix the discovery of jid type (muc/account) for some bridges