### PR TITLE
Use https instead of ssh for all submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,4 +8,4 @@
 	branch = main
 [submodule "appstore_metadata"]
 	path = appstore_metadata
-	url = git@github.com:monal-im/Monal-localization-appstore.git
+	url = https://github.com/monal-im/Monal-localization-appstore.git


### PR DESCRIPTION
Checking out using ssh works if you use a key which is registered with github, but fails with permission denied otherwise.

This means that git submodule update would fail if cloning the project without a github account, or on a device where your ssh key is not available (in my case).