### PR TITLE
Use AVAudioSessionCategoryOptionAllowBluetoothHFP

### DIFF
--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -522,7 +522,7 @@
     // AVAudioSessionCategoryOptionAllowBluetoothHFP is the same in reverse.
     // __IPHONE_26_0 is only defined in SDKs >= 26.
     // See https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956
-    // Once all developers and the build run XCode 26, remove the guards in favour of AVAudioSessionCategoryOptionAllowBluetoothHFP.
+    // TODO: Once all developers and the build run XCode 26, remove the guards in favour of AVAudioSessionCategoryOptionAllowBluetoothHFP.
 #ifdef __IPHONE_26_0
     options |= AVAudioSessionCategoryOptionAllowBluetoothHFP;
 #else

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -517,7 +517,18 @@
     DDLogInfo(@"Activating audio session now: %@", audioSession);
     [[RTCAudioSession sharedInstance] lockForConfiguration];
     NSUInteger options = 0;
+
+    // AVAudioSessionCategoryOptionAllowBluetooth is available in SDK 26, but not SDK 16.
+    // AVAudioSessionCategoryOptionAllowBluetoothHFP is the same in reverse.
+    // __IPHONE_26_0 is only defined in SDKs >= 26.
+    // See https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956
+    // Once all developers and the build run XCode 26, remove the guards in favour of AVAudioSessionCategoryOptionAllowBluetoothHFP.
+#ifdef __IPHONE_26_0
+    options |= AVAudioSessionCategoryOptionAllowBluetoothHFP;
+#else
     options |= AVAudioSessionCategoryOptionAllowBluetooth;
+#endif
+
     options |= AVAudioSessionCategoryOptionAllowBluetoothA2DP;
     options |= AVAudioSessionCategoryOptionInterruptSpokenAudioAndMixWithOthers;
     options |= AVAudioSessionCategoryOptionAllowAirPlay;


### PR DESCRIPTION
`AVAudioSessionCategoryOptionAllowBluetooth` is deprecated now, and Monal fails to build on XCode 26 as a result.

`AVAudioSessionCategoryOptionAllowBluetoothHFP` is equivalent to `AVAudioSessionCategoryOptionAllowBluetooth`: both enums are defined as `0x4` in `AVAudioSessionTypes.h` and there is a quick-fix in XCode to make the replacement.

[There is no graceful deprecation](https://forums.swift.org/t/xcode-26-avaudiosession-categoryoptions-allowbluetooth-deprecated/80956): `AVAudioSessionCategoryOptionAllowBluetoothHFP` is not available in XCode 16, while `AVAudioSessionCategoryOptionAllowBluetooth` does not compile in XCode 26. So, we need a preprocessor guard to let it compile with both SDKs.

To do this, we can check if `__IPHONE_26_0` is defined: it only is in XCode 26 and above, in `AvailabilityVersions.h.`

I tested with XCode 16.4 and 26.0: both compiled, selecting the correct branch in each case.