### PR TITLE
6.4.18-b1

### DIFF
--- a/Monal/Classes/ActiveChatsViewController.m
+++ b/Monal/Classes/ActiveChatsViewController.m
@@ -313,6 +313,8 @@ static NSMutableSet* _pushWarningDisplayed;
     self.chatListTable.emptyDataSetSource = self;
     self.chatListTable.emptyDataSetDelegate = self;
     
+    [self refresh];
+    
     //has to be done here to not always prepend intro screens onto our view queue
     //once a fullscreen view is dismissed (or the app is switched to foreground)
     [self segueToIntroScreensIfNeeded];
@@ -355,13 +357,15 @@ static NSMutableSet* _pushWarningDisplayed;
         }
     };
 
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [HelperTools dispatchAsync:YES reentrantOnQueue:dispatch_get_main_queue() withBlock:^{
         size_t unpinnedConCntBefore = self.unpinnedContacts.count;
         size_t pinnedConCntBefore = self.pinnedContacts.count;
         NSMutableArray<MLContact*>* newUnpinnedContacts = [[DataLayer sharedInstance] activeContactsWithPinned:NO];
         NSMutableArray<MLContact*>* newPinnedContacts = [[DataLayer sharedInstance] activeContactsWithPinned:YES];
-        if(!newUnpinnedContacts || ! newPinnedContacts)
-            return;
+        if(!newUnpinnedContacts)
+            newUnpinnedContacts = [NSMutableArray new];
+        if(!newPinnedContacts)
+            newPinnedContacts = [NSMutableArray new];
 
         int unpinnedCntDiff = (int)unpinnedConCntBefore - (int)newUnpinnedContacts.count;
         int pinnedCntDiff = (int)pinnedConCntBefore - (int)newPinnedContacts.count;
@@ -380,8 +384,8 @@ static NSMutableSet* _pushWarningDisplayed;
                 [self presentChatWithContact:nil];
         }
         
-        if(self.chatListTable.hasUncommittedUpdates)
-            return;
+//         if(self.chatListTable.hasUncommittedUpdates)
+//             return;
         [CATransaction begin];
         [UIView performWithoutAnimation:^{
             [self.chatListTable beginUpdates];
@@ -398,7 +402,7 @@ static NSMutableSet* _pushWarningDisplayed;
 
         MonalAppDelegate* appDelegate = (MonalAppDelegate*)[UIApplication sharedApplication].delegate;
         [appDelegate updateUnread];
-    });
+    }];
 }
 
 -(void) refreshContact:(NSNotification*) notification
@@ -566,9 +570,7 @@ static NSMutableSet* _pushWarningDisplayed;
                 [self.chatListTable insertRowsAtIndexPaths:@[insertAtPath] withRowAnimation:UITableViewRowAnimationRight];
                 //make sure to fully refresh to remove the empty dataset (yes this will trigger on first chat pinning, too, but that does no harm)
                 if(oldCount == 0)
-                    dispatch_async(dispatch_get_main_queue(), ^{
-                        [self refreshDisplay];
-                    });
+                    [self refreshDisplay];
             }
         } completion:^(BOOL finished) {
             if(completion) completion(finished);
@@ -594,7 +596,6 @@ static NSMutableSet* _pushWarningDisplayed;
 {
     DDLogDebug(@"active chats view did appear");
     [super viewDidAppear:animated];
-    
     [self refresh];
 }
 
@@ -605,10 +606,10 @@ static NSMutableSet* _pushWarningDisplayed;
 
 -(void) refresh
 {
-    dispatch_async(dispatch_get_main_queue(), ^{
+    [HelperTools dispatchAsync:YES reentrantOnQueue:dispatch_get_main_queue() withBlock:^{
         [self refreshDisplay];      // load contacts
         [self processViewQueue];
-    });
+    }];
 }
 
 -(void) didReceiveMemoryWarning

--- a/Monal/Classes/AddContactMenu.swift
+++ b/Monal/Classes/AddContactMenu.swift
@@ -156,7 +156,7 @@ struct AddContactMenu: View {
                     self.newContact = MLContact.createContact(fromJid: jid, andAccountNo: account.accountNo)
                     successAlert(title: Text("Success!"), message: Text("Successfully joined group/channel \(jid)!"))
                 }.catch { error in
-                    errorAlert(title: Text("Error entering group/channel!"), message: Text("\(String(describing:error))"))
+                    errorAlert(title: Text("Error entering group/channel!"), message: Text(error.localizedDescription))
                 }
             }
         }.catch { error in

--- a/Monal/Classes/ContactDetails.swift
+++ b/Monal/Classes/ContactDetails.swift
@@ -582,7 +582,7 @@ struct ContactDetails: View {
                                                 }
                                                 successAlert(title: Text("Success"), message: contact.mucType == "group" ? Text("Successfully destroyed group.") : Text("Successfully destroyed channel."))
                                             }.catch { error in
-                                                errorAlert(title: Text("Error destroying group!"), message: Text("\(String(describing:error))"))
+                                                errorAlert(title: Text("Error destroying group!"), message: Text(error.localizedDescription))
                                             }
                                         }
                                     )

--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -1091,6 +1091,11 @@
             [db executeNonQuery:@"ALTER TABLE account DROP COLUMN 'supports_sasl2';"];
         }];
         
+        //make sure all omemo devices have a "last used" timestamp
+        [self updateDB:db withDataLayer:dataLayer toVersion:6.407 withBlock:^{
+            [db executeNonQuery:@"UPDATE signalContactIdentity SET lastReceivedMsg=CURRENT_TIMESTAMP WHERE lastReceivedMsg IS NULL;"];
+        }];
+
         
         //check if device id changed and invalidate state, if so
         //but do so only for non-sandbox (e.g. non-development) installs

--- a/Monal/Classes/GeneralSettings.swift
+++ b/Monal/Classes/GeneralSettings.swift
@@ -59,6 +59,12 @@ class GeneralSettingsDefaultsDB: ObservableObject {
     @defaultsDB("OMEMODefaultOn") 
     var omemoDefaultOn:Bool
     
+    @defaultsDB("allowMixedTrustInGroups")
+    var allowMixedTrustInGroups: Bool
+    
+    @defaultsDB("allowUnverifiedCalls")
+    var allowUnverifiedCalls: Bool
+    
     @defaultsDB("AutodeleteInterval")
     var AutodeleteInterval: Int
     
@@ -287,9 +293,43 @@ struct SecuritySettings: View {
             Section(header: Text("Encryption")) {
                 SettingsToggle(isOn: $generalSettingsDefaultsDB.omemoDefaultOn) {
                     Text("Enable encryption by default for new chats")
-                    Text("Every new contact will have encryption enabled, but already known contacts will preserve their encryption settings.")
+                    Text(
+"""
+Every new contact will have encryption enabled, but already known contacts will preserve their encryption settings.
+Generally this should never be turned off by members of high risk groups like journalists, activists etc.
+"""
+                    )
                 }
                 
+                SettingsToggle(isOn: $generalSettingsDefaultsDB.allowUnverifiedCalls) {
+                    Text("Allow unverified calls in encrypted chats")
+                    Text(
+"""
+Allow calls not being OMEMO-verified in OMEMO encrypted chats.
+If you turn this off, you won't be able to place or receive calls to/from contacts not using a client implementing [http://gultsch.de/xmpp/drafts/omemo/dlts-srtp-verification](https://gist.github.com/iNPUTmice/aa4fc0aeea6ce5fb0e0fe04baca842cd).
+This should be turned off by members of high risk groups like journalists, activists etc.
+"""
+                    )
+                }
+                
+                SettingsToggle(isOn: $generalSettingsDefaultsDB.allowMixedTrustInGroups) {
+                    Text("Allow BTBV-only participants in verified encrypted groups")
+                    Text(
+"""
+If this is off, you won't send encrypted messages to members of a group not having any explicitly trusted device once you explicitly trusted/distrusted at least one single device of another member of this group.
+Use with care, because this means you'll have to explicitly trust at least one device of *all* members of a group once you started manually changing the trust of one device of a member of this group (even if you did this in an 1:1 chat with one of the members)!
+Generally this should only be turned off by members of high risk groups like journalists, activists etc.
+"""
+                    )
+                }
+            }
+
+            Section(header: Text("Networking")) {
+                SettingsToggle(isOn: $generalSettingsDefaultsDB.webrtcAllowP2P) {
+                    Text("Calls: Allow P2P sessions")
+                    Text("Allow your device to establish a direct network connection to the remote party. This might leak your IP address to the caller/callee.")
+                }
+
                 if #available(iOS 16.0, macCatalyst 16.0, *) {
                     SettingsToggle(isOn: $generalSettingsDefaultsDB.useDnssecForAllConnections) {
                         Text("Use DNSSEC validation for all connections")
@@ -302,11 +342,6 @@ like hotel wifi, ugly mobile carriers etc.
 """
                         )
                     }
-                }
-                
-                SettingsToggle(isOn: $generalSettingsDefaultsDB.webrtcAllowP2P) {
-                    Text("Calls: Allow P2P sessions")
-                    Text("Allow your device to establish a direct network connection to the remote party. This might leak your IP address to the caller/callee.")
                 }
             }
             

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -1568,6 +1568,14 @@
                     return;
                 }
             }
+            
+            //all calls in encrypted chats eventually reach this point (either as session-initiate or as session-accept)
+            //--> check if we allow unverified calls and abort if the call is unverified and this isn't allowed
+            if(![[HelperTools defaultsDB] boolForKey:@"allowUnverifiedCalls"] && self.encryptionState == MLCallEncryptionStateClear)
+            {
+                [self handleEndCallActionWithReason:MLCallFinishReasonSecurityError];
+                return;
+            }
         }
         else
             self.encryptionState = MLCallEncryptionStateClear;
@@ -1765,15 +1773,22 @@
 
 -(MLCallEncryptionState) encryptionTypeForDeviceid:(NSNumber* _Nonnull) deviceid
 {
+    //problem is: an attacking server could simply strip out the omemo deviceid from the <proceed> to downgrade us to a non-verified call
+    //dropping calls from a device not trusted but known, would not improve security because the attacker using that device could simply
+    //strip off the omemo deviceid from the <proceed>
+    //--> simply report those calls as unverified (MLCallEncryptionStateClear)
+    //if configured to not allow unverified calls, we drop all MLCallEncryptionStateClear calls in processIncomingSDP
+    
     NSNumber* trustLevel = [self.account.omemo getTrustLevelForJid:self.contact.contactJid andDeviceId:deviceid];
+    DDLogVerbose(@"Trust level: %@", trustLevel);
+    
     if(trustLevel == nil)
         return MLCallEncryptionStateClear;
-    switch(trustLevel.intValue)
-    {
-        case MLOmemoTrusted: return MLCallEncryptionStateTrusted;
-        case MLOmemoToFU: return MLCallEncryptionStateToFU;
-        default: return MLCallEncryptionStateClear;
-    }
+    else if([MLSignalStore acceptedTrustLevel:trustLevel.intValue withTofu:NO andOutgoing:(self.direction == MLCallDirectionOutgoing)])
+        return MLCallEncryptionStateTrusted;
+    else if([MLSignalStore acceptedTrustLevel:trustLevel.intValue withTofu:YES andOutgoing:(self.direction == MLCallDirectionOutgoing)])
+        return MLCallEncryptionStateToFU;
+    return MLCallEncryptionStateClear;
 }
 
 -(BOOL) encryptFingerprintsInChildren:(NSArray<MLXMLNode*>*) children
@@ -1820,7 +1835,7 @@
             DDLogWarn(@"More than one OMEMO envelope found!");
             return NO;
         }
-        NSString* decryptedFingerprint = [self.account.omemo decryptOmemoEnvelope:[fingerprintNode findFirst:@"{eu.siacs.conversations.axolotl}encrypted"] forSenderJid:self.contact.contactJid andReturnErrorString:NO];
+        NSString* decryptedFingerprint = [self.account.omemo decryptOmemoEnvelope:[fingerprintNode findFirst:@"{eu.siacs.conversations.axolotl}encrypted"] forSenderJid:self.contact.contactJid inMuc:nil andReturnErrorString:NO];
         if(decryptedFingerprint == nil)
         {
             DDLogWarn(@"Could not decrypt OMEMO encrypted fingerprint!");

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -223,17 +223,10 @@
 -(void) setSpeaker:(BOOL) speaker
 {
     @synchronized(self) {
-        DDLogError(@"*** setSpeaker:%@ called...", bool2str(speaker));
         if(self.webRTCClient == nil || self.audioSession == nil)
-        {
-            DDLogError(@"*** setSpeaker: not ready: %@, %@", self.webRTCClient, self.audioSession);
             return;
-        }
         if(_speaker == speaker)
-        {
-            DDLogError(@"*** setSpeaker: called but identical...");
             return;
-        }
         _speaker = speaker;
         if(_speaker)
             [self.webRTCClient speakerOn];
@@ -484,7 +477,7 @@
     [[RTCAudioSession sharedInstance] unlockForConfiguration];
     if(self.callType == MLCallTypeVideo)
     {
-        DDLogError(@"*** Activating speaker...");
+        DDLogInfo(@"*** Video call detected, activating speaker...");
         self.speaker = YES;
     }
 }

--- a/Monal/Classes/MLCall.m
+++ b/Monal/Classes/MLCall.m
@@ -876,7 +876,7 @@
         DDLogDebug(@"WebRTC reported local SDP '%@', sending to '%@': %@", [RTCSessionDescription stringForType:sdp.type], self.fullRemoteJid, sdp.sdp);
         
         NSArray<MLXMLNode*>* children = [HelperTools sdp2xml:sdp.sdp withInitiator:YES];
-        if(children.count == 0)
+        if(children == nil || children.count == 0)
         {
             DDLogError(@"Could not serialize local SDP to XML!");
             [self handleEndCallActionWithReason:MLCallFinishReasonError];

--- a/Monal/Classes/MLIQProcessor.m
+++ b/Monal/Classes/MLIQProcessor.m
@@ -204,6 +204,7 @@ $$class_handler(handleCatchup, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode), $$BO
         }
         return;
     }
+    //we need to check for the rsm/last element because of a weird ejabberd bug sending complete=false, but no rsm last element
     if(![[iqNode findFirst:@"{urn:xmpp:mam:2}fin@complete|bool"] boolValue] && [iqNode check:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/last#"])
     {
         DDLogVerbose(@"Paging through mam catchup results at %@ with after: %@", account.connectionProperties.identity.jid, [iqNode findFirst:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/last#"]);
@@ -212,7 +213,7 @@ $$class_handler(handleCatchup, $$ID(xmpp*, account), $$ID(XMPPIQ*, iqNode), $$BO
         [pageQuery setMAMQueryAfter:[iqNode findFirst:@"{urn:xmpp:mam:2}fin/{http://jabber.org/protocol/rsm}set/last#"]];
         [account sendIq:pageQuery withHandler:$newHandler(self, handleCatchup, $BOOL(secondTry, NO))];
     }
-    else if([[iqNode findFirst:@"{urn:xmpp:mam:2}fin@complete|bool"] boolValue])
+    else
     {
         DDLogVerbose(@"Mam catchup finished for %@", account.connectionProperties.identity.jid);
         [account mamFinishedFor:account.connectionProperties.identity.jid];

--- a/Monal/Classes/MLOMEMO.h
+++ b/Monal/Classes/MLOMEMO.h
@@ -32,7 +32,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 -(MLXMLNode* _Nullable) encryptString:(NSString* _Nullable) message toDeviceids:(NSDictionary<NSString*, NSSet<NSNumber*>*>*) contactDeviceMap;
 -(void) encryptMessage:(XMPPMessage*) messageNode withMessage:(NSString* _Nullable) message toContact:(NSString*) toContact;
--(NSString* _Nullable) decryptOmemoEnvelope:(MLXMLNode*) envelope forSenderJid:(NSString*) senderJid andReturnErrorString:(BOOL) returnErrorString;
+-(NSString* _Nullable) decryptOmemoEnvelope:(MLXMLNode*) envelope forSenderJid:(NSString*) senderJid inMuc:(NSString* _Nullable) mucJid andReturnErrorString:(BOOL) returnErrorString;
 -(NSString* _Nullable) decryptMessage:(XMPPMessage*) messageNode withMucParticipantJid:(NSString* _Nullable) mucParticipantJid;
 
 -(NSSet<NSNumber*>*) knownDevicesForAddressName:(NSString*) addressName;

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -1288,7 +1288,7 @@ $$
     BOOL devicePreKey = [[envelope findFirst:@"header/key<rid=%u>@prekey|bool", self.monalSignalStore.deviceid] boolValue];
     
     DDLogVerbose(@"Decrypting using:\nrid=%u --> messageKey=%@\nrid=%u --> isPreKey=%@", self.monalSignalStore.deviceid, messageKey, self.monalSignalStore.deviceid, bool2str(devicePreKey));
-
+    
     if(!messageKey && isKeyTransportElement)
     {
         DDLogVerbose(@"Received KeyTransportElement without our own rid included --> Ignore it");
@@ -1377,6 +1377,11 @@ $$
                 return nil;
 #endif
             }
+            
+            //make sure the dh ratchet always advances, even on "receive only" devices
+            //--> force a key transport message with 1% probability (~ every 100th message)
+            if(arc4random_uniform(100)==42)
+                [self sendKeyTransportElement:senderJid forRids:[NSSet setWithArray:@[sid]]];
 
             //some clients have the auth parameter in the ciphertext?
             if(decryptedKey.length == 16 * 2)

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -443,6 +443,23 @@ $$instance_handler(handleDevicelistFetch, account.omemo, $$ID(xmpp*, account), $
     [self sendFetchUpdateNotificationForJid:jid];
 $$
 
+-(void) postOMEMOMessageForUser:(NSString*) jid withMessage:(NSString*) omemoMessage
+{
+    if(![[DataLayer sharedInstance] isContactInList:jid forAccount:self.account.accountNo]) {
+        [[DataLayer sharedInstance] addContact:jid forAccount:self.account.accountNo nickname:nil];
+    }
+    NSString* newMessageID = [[NSUUID UUID] UUIDString];
+    NSNumber* historyId = [[DataLayer sharedInstance] addMessageHistoryTo:jid forAccount:self.account.accountNo withMessage:omemoMessage actuallyFrom:jid withId:newMessageID encrypted:NO messageType:kMessageTypeStatus mimeType:nil size:nil];
+
+    MLMessage* message = [[DataLayer sharedInstance] messageForHistoryID:historyId];
+    MLContact* contact = [MLContact createContactFromJid:jid andAccountNo:self.account.accountNo];
+    [[MLNotificationQueue currentQueue] postNotificationName:kMonalNewMessageNotice object:self.account userInfo:@{
+        @"message": message,
+        @"showAlert": @(NO),
+        @"contact": contact,
+    }];
+}
+
 -(void) processOMEMODevices:(NSSet<NSNumber*>*) receivedDevices from:(NSString*) source
 {
     DDLogVerbose(@"Processing omemo devices from %@: %@", source, receivedDevices);
@@ -477,6 +494,7 @@ $$
         if(![source isEqualToString:self.account.connectionProperties.identity.jid] || deviceId.unsignedIntValue != self.monalSignalStore.deviceid)
         {
             DDLogDebug(@"Removing device %@", deviceId);
+            [self postOMEMOMessageForUser:source withMessage:[NSString stringWithFormat:NSLocalizedString(@"OMEMO: Device %@ is now inactive, because it is no longer advertised by your contact", @"OMEMO warning shown inside chat view"), deviceId]];
             SignalAddress* address = [[SignalAddress alloc] initWithName:source deviceId:deviceId.unsignedIntValue];
             [self.monalSignalStore markDeviceAsDeleted:address];
         }
@@ -635,6 +653,8 @@ $$instance_handler(handleBundleFetchResult, account.omemo, $$ID(xmpp*, account),
     }
     else
     {
+        [self postOMEMOMessageForUser:jid withMessage:[NSString stringWithFormat:NSLocalizedString(@"OMEMO: Detected new device with id: %@", @"OMEMO warning shown inside chat view"), rid]];
+
         //check that a corresponding buddy exists -> prevent foreign key errors
         MLXMLNode* receivedKeys = data[@"current"];
         if(receivedKeys == nil && data.count == 1)

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -953,6 +953,21 @@ $$
     }
 }
 
+$$instance_handler(omemoBundlePublished, account.omemo, $$ID(xmpp*, account), $$BOOL(success), $_ID(XMPPIQ*, errorIq), $_ID(NSString*, errorReason))
+    if(success)
+    {
+        DDLogInfo(@"Successfully published own omemo bundle...");
+        [self.monalSignalStore deleteUsedPrekeys];
+    }
+    else
+        DDLogError(@"Unable to published own omemo bundle: %@; %@", errorReason, errorIq);
+    
+    
+$$
+$$instance_handler(omemoBundlePublishedInvalidation, account.omemo, $$ID(xmpp*, account), $$BOOL(success), $_ID(XMPPIQ*, errorIq), $_ID(NSString*, errorReason))
+    DDLogInfo(@"Failed to publish own omemo bundle, publish was invalidated");
+$$
+
 -(void) sendOMEMOBundle
 {
     MLAssert(self.monalSignalStore.deviceid > 0, @"Tried to publish own bundle without knowing my own deviceid!");
@@ -976,7 +991,7 @@ $$
     ] andData:nil] onNode:[NSString stringWithFormat:@"eu.siacs.conversations.axolotl.bundles:%u", self.monalSignalStore.deviceid] withConfigOptions:@{
         @"pubsub#persist_items": @"true",
         @"pubsub#access_model": @"open"
-    }];
+    } andHandler:$newHandlerWithInvalidation(self, omemoBundlePublished, omemoBundlePublishedInvalidation)];
 }
 
 /*
@@ -987,12 +1002,13 @@ $$
 {
     // generate new keys if less than MIN_OMEMO_KEYS are available
     unsigned int preKeyCount = [self.monalSignalStore getPreKeyCount];
+    int lastPreyKedId = [self.monalSignalStore getHighestPreyKeyId];
+    DDLogDebug(@"Current prekey count: %u, lastPreyKedId=%d", preKeyCount, lastPreyKedId);
     if(preKeyCount < MIN_OMEMO_KEYS)
     {
         SignalKeyHelper* signalHelper = [[SignalKeyHelper alloc] initWithContext:self.signalContext];
 
         // Generate new keys so that we have a total of MAX_OMEMO_KEYS keys again
-        int lastPreyKedId = [self.monalSignalStore getHighestPreyKeyId];
         if(MAX_OMEMO_KEYS < preKeyCount)
         {
             DDLogWarn(@"OMEMO MAX_OMEMO_KEYs has changed: MAX: %zu current: %u", MAX_OMEMO_KEYS, preKeyCount);
@@ -1391,6 +1407,9 @@ $$
                     [self.state.queuedSessionRepairs[senderJid] removeObject:sid];
                 }
             }
+            
+            //mark used prekeys for removal
+            [self.monalSignalStore deletePreKeyWithId:devicePreKey];
 
             //key transport elements have an empty payload --> nothing to return as decrypted
             if(isKeyTransportElement)

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -789,7 +789,7 @@ $$
 
     if(preKeyIds == nil || preKeyIds.count == 0)
     {
-        DDLogWarn(@"Could not create array of preKeyIds, ignoring: preKeyIds=%@ %lu", preKeyIds, (unsigned long)preKeyIds.count);
+        DDLogWarn(@"Could not create array of preKeyIds, ignoring %lu preKeyIds: %@", (unsigned long)preKeyIds.count, preKeyIds);
         return;
     }
     
@@ -831,7 +831,6 @@ $$
             continue;
         }
         // mark session as functional
-        SignalAddress* address = [[SignalAddress alloc] initWithName:jid deviceId:(uint32_t)rid.unsignedIntValue];
         [self.monalSignalStore markBundleAsFixed:address];
 
         //found and imported a working key --> try to (re)build a new session proactively (or repair a broken one)
@@ -1560,9 +1559,7 @@ $$
 {
     NSSet<NSNumber*>* devices = [self knownDevicesForAddressName:jid];
     for(NSNumber* device in devices)
-    {
         [self deleteDeviceForSource:jid andRid:device];
-    }
     [self sendOMEMOBundle];
     [self.account.pubsub fetchNode:@"eu.siacs.conversations.axolotl.devicelist" from:self.account.connectionProperties.identity.jid withItemsList:nil andHandler:$newHandlerWithInvalidation(self, handleDevicelistFetch, handleDevicelistFetchInvalidation, $BOOL(subscribe, NO))];
     [self.account.pubsub fetchNode:@"eu.siacs.conversations.axolotl.devicelist" from:jid withItemsList:nil andHandler:$newHandlerWithInvalidation(self, handleDevicelistFetch, handleDevicelistFetchInvalidation, $BOOL(subscribe, NO))];

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 static const size_t MIN_OMEMO_KEYS = 80;
 static const size_t MAX_OMEMO_KEYS = 100;
 static const int KEY_SIZE = 16;
+static NSDictionary* trustLevels2Text = nil;
 
 @interface MLOMEMO ()
 {
@@ -41,6 +42,17 @@ static const int KEY_SIZE = 16;
 @end
 
 @implementation MLOMEMO
+
++(void) initialize
+{
+    trustLevels2Text = @{
+        @MLOmemoNotTrusted: NSLocalizedString(@"untrusted", @"OMEMO warning shown inside chat view"),
+        @MLOmemoToFU: NSLocalizedString(@"automatically trusted", @"OMEMO warning shown inside chat view"),
+        @MLOmemoToFUButNoMsgSeenInTime: NSLocalizedString(@"automatically trusted", @"OMEMO warning shown inside chat view"),
+        @MLOmemoTrusted: NSLocalizedString(@"trusted", @"OMEMO warning shown inside chat view"),
+        @MLOmemoTrustedButNoMsgSeenInTime: NSLocalizedString(@"trusted", @"OMEMO warning shown inside chat view"),
+    };
+}
 
 -(MLOMEMO*) initWithAccount:(xmpp*) account;
 {
@@ -520,30 +532,6 @@ $$
 
 -(void) handleOwnDevicelistUpdate:(NSSet<NSNumber*>*) receivedDevices
 {
-    //check for new deviceids not previously known, but only if this isn't the first login we see a devicelist
-    //this has to be a property of the xmpp class to persist it even across state resets
-    if(self.account.hasSeenOmemoDeviceListAfterOwnDeviceid)
-    {
-        NSMutableSet<NSNumber*>* newDevices = [receivedDevices mutableCopy];
-        [newDevices minusSet:self.ownDeviceList];
-        //alert for all devices now still listed in newDevices
-        for(NSNumber* device in newDevices)
-            if([device unsignedIntValue] != self.monalSignalStore.deviceid)
-            {
-                DDLogWarn(@"Got new deviceid %@ for own account %@", device, self.account.connectionProperties.identity.jid);
-                UNMutableNotificationContent* content = [UNMutableNotificationContent new];
-                content.title = NSLocalizedString(@"New omemo device", @"");;
-                content.subtitle = self.account.connectionProperties.identity.jid;
-                content.body = [NSString stringWithFormat:NSLocalizedString(@"Detected a new omemo device on your account: %@", @""), device];
-                content.sound = [UNNotificationSound defaultSound];
-                content.categoryIdentifier = @"simple";
-                UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:[NSString stringWithFormat:@"newOwnOmemoDevice::%@::%@", self.account.connectionProperties.identity.jid, device] content:content trigger:nil];
-                NSError* error = [HelperTools postUserNotificationRequest:request];
-                if(error)
-                    DDLogError(@"Error posting new deviceid notification: %@", error);
-            }
-    }
-    
     //update own devicelist (this can be an empty list, if the list on our server is empty)
     self.ownDeviceList = [receivedDevices mutableCopy];
     //this has to be a property of the xmpp class to persist it even across state resets
@@ -653,7 +641,9 @@ $$instance_handler(handleBundleFetchResult, account.omemo, $$ID(xmpp*, account),
     }
     else
     {
-        [self postOMEMOMessageForUser:jid withMessage:[NSString stringWithFormat:NSLocalizedString(@"OMEMO: Detected new device with id: %@", @"OMEMO warning shown inside chat view"), rid]];
+        //only show warning, if we don't already know this deviceid (e.g. a really new device, not a bundle fetch due to a session repair)
+        SignalAddress* address = [[SignalAddress alloc] initWithName:jid deviceId:(uint32_t)rid.unsignedIntValue];
+        NSData* oldIdentity = [self.monalSignalStore getIdentityForAddress:address];
 
         //check that a corresponding buddy exists -> prevent foreign key errors
         MLXMLNode* receivedKeys = data[@"current"];
@@ -667,7 +657,39 @@ $$instance_handler(handleBundleFetchResult, account.omemo, $$ID(xmpp*, account),
             DDLogWarn(@"More than one bundle item found from %@ rid: %@, ignoring all items!", jid, rid);
         
         if(receivedKeys)
+        {
             [self processOMEMOKeys:receivedKeys forJid:jid andRid:rid];
+            
+            NSData* newIdentity = [self.monalSignalStore getIdentityForAddress:address];
+            if(oldIdentity == nil || ![oldIdentity isEqual:newIdentity])
+            {
+                NSString* trustLevel = trustLevels2Text[[self.monalSignalStore getTrustLevel:address identityKey:newIdentity]];
+                [self postOMEMOMessageForUser:jid withMessage:[NSString stringWithFormat:NSLocalizedString(@"OMEMO: Detected new %@ device with id: %@", @"OMEMO warning shown inside chat view"), trustLevel, rid]];
+            }
+            
+            //check for new deviceids not previously known, but only if this isn't the first login we see a devicelist
+            //this has to be a property of the xmpp class to persist it even across state resets
+            if(self.account.hasSeenOmemoDeviceListAfterOwnDeviceid && [jid isEqualToString:self.account.connectionProperties.identity.jid])
+            {
+                //only show warning, if we don't already know this deviceid
+                //(e.g. a really new device, not a devicelist removal followed by adding it back)
+                if((oldIdentity == nil || ![oldIdentity isEqual:newIdentity]) && [rid unsignedIntValue] != self.monalSignalStore.deviceid)
+                {
+                    NSString* trustLevel = trustLevels2Text[[self.monalSignalStore getTrustLevel:address identityKey:newIdentity]];
+                    DDLogWarn(@"Got new %@ deviceid %@ for own account %@", trustLevel, rid, jid);
+                    UNMutableNotificationContent* content = [UNMutableNotificationContent new];
+                    content.title = NSLocalizedString(@"New omemo device", @"");;
+                    content.subtitle = jid;
+                    content.body = [NSString stringWithFormat:NSLocalizedString(@"Detected a new %@ omemo device on your account: %@", @"OMEMO warning shown as notification"), trustLevel, rid];
+                    content.sound = [UNNotificationSound defaultSound];
+                    content.categoryIdentifier = @"simple";
+                    UNNotificationRequest* request = [UNNotificationRequest requestWithIdentifier:[NSString stringWithFormat:@"newOwnOmemoDevice::%@::%@", jid, rid] content:content trigger:nil];
+                    NSError* error = [HelperTools postUserNotificationRequest:request];
+                    if(error)
+                        DDLogError(@"Error posting new deviceid notification: %@", error);
+                }
+            }
+        }
         else
         {
             DDLogWarn(@"Could not find any bundle in pubsub data from %@ rid: %@, data=%@", jid, rid, data);
@@ -1526,7 +1548,9 @@ $$
     }
 
     SignalAddress* address = [[SignalAddress alloc] initWithName:source deviceId:rid.unsignedIntValue];
-    [self.monalSignalStore deleteDeviceforAddress:address];
+    //don't delete the identity record to not trigger spurious "detected a new omemo device on your account"
+    //notifications in handleOwnDevicelistUpdate if a device was briefly removed from our devicelist before it was added back in
+    [self.monalSignalStore markDeviceAsDeleted:address];
     [self.monalSignalStore deleteSessionRecordForAddress:address];
     [self notifyKnownDevicesUpdated:address.name];
 }

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -949,9 +949,129 @@ $$
     return NO;
 }
 
+-(NSMutableDictionary<NSNumber*, NSNumber*>*) checkTrustOfAllDevices:(NSSet<NSNumber*>*) devices ofJid:(NSString*) encryptForJid
+{
+    NSMutableDictionary* trustLevels = [NSMutableDictionary new];
+    for(NSNumber* device in devices)
+    {
+        //do not encrypt for our own device (MUST be scoped by jid for omemo 2)
+        if(device.unsignedIntValue == self.monalSignalStore.deviceid)
+            continue;
+        
+        if(self.state.openBundleFetches[encryptForJid] != nil && [self.state.openBundleFetches[encryptForJid] containsObject:device])
+        {
+            DDLogWarn(@"Ignoring deviceid %@ of %@ for KeyTransportElement: bundle fetch still pending...", device, encryptForJid);
+            continue;
+        }
+        
+        SignalAddress* address = [[SignalAddress alloc] initWithName:encryptForJid deviceId:(uint32_t)device.unsignedIntValue];
+
+        NSData* identity = [self.monalSignalStore getIdentityForAddress:address];
+        if(!identity)
+        {
+            showErrorOnAlpha(self.account, @"Could not get Identity for: %@ device id %@", encryptForJid, device);
+            //TODO: is it correct to rebuild broken(?) session here, too?
+            [self rebuildSessionWithJid:encryptForJid forRid:device];
+            continue;
+        }
+        
+        //check trust level
+        trustLevels[device] = [self.monalSignalStore getTrustLevel:address identityKey:identity];
+    }
+    return trustLevels;
+}
+
+-(NSMutableDictionary<NSString*, NSMutableSet<NSNumber*>*>*) createRecipientDeviceMapFromContactDeviceMap:(NSDictionary<NSString*, NSSet<NSNumber*>*>*) contactDeviceMap withOutgoing:(BOOL) outgoing
+{
+    //query trust for all given contacts' devices
+    NSMutableDictionary<NSString*, NSMutableDictionary<NSNumber*, NSNumber*>*>* contactTrustMap = [NSMutableDictionary new];
+    for(NSString* recipient in contactDeviceMap)
+    {
+        NSMutableDictionary* trustMap = [self checkTrustOfAllDevices:contactDeviceMap[recipient] ofJid:recipient];
+        DDLogVerbose(@"Checked trust of devices of %@: %@", recipient, trustMap);
+        contactTrustMap[recipient] = trustMap;
+    }
+    
+    //check tofu state for tofu-only recipients (but only do so in mucs, e.g. more than one recipient)
+    NSMutableSet<NSString*>* tofuOnlyRecipients = [NSMutableSet new];
+    BOOL tofuOnlyRecipientAllowed = YES;
+    if(contactTrustMap.count > 1 && ![[HelperTools defaultsDB] boolForKey:@"allowMixedTrustInGroups"])
+        for(NSString* recipient in contactTrustMap)
+        {
+            BOOL tofuOnlyContact = YES;
+            for(NSNumber* device in contactTrustMap[recipient])
+            {
+                int trust = contactTrustMap[recipient][device].intValue;
+                if(!(trust == MLOmemoToFU || trust == MLOmemoToFUButRemoved || trust == MLOmemoToFUButNoMsgSeenInTime))
+                    tofuOnlyContact = NO;
+            }
+            if(tofuOnlyContact)
+                [tofuOnlyRecipients addObject:recipient];
+            else
+                tofuOnlyRecipientAllowed = NO;
+        }
+    DDLogVerbose(@"Trust state: tofuOnlyRecipientAllowed=%@, tofuOnlyRecipients=%@", bool2str(tofuOnlyRecipientAllowed), tofuOnlyRecipients);
+    
+    //add devices allowed, ignoring tofu-only recipients (in mucs), if requested to do so
+    NSMutableDictionary<NSString*, NSMutableSet<NSNumber*>*>* recipientDeviceMap = [NSMutableDictionary new];
+    for(NSString* recipient in contactTrustMap)
+    {
+        if(!tofuOnlyRecipientAllowed && [tofuOnlyRecipients containsObject:recipient])
+            continue;
+        for(NSNumber* device in contactTrustMap[recipient])
+        {
+            int trustLevel = contactTrustMap[recipient][device].intValue;
+            if(![MLSignalStore acceptedTrustLevel:trustLevel withTofu:YES andOutgoing:outgoing])
+                continue;
+            if(recipientDeviceMap[recipient] == nil)
+                recipientDeviceMap[recipient] = [NSMutableSet new];
+            [recipientDeviceMap[recipient] addObject:device];
+        }
+    }
+    
+    DDLogVerbose(@"Returning recipient device map: %@", recipientDeviceMap);
+    return recipientDeviceMap;
+}
+
+-(NSMutableSet<NSNumber*>*) getRecipientDevices:(NSString*) recipient
+{
+    NSMutableSet<NSNumber*>* recipientDevices = [NSMutableSet new];
+    [recipientDevices addObjectsFromArray:[self.monalSignalStore knownDevicesWithValidSession:recipient]];
+    // add devices with known but old broken session to trigger a bundle refetch
+    [recipientDevices addObjectsFromArray:[self.monalSignalStore knownDevicesWithPendingBrokenSessionHandling:recipient]];
+    return recipientDevices;
+}
+
+-(NSMutableDictionary<NSString*, NSSet<NSNumber*>*>*) getContactDeviceMapForContactJid:(NSString*) contactJid
+{
+    NSMutableSet<NSString*>* recipients = [NSMutableSet new];
+    if([[DataLayer sharedInstance] isBuddyMuc:contactJid forAccount:self.account.accountNo])
+        for(NSDictionary* participant in [[DataLayer sharedInstance] getMembersAndParticipantsOfMuc:contactJid forAccountId:self.account.accountNo])
+        {
+            if(participant[@"participant_jid"])
+                [recipients addObject:participant[@"participant_jid"]];
+            else if(participant[@"member_jid"])
+                [recipients addObject:participant[@"member_jid"]];
+        }
+    else
+        [recipients addObject:contactJid];
+    
+    //remove own jid from recipients (our own devices get special treatment)
+    [recipients removeObject:self.account.connectionProperties.identity.jid];
+    
+    NSMutableDictionary<NSString*, NSSet<NSNumber*>*>* contactDeviceMap = [NSMutableDictionary new];
+    for(NSString* recipient in recipients)
+    {
+        NSMutableSet<NSNumber*>* recipientDevices = [self getRecipientDevices:recipient];
+        if(recipientDevices && recipientDevices.count > 0)
+            contactDeviceMap[recipient] = recipientDevices;
+    }
+    
+    return contactDeviceMap;
+}
+
 -(MLXMLNode* _Nullable) encryptString:(NSString* _Nullable) message toDeviceids:(NSDictionary<NSString*, NSSet<NSNumber*>*>*) contactDeviceMap
 {
-    
     MLXMLNode* encrypted = [[MLXMLNode alloc] initWithElement:@"encrypted" andNamespace:@"eu.siacs.conversations.axolotl"];
 
     MLEncryptedPayload* encryptedPayload;
@@ -991,11 +1111,12 @@ $$
         [[MLXMLNode alloc] initWithElement:@"iv" andData:[HelperTools encodeBase64WithData:encryptedPayload.iv]],
     ] andData:nil];
 
-    //add encryption for all given contacts' devices
-    for(NSString* recipient in contactDeviceMap)
+    //add encryption for all given contacts' devices that have been accepted
+    NSMutableDictionary<NSString*, NSMutableSet<NSNumber*>*>* recipientDeviceMap = [self createRecipientDeviceMapFromContactDeviceMap:contactDeviceMap withOutgoing:YES];
+    for(NSString* recipient in recipientDeviceMap)
     {
-        DDLogVerbose(@"Adding encryption for devices of %@: %@", recipient, contactDeviceMap[recipient]);
-        [self addEncryptionKeyForAllDevices:contactDeviceMap[recipient] encryptForJid:recipient withEncryptedPayload:encryptedPayload withXMLHeader:header];
+        DDLogVerbose(@"Adding encryption for devices of %@: %@", recipient, recipientDeviceMap[recipient]);
+        [self addEncryptionKeyForAllDevices:recipientDeviceMap[recipient] encryptForJid:recipient withEncryptedPayload:encryptedPayload withXMLHeader:header];
     }
     
     [encrypted addChildNode:header];
@@ -1016,33 +1137,7 @@ $$
         [messageNode setStoreHint];
     }
     
-    NSMutableSet<NSString*>* recipients = [NSMutableSet new];
-    if([[DataLayer sharedInstance] isBuddyMuc:toContact forAccount:self.account.accountNo])
-        for(NSDictionary* participant in [[DataLayer sharedInstance] getMembersAndParticipantsOfMuc:toContact forAccountId:self.account.accountNo])
-        {
-            if(participant[@"participant_jid"])
-                [recipients addObject:participant[@"participant_jid"]];
-            else if(participant[@"member_jid"])
-                [recipients addObject:participant[@"member_jid"]];
-        }
-    else
-        [recipients addObject:toContact];
-    
-    //remove own jid from recipients (our own devices get special treatment via myDevices NSSet below)
-    [recipients removeObject:self.account.connectionProperties.identity.jid];
-    
-    NSMutableDictionary<NSString*, NSSet<NSNumber*>*>* contactDeviceMap = [NSMutableDictionary new];
-    for(NSString* recipient in recipients)
-    {
-        //contactDeviceMap
-        NSMutableSet<NSNumber*>* recipientDevices = [NSMutableSet new];
-        [recipientDevices addObjectsFromArray:[self.monalSignalStore knownDevicesWithValidSession:recipient]];
-        // add devices with known but old broken session to trigger a bundle refetch
-        [recipientDevices addObjectsFromArray:[self.monalSignalStore knownDevicesWithPendingBrokenSessionHandling:recipient]];
-
-         if(recipientDevices && recipientDevices.count > 0)
-            contactDeviceMap[recipient] = recipientDevices;
-    }
+    NSMutableDictionary<NSString*, NSSet<NSNumber*>*>* contactDeviceMap = [self getContactDeviceMapForContactJid:toContact];
 
     //check if we found omemo keys of at least one of the recipients or more than 1 own device, otherwise don't encrypt anything
     NSSet<NSNumber*>* myDevices = [self knownDevicesForAddressName:self.account.connectionProperties.identity.jid];
@@ -1081,55 +1176,32 @@ $$
     //encrypt message for all given deviceids
     for(NSNumber* device in devices)
     {
-        //do not encrypt for our own device (MUST be scoped by jid for omemo 2)
-        if(device.unsignedIntValue == self.monalSignalStore.deviceid)
-            continue;
-        
-        if(self.state.openBundleFetches[encryptForJid] != nil && [self.state.openBundleFetches[encryptForJid] containsObject:device])
-        {
-            DDLogWarn(@"Ignoring deviceid %@ of %@ for KeyTransportElement: bundle fetch still pending...", device, encryptForJid);
-            continue;
-        }
-        
         SignalAddress* address = [[SignalAddress alloc] initWithName:encryptForJid deviceId:(uint32_t)device.unsignedIntValue];
-
-        NSData* identity = [self.monalSignalStore getIdentityForAddress:address];
-        if(!identity)
+        SignalSessionCipher* cipher = [[SignalSessionCipher alloc] initWithAddress:address context:self.signalContext];
+        NSError* error;
+        SignalCiphertext* deviceEncryptedKey = [cipher encryptData:encryptedPayload.key error:&error];
+        if(error)
         {
-            showErrorOnAlpha(self.account, @"Could not get Identity for: %@ device id %@", encryptForJid, device);
-            //TODO: is it correct to rebuild broken(?) session here, too?
+            //only show errors not being of type "unknown error"
+            if(![error.domain isEqualToString:@"org.whispersystems.SignalProtocol"] || error.code != 0)
+                showErrorOnAlpha(self.account, @"Error while adding encryption key for jid: %@ device: %@ error: %@", encryptForJid, device, error);
             [self rebuildSessionWithJid:encryptForJid forRid:device];
             continue;
         }
-        //only encrypt for devices that are trusted (tofu or explicitly)
-        if([self.monalSignalStore isTrustedIdentity:address identityKey:identity])
-        {
-            SignalSessionCipher* cipher = [[SignalSessionCipher alloc] initWithAddress:address context:self.signalContext];
-            NSError* error;
-            SignalCiphertext* deviceEncryptedKey = [cipher encryptData:encryptedPayload.key error:&error];
-            if(error)
-            {
-                //only show errors not being of type "unknown error"
-                if(![error.domain isEqualToString:@"org.whispersystems.SignalProtocol"] || error.code != 0)
-                    showErrorOnAlpha(self.account, @"Error while adding encryption key for jid: %@ device: %@ error: %@", encryptForJid, device, error);
-                [self rebuildSessionWithJid:encryptForJid forRid:device];
-                continue;
-            }
-            [xmlHeader addChildNode:[[MLXMLNode alloc] initWithElement:@"key" withAttributes:@{
-                @"rid": [NSString stringWithFormat:@"%@", device],
-                @"prekey": (deviceEncryptedKey.type == SignalCiphertextTypePreKeyMessage ? @"1" : @"0"),
-            } andChildren:@[] andData:[HelperTools encodeBase64WithData:deviceEncryptedKey.data]]];
-            
-            //record this deviceid as used for encryption (it doesn't need any further key transport element potentially already queued)
-            [usedRids addObject:device];
-        }
+        [xmlHeader addChildNode:[[MLXMLNode alloc] initWithElement:@"key" withAttributes:@{
+            @"rid": [NSString stringWithFormat:@"%@", device],
+            @"prekey": (deviceEncryptedKey.type == SignalCiphertextTypePreKeyMessage ? @"1" : @"0"),
+        } andChildren:@[] andData:[HelperTools encodeBase64WithData:deviceEncryptedKey.data]]];
+        
+        //record this deviceid as used for encryption (it doesn't need any further key transport element potentially already queued)
+        [usedRids addObject:device];
     }
     
     //remove queued key transport element entry
     [self removeQueuedKeyTransportElementsFor:encryptForJid andDevices:usedRids];
 }
 
--(NSString* _Nullable) decryptOmemoEnvelope:(MLXMLNode*) envelope forSenderJid:(NSString*) senderJid andReturnErrorString:(BOOL) returnErrorString
+-(NSString* _Nullable) decryptOmemoEnvelope:(MLXMLNode*) envelope forSenderJid:(NSString*) senderJid inMuc:(NSString* _Nullable) mucJid andReturnErrorString:(BOOL) returnErrorString
 {
     DDLogVerbose(@"OMEMO envelope: %@", envelope);
     
@@ -1147,6 +1219,18 @@ $$
     BOOL isKeyTransportElement = ![envelope check:@"payload"];
     NSNumber* sid = [envelope findFirst:@"header@sid|uint"];
 
+    //check if we trust this sender before trying to decrypt the content (we need to check our own devices for tofu, too)
+    NSMutableDictionary<NSString*, NSSet<NSNumber*>*>* contactDeviceMap = [self getContactDeviceMapForContactJid:(mucJid != nil ? mucJid : senderJid)];
+    NSSet<NSNumber*>* myDevices = [self knownDevicesForAddressName:self.account.connectionProperties.identity.jid];
+    if(myDevices.count > 1)
+        contactDeviceMap[self.account.connectionProperties.identity.jid] = myDevices;
+    NSMutableDictionary<NSString*, NSMutableSet<NSNumber*>*>* recipientDeviceMap = [self createRecipientDeviceMapFromContactDeviceMap:contactDeviceMap withOutgoing:NO];
+    if(![recipientDeviceMap[senderJid] containsObject:sid])
+    {
+        DDLogWarn(@"Received message from '%@' (possibly in muc: %@) device %@, but not trusted: ignoring!", senderJid, mucJid, sid);
+        return !returnErrorString ? nil : [NSString stringWithFormat:NSLocalizedString(@"Could not decrypt because you didn't trust the sender's device %u.", @""), sid.unsignedIntValue];
+    }
+    
     SignalAddress* address = [[SignalAddress alloc] initWithName:senderJid deviceId:(uint32_t)sid.unsignedIntValue];
 
     if(!self.signalContext)
@@ -1298,6 +1382,7 @@ $$
 -(NSString* _Nullable) decryptMessage:(XMPPMessage*) messageNode withMucParticipantJid:(NSString* _Nullable) mucParticipantJid
 {
     NSString* senderJid = nil;
+    NSString* mucJid = nil;
     if([messageNode check:@"/<type=groupchat>"])
     {
         if(mucParticipantJid == nil)
@@ -1309,13 +1394,13 @@ $$
             return nil;
 #endif
         }
-        else
-            senderJid = mucParticipantJid;
+        senderJid = mucParticipantJid;
+        mucJid = messageNode.fromUser;
     }
     else
         senderJid = messageNode.fromUser;
     
-    return [self decryptOmemoEnvelope:[messageNode findFirst:@"{eu.siacs.conversations.axolotl}encrypted"] forSenderJid:senderJid andReturnErrorString:YES];
+    return [self decryptOmemoEnvelope:[messageNode findFirst:@"{eu.siacs.conversations.axolotl}encrypted"] forSenderJid:senderJid inMuc:mucJid andReturnErrorString:YES];
 }
 
 $$instance_handler(handleDevicelistUnsubscribe, account.omemo, $$ID(xmpp*, account), $$ID(NSString*, jid), $$BOOL(success), $_ID(XMPPIQ*, errorIq), $_ID(NSString*, errorReason))
@@ -1366,7 +1451,8 @@ $$
 //interfaces for UI
 -(BOOL) isTrustedIdentity:(SignalAddress*) address identityKey:(NSData*) identityKey
 {
-    return [self.monalSignalStore isTrustedIdentity:address identityKey:identityKey];
+    int trustLevel = [self.monalSignalStore getTrustLevel:address identityKey:identityKey].intValue;
+    return [MLSignalStore acceptedTrustLevel:trustLevel withTofu:YES andOutgoing:NO];
 }
 
 -(NSNumber*) getTrustLevel:(SignalAddress*) address identityKey:(NSData*) identityKey

--- a/Monal/Classes/MLOMEMO.m
+++ b/Monal/Classes/MLOMEMO.m
@@ -235,6 +235,7 @@ static NSDictionary* trustLevels2Text = nil;
         {
             [self generateNewKeysIfNeeded];     //generate new prekeys if needed and publish them
             [self repairQueuedSessions];
+            [self cleanupOwnOldDevices];
         }
     }
 #endif
@@ -555,6 +556,30 @@ $$
     }
 
     [self notifyKnownDevicesUpdated:self.account.connectionProperties.identity.jid];
+    
+    [self cleanupOwnOldDevices];
+}
+
+-(void) cleanupOwnOldDevices
+{
+    NSString* jid = self.account.connectionProperties.identity.jid;
+    for(NSNumber* device in [self.ownDeviceList copy])
+    {
+        SignalAddress* address = [[SignalAddress alloc] initWithName:jid deviceId:(uint32_t)device.unsignedIntValue];
+        NSData* identity = [self.monalSignalStore getIdentityForAddress:address];
+        if(!identity)
+        {
+            //TODO: is it correct to rebuild broken(?) session here, too?
+            [self rebuildSessionWithJid:jid forRid:device];
+            continue;
+        }
+        int trust = [self.monalSignalStore getTrustLevel:address identityKey:identity].intValue;
+        
+        //remove own old devices (these clients will add thei id back, if they are still active)
+        //this is what conversations does, too
+        if(trust == MLOmemoToFUButNoMsgSeenInTime || trust == MLOmemoTrustedButNoMsgSeenInTime)
+            [self bulkDeleteDeviceForSource:jid andRid:device];
+    }
 }
 
 -(void) publishOwnDeviceList
@@ -1541,15 +1566,20 @@ $$
 
 -(void) deleteDeviceForSource:(NSString*) source andRid:(NSNumber*) rid
 {
+    [self bulkDeleteDeviceForSource:source andRid:rid];
+    if([source isEqualToString:self.account.connectionProperties.identity.jid])
+        [self publishOwnDeviceList];
+}
+
+-(void) bulkDeleteDeviceForSource:(NSString*) source andRid:(NSNumber*) rid
+{
     //we should not delete our own device
     if([source isEqualToString:self.account.connectionProperties.identity.jid] && rid.unsignedIntValue == self.monalSignalStore.deviceid)
         return;
+    DDLogInfo(@"Deleting deviceid %@ of contact %@...", rid, source);
     //handle removal of own deviceids
     if([source isEqualToString:self.account.connectionProperties.identity.jid])
-    {
         [self.ownDeviceList removeObject:rid];
-        [self publishOwnDeviceList];
-    }
 
     SignalAddress* address = [[SignalAddress alloc] initWithName:source deviceId:rid.unsignedIntValue];
     //don't delete the identity record to not trigger spurious "detected a new omemo device on your account"
@@ -1564,7 +1594,7 @@ $$
 {
     NSSet<NSNumber*>* devices = [self knownDevicesForAddressName:jid];
     for(NSNumber* device in devices)
-        [self deleteDeviceForSource:jid andRid:device];
+        [self bulkDeleteDeviceForSource:jid andRid:device];
     [self sendOMEMOBundle];
     [self.account.pubsub fetchNode:@"eu.siacs.conversations.axolotl.devicelist" from:self.account.connectionProperties.identity.jid withItemsList:nil andHandler:$newHandlerWithInvalidation(self, handleDevicelistFetch, handleDevicelistFetchInvalidation, $BOOL(subscribe, NO))];
     [self.account.pubsub fetchNode:@"eu.siacs.conversations.axolotl.devicelist" from:jid withItemsList:nil andHandler:$newHandlerWithInvalidation(self, handleDevicelistFetch, handleDevicelistFetchInvalidation, $BOOL(subscribe, NO))];

--- a/Monal/Classes/MLSignalStore.h
+++ b/Monal/Classes/MLSignalStore.h
@@ -75,4 +75,8 @@
 
 -(void) cleanupKeys;
 -(void) reloadCachedPrekeys;
+
+-(BOOL) deletePreKeyWithId:(uint32_t) preKeyId;
+-(BOOL) deleteUsedPrekeys;
+
 @end

--- a/Monal/Classes/MLSignalStore.h
+++ b/Monal/Classes/MLSignalStore.h
@@ -28,6 +28,8 @@
 @property (nonatomic, strong) SignalSignedPreKey* _Nullable signedPreKey;
 @property (nonatomic, strong) NSArray<SignalPreKey*>* _Nullable preKeys;
 
++(BOOL) acceptedTrustLevel:(int) trustLevel withTofu:(BOOL) withTofu andOutgoing:(BOOL) outgoing;
+
 -(MLSignalStore* _Nonnull) initWithAccountId:(NSNumber* _Nonnull) accountId andAccountJid:(NSString* _Nonnull) accountJid;
 -(void) saveValues;
 

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -536,13 +536,13 @@
         return [self.sqliteDatabase executeScalar:(@"SELECT \
                 CASE \
                     WHEN (trustLevel=0) THEN 0 \
-                    WHEN (trustLevel=1 AND removedFromDeviceList IS NULL AND (lastReceivedMsg IS NULL OR lastReceivedMsg >= unixepoch('now', '-90 day'))) THEN 100 \
+                    WHEN (trustLevel=1 AND removedFromDeviceList IS NULL AND (lastReceivedMsg IS NULL OR unixepoch(lastReceivedMsg) >= unixepoch('now', '-90 day'))) THEN 100 \
                     WHEN (trustLevel=1 AND removedFromDeviceList IS NOT NULL) THEN 101 \
-                    WHEN (trustLevel=1 AND removedFromDeviceList IS NULL AND (lastReceivedMsg < unixepoch('now', '-90 day'))) THEN 102 \
+                    WHEN (trustLevel=1 AND removedFromDeviceList IS NULL AND (unixepoch(lastReceivedMsg) < unixepoch('now', '-90 day'))) THEN 102 \
                     WHEN (COUNT(*)=0) THEN 100 \
-                    WHEN (trustLevel=2 AND removedFromDeviceList IS NULL AND (lastReceivedMsg IS NULL OR lastReceivedMsg >= unixepoch('now', '-90 day'))) THEN 200 \
+                    WHEN (trustLevel=2 AND removedFromDeviceList IS NULL AND (lastReceivedMsg IS NULL OR unixepoch(lastReceivedMsg) >= unixepoch('now', '-90 day'))) THEN 200 \
                     WHEN (trustLevel=2 AND removedFromDeviceList IS NOT NULL) THEN 201 \
-                    WHEN (trustLevel=2 AND removedFromDeviceList IS NULL AND (lastReceivedMsg < unixepoch('now', '-90 day'))) THEN 202 \
+                    WHEN (trustLevel=2 AND removedFromDeviceList IS NULL AND (unixepoch(lastReceivedMsg) < unixepoch('now', '-90 day'))) THEN 202 \
                     ELSE 0 \
                 END \
                 FROM signalContactIdentity \

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -90,9 +90,9 @@
 {
     [self.sqliteDatabase voidWriteTransaction:^{
         // remove old keys that have been remove a long time ago from pubsub
-        [self.sqliteDatabase executeNonQuery:@"DELETE FROM signalPreKey WHERE account_id=? AND pubSubRemovalTimestamp IS NOT NULL AND pubSubRemovalTimestamp <= unixepoch('now', '-14 day');" andArguments:@[self.accountId]];
+        [self.sqliteDatabase executeNonQuery:@"DELETE FROM signalPreKey WHERE account_id=? AND pubSubRemovalTimestamp IS NOT NULL AND unixepoch(pubSubRemovalTimestamp) <= unixepoch('now', '-14 day');" andArguments:@[self.accountId]];
         // mark old unused keys to be removed from pubsub
-        [self.sqliteDatabase executeNonQuery:@"UPDATE signalPreKey SET pubSubRemovalTimestamp=CURRENT_TIMESTAMP WHERE account_id=? AND keyUsed=0 AND pubSubRemovalTimestamp IS  NULL AND creationTimestamp<= unixepoch('now','-14 day');" andArguments:@[self.accountId]];
+        [self.sqliteDatabase executeNonQuery:@"UPDATE signalPreKey SET pubSubRemovalTimestamp=CURRENT_TIMESTAMP WHERE account_id=? AND keyUsed=0 AND pubSubRemovalTimestamp IS  NULL AND unixepoch(creationTimestamp) <= unixepoch('now','-14 day');" andArguments:@[self.accountId]];
     }];
 }
 
@@ -240,7 +240,7 @@
                     AND contactName=? \
                     AND removedFromDeviceList IS NULL \
                     AND brokenSession=true \
-                    AND (lastFailedBundleFetch IS NULL OR lastFailedBundleFetch <= unixepoch('now', '-5 day'))\
+                    AND (lastFailedBundleFetch IS NULL OR unixepoch(lastFailedBundleFetch) <= unixepoch('now', '-5 day'))\
             ;" andArguments:@[self.accountId, jid]];
     }];
 }

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -426,8 +426,8 @@
         // if at least one fingerprint isn't TOFU new fingerprints shouldn't be trusted
         // if all fingerprints are TOFU -> trust new ones with TOFU as well
         return [self.sqliteDatabase executeNonQuery:@"INSERT INTO signalContactIdentity \
-            (account_id, contactName, contactDeviceId, identity, trustLevel) \
-            VALUES (?, ?, ?, ?, \
+            (account_id, contactName, contactDeviceId, identity, lastReceivedMsg, trustLevel) \
+            VALUES (?, ?, ?, ?, CURRENT_TIMESTAMP, \
                 (SELECT CASE \
                     WHEN COUNT(contactDeviceId) == 0 THEN 1 \
                     ELSE 0 \

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -312,15 +312,25 @@
     return prekey ? YES : NO;
 }
 
-/**
- * Delete a PreKey record from local storage.
- */
+
 -(BOOL) deletePreKeyWithId:(uint32_t) preKeyId
 {
     DDLogDebug(@"Marking prekey %lu as deleted", (unsigned long)preKeyId);
     // only mark the key for deletion -> key should be removed from pubSub
     return [self.sqliteDatabase boolWriteTransaction:^{
         BOOL ret = [self.sqliteDatabase executeNonQuery:@"UPDATE signalPreKey SET pubSubRemovalTimestamp=CURRENT_TIMESTAMP, keyUsed=1 WHERE account_id=? AND prekeyid=?;" andArguments:@[self.accountId, [NSNumber numberWithInteger:preKeyId]]];
+        [self reloadCachedPrekeys];
+        return ret;
+    }];
+}
+
+/**
+ * Delete a PreKey record from local storage.
+ */
+-(BOOL) deleteUsedPrekeys
+{
+    return [self.sqliteDatabase boolWriteTransaction:^{
+        BOOL ret = [self.sqliteDatabase executeNonQuery:@"UPDATE signalPreKey SET pubSubRemovalTimestamp=CURRENT_TIMESTAMP WHERE account_id=? AND keyUsed=1 AND pubSubRemovalTimestamp IS NULL;" andArguments:@[self.accountId]];
         [self reloadCachedPrekeys];
         return ret;
     }];

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -423,10 +423,22 @@
         NSData* dbIdentity= (NSData *)[self.sqliteDatabase executeScalar:@"SELECT IDENTITY FROM signalContactIdentity WHERE account_id=? AND contactDeviceId=? AND contactName=?;" andArguments:@[self.accountId, [NSNumber numberWithInteger:address.deviceId], address.name]];
         if(dbIdentity)
             return YES;
-        // Set every new identity to TOFU to increase user experience
+        // if at least one fingerprint isn't TOFU new fingerprints shouldn't be trusted
+        // if all fingerprints are TOFU -> trust new ones with TOFU as well
         return [self.sqliteDatabase executeNonQuery:@"INSERT INTO signalContactIdentity \
             (account_id, contactName, contactDeviceId, identity, trustLevel) \
-            VALUES (?, ?, ?, ?, ?)" andArguments:@[self.accountId, address.name, [NSNumber numberWithInteger:address.deviceId], identityKey, [NSNumber numberWithInt:MLOmemoInternalToFU]]];
+            VALUES (?, ?, ?, ?, \
+                (SELECT CASE \
+                    WHEN COUNT(contactDeviceId) == 0 THEN 1 \
+                    ELSE 0 \
+                END \
+                FROM signalContactIdentity \
+                WHERE \
+                    account_id=? \
+                    AND contactName=? \
+                    AND trustLevel!=1 \
+                ) \
+            );" andArguments:@[self.accountId, address.name, [NSNumber numberWithInteger:address.deviceId], identityKey, self.accountId, address.name]];
     }];
 }
 

--- a/Monal/Classes/MLSignalStore.m
+++ b/Monal/Classes/MLSignalStore.m
@@ -12,6 +12,7 @@
 #import "DataLayer.h"
 #import "MLSQLite.h"
 #import "HelperTools.h"
+#import "MLOMEMO.h"
 
 @interface MLSignalStore()
 {
@@ -29,6 +30,20 @@
     
     //make sure the datalayer has migrated the database file to the app group location first
     [DataLayer initialize];
+}
+
++(BOOL) acceptedTrustLevel:(int) trustLevel withTofu:(BOOL) withTofu andOutgoing:(BOOL) outgoing
+{
+    //for better UX never refuse to encrypt/decrypt from/to old devices
+    if(withTofu)
+        return
+            trustLevel == MLOmemoTrusted ||
+            trustLevel == MLOmemoTrustedButNoMsgSeenInTime ||
+            trustLevel == MLOmemoToFU ||
+            trustLevel == MLOmemoToFUButNoMsgSeenInTime;
+    return
+        trustLevel == MLOmemoTrusted ||
+        trustLevel == MLOmemoTrustedButNoMsgSeenInTime;
 }
 
 //this is the getter of our readonly "sqliteDatabase" property always returning the thread-local instance of the MLSQLite class
@@ -427,9 +442,13 @@
  */
 -(BOOL) isTrustedIdentity:(SignalAddress*) address identityKey:(NSData*) identityKey;
 {
+    //this method gets called by the C implementation of libsignal when *sending* messages (apparently not when receiving?).
+    //this means, libsignal doesn't send messages to devices we return NO for, but happily receives and decrypts messages
+    //from these devices.
+    //we already fixed this behavior by explicitly checking the deviceids for sending/receiving in MLOMEMO,
+    //but still call acceptedTrustLevel: here, too, for good measures
     int trustLevel = [self getTrustLevel:address identityKey:identityKey].intValue;
-    // For better UX trust ToFU devices even if we did not receive msg in a long time
-    return (trustLevel == MLOmemoTrusted || trustLevel == MLOmemoToFU || trustLevel == MLOmemoToFUButNoMsgSeenInTime);
+    return [[self class] acceptedTrustLevel:trustLevel withTofu:YES andOutgoing:YES];
 }
 
 -(NSData*) getIdentityForAddress:(SignalAddress*) address

--- a/Monal/Classes/MLXMPPManager.m
+++ b/Monal/Classes/MLXMPPManager.m
@@ -71,6 +71,10 @@ static const int pingFreqencyMinutes = 5;       //about the same Conversations u
     //upgrade default omemo on
     [self upgradeBoolUserSettingsIfUnset:@"OMEMODefaultOn" toDefault:YES];
     
+    //upgrade special omemo settings
+    [self upgradeBoolUserSettingsIfUnset:@"allowMixedTrustInGroups" toDefault:YES];
+    [self upgradeBoolUserSettingsIfUnset:@"allowUnverifiedCalls" toDefault:YES];
+    
     // upgrade udp logger
     [self upgradeBoolUserSettingsIfUnset:@"udpLoggerEnabled" toDefault:NO];
     [self upgradeObjectUserSettingsIfUnset:@"udpLoggerHostname" toDefault:@""];

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -177,11 +177,11 @@ struct MemberList: View {
                                 account.mucProcessor.inviteUser(contact.contactJid, inMuc: self.muc.contactJid)
                             }
                         }.catch { error in
-                            showAlert(title:Text("Error inviting user!"), description:Text("\(String(describing:error))"))
+                            showAlert(title:Text("Error inviting user!"), description:Text(error.localizedDescription))
                         }
                         return Guarantee.value(())
                     }.catch { error in
-                        showAlert(title:Text("Error unblocking user!"), description:Text("\(String(describing:error))"))
+                        showAlert(title:Text("Error unblocking user!"), description:Text(error.localizedDescription))
                     }
                 } else if newAffiliation == "outcast" {
                     showActionSheet(title: Text("Block user?"), description: Text("Do you want to block this user from entering this group/channel?")) {
@@ -191,7 +191,7 @@ struct MemberList: View {
                                 account.mucProcessor.setAffiliation(newAffiliation, ofUser:contact.contactJid, inMuc:self.muc.contactJid)
                             }
                         }.catch { error in
-                            showAlert(title:Text("Error blocking user!"), description:Text("\(String(describing:error))"))
+                            showAlert(title:Text("Error blocking user!"), description:Text(error.localizedDescription))
                         }
                     }
                 } else {
@@ -201,7 +201,7 @@ struct MemberList: View {
                             account.mucProcessor.setAffiliation(newAffiliation, ofUser:contact.contactJid, inMuc:self.muc.contactJid)
                         }
                     }.catch { error in
-                        showAlert(title:Text("Error changing affiliation!"), description:Text("\(String(describing:error))"))
+                        showAlert(title:Text("Error changing affiliation!"), description:Text(error.localizedDescription))
                     }
                 }
             }
@@ -230,10 +230,10 @@ struct MemberList: View {
                                                 account.mucProcessor.inviteUser(member.contactJid, inMuc: self.muc.contactJid)
                                             }
                                         }.catch { error in
-                                            showAlert(title:Text("Error inviting new member!"), description:Text("\(String(describing:error))"))
+                                            showAlert(title:Text("Error inviting new member!"), description:Text(error.localizedDescription))
                                         }
                                     }.catch { error in
-                                        showAlert(title:Text("Error adding new member!"), description:Text("\(String(describing:error))"))
+                                        showAlert(title:Text("Error adding new member!"), description:Text(error.localizedDescription))
                                     }
                                 } else {
                                     showPromisingLoadingOverlay(self.overlay, headlineView: Text("Inviting new participant"), descriptionView: Text("Adding \(member.contactJid as String)...")) {
@@ -241,7 +241,7 @@ struct MemberList: View {
                                             account.mucProcessor.inviteUser(member.contactJid, inMuc: self.muc.contactJid)
                                         }
                                     }.catch { error in
-                                        showAlert(title:Text("Error inviting new participant!"), description:Text("\(String(describing:error))"))
+                                        showAlert(title:Text("Error inviting new participant!"), description:Text(error.localizedDescription))
                                     }
                                 }
                             }
@@ -296,7 +296,7 @@ struct MemberList: View {
                                 account.mucProcessor.setAffiliation("none", ofUser: member.contactJid, inMuc: self.muc.contactJid)
                             }
                         }.catch { error in
-                            showAlert(title:Text("Error removing user!"), description:Text("\(String(describing:error))"))
+                            showAlert(title:Text("Error removing user!"), description:Text(error.localizedDescription))
                         }
                     }
                 })

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -12,8 +12,7 @@ struct OmemoKeysEntry: View {
     private let contactJid: String
     
     @State private var trustLevel: NSNumber
-    @State private var showEntryInfo = false
-    @State private var showClipboardCopy = false
+    @State private var showAlert: Alert?
 
     private let deviceId: NSNumber
     private let fingerprint: Data
@@ -159,14 +158,18 @@ struct OmemoKeysEntry: View {
                 }
                 .onTapGesture(count: 2) {
                     UIPasteboard.general.setValue(clipboardValue, forPasteboardType:UTType.utf8PlainText.identifier)
-                    showClipboardCopy = true
+                    showAlert = Alert(
+                        title: Text("Copied to clipboard"),
+                        message: Text(clipboardValue),
+                        dismissButton: nil
+                    )
                 }
                 Spacer()
                 // the trust level of our own device should not be displayed
                 if(!isOwnDevice) {
                     VStack(alignment:.center) {
                         Button {
-                            showEntryInfo = true
+                            showAlert = getEntryInfoAlert()
                         } label: {
                             getTrustLevelIcon()
                         }
@@ -175,21 +178,14 @@ struct OmemoKeysEntry: View {
                     }
                 } else {
                     Button {
-                        showEntryInfo = true
+                        showAlert = getEntryInfoAlert()
                     } label: {
                         getDeviceIconForOwnDevice()
                     }
                 }
             }
-            .alert(isPresented: $showEntryInfo) {
-                getEntryInfoAlert()
-            }
-            .alert(isPresented: $showClipboardCopy) {
-                Alert(
-                    title: Text("Copied to clipboard"),
-                    message: Text(clipboardValue),
-                    dismissButton: nil
-                );
+            .alert(isPresented: $showAlert.optionalMappedToBool()) {
+                showAlert!
             }
         }
     }

--- a/Monal/Classes/OmemoKeys.swift
+++ b/Monal/Classes/OmemoKeys.swift
@@ -45,40 +45,48 @@ struct OmemoKeysEntry: View {
                 dismissButton: nil);
         }
         switch(self.trustLevel.int32Value) {
-        case MLOmemoTrusted:
-            return Alert(
-                title: Text("Trusted and verified key"),
-                message: Text("This key is trusted and verified by manually comparing fingerprints. To stop trusting this key, use the toggle element."),
-                dismissButton: nil)
-        case MLOmemoToFU:
-            return Alert(
-                title: Text("Trusted but unverified key"),
-                message: Text("Monal currently trusts this key, but fingerprints were not compared yet. To increase security, please confirm with the contact that the displayed fingerprints do match before trusting this key!"),
-                primaryButton: .destructive(Text("Trust Key"), action: {
-                    setTrustLevel(true)
-                }),
-                secondaryButton: .default(Text("Okay")))
         case MLOmemoNotTrusted:
             return Alert(
                 title: Text("Untrusted key"),
                 message: Text("Monal does not trust this key. Either it was manually disabled or not manually verified while other keys of that contact are verified. You can trust this key by using the toggle element. Please ensure with the contact that fingerprints are matching before trusting this key."),
                 dismissButton: nil)
+        case MLOmemoToFU:
+            return Alert(
+                title: Text("Trusted but unverified key"),
+                message: Text("Monal currently trusts this key, but fingerprints were not compared yet. To increase security, please confirm with the contact that the displayed fingerprints do match before trusting this key!"),
+                primaryButton: .default(Text("Trust Key"), action: {
+                    setTrustLevel(true)
+                }),
+                secondaryButton: .default(Text("OK")))
+        case MLOmemoToFUButNoMsgSeenInTime:
+            return Alert(
+                title: Text("Trusted but unverified and unused key"),
+                message: Text("Monal currently trusts this key, but fingerprints were not compared yet and the contact has not used it for a long time. Consider to disable trust for this key."),
+                primaryButton: .destructive(Text("Don't trust Key"), action: {
+                    setTrustLevel(false)
+                }),
+                secondaryButton: .default(Text("OK")))
+        case MLOmemoTrusted:
+            return Alert(
+                title: Text("Trusted and verified key"),
+                message: Text("This key is trusted and verified by manually comparing fingerprints. To stop trusting this key, use the toggle element."),
+                dismissButton: nil)
         case MLOmemoTrustedButRemoved:
             return Alert(
                 title: Text("Trusted but removed key"),
                 message: Text("This key is trusted, but the contact does not use it anymore. Consider to disable trust for this key."),
-                primaryButton: .default(Text("Dont' trust Key"), action: {
+                primaryButton: .destructive(Text("Dont' trust Key"), action: {
                     setTrustLevel(false)
                 }),
-                secondaryButton: .cancel(Text("Okay")))
+                secondaryButton: .cancel(Text("OK")))
         case MLOmemoTrustedButNoMsgSeenInTime:
             return Alert(
                 title: Text("Trusted but unused key"),
-                message: Text("This key is trusted, but the contact has not used it for a long time. Consider to disable trust for this key"),
-                primaryButton: .default(Text("Don't trust Key"), action: {
+                message: Text("This key is trusted, but the contact has not used it for a long time. Consider to disable trust for this key."),
+                primaryButton: .destructive(Text("Don't trust Key"), action: {
                     setTrustLevel(false)
                 }),
-                secondaryButton: .cancel(Text("Okay")))
+                secondaryButton: .cancel(Text("OK")))
         default:
             return Alert(
                 title: Text("Invalid State"),
@@ -87,30 +95,35 @@ struct OmemoKeysEntry: View {
         }
     }
 
-    // @ViewBuilder
-    func getTrustLevelIcon() -> some View {
-        var accentColor = Color.yellow
-        var iconName = "key.fill"
+    @ViewBuilder
+    func getTrustLevelIcons() -> some View {
         switch(self.trustLevel.int32Value) {
-        case MLOmemoTrusted:
-            accentColor = Color.green
-            break
-        case MLOmemoToFU:
-            break
-        case MLOmemoNotTrusted:
-            accentColor = Color.red
-            break
-        case MLOmemoTrustedButRemoved:
-            iconName = "trash.fill"
-        case MLOmemoTrustedButNoMsgSeenInTime:
-            iconName = "clock.fill"
-        default:
-            break
+            case MLOmemoNotTrusted:
+                getTrustLevelIcon("key.fill", .red)
+            case MLOmemoToFU:
+                getTrustLevelIcon("key.fill", .yellow)
+            case MLOmemoToFUButNoMsgSeenInTime:
+                getTrustLevelIcon("clock.fill", .clear)
+                getTrustLevelIcon("key.fill", .yellow)
+            case MLOmemoToFUButRemoved:
+                getTrustLevelIcon("trash.fill", .yellow)
+            case MLOmemoTrusted:
+                getTrustLevelIcon("key.fill", .green)
+            case MLOmemoTrustedButRemoved:
+                getTrustLevelIcon("trash.fill", .yellow)
+            case MLOmemoTrustedButNoMsgSeenInTime:
+                getTrustLevelIcon("clock.fill", .clear)
+                getTrustLevelIcon("key.fill", .green)
+            default:
+                EmptyView()
         }
+    }
+    
+    func getTrustLevelIcon(_ iconName: String, _ iconColor: Color) -> some View {
         return Image(systemName: iconName)
             .frame(width: 30, height: 30, alignment: .center)
             .foregroundColor(Color.primary)
-            .background(accentColor)
+            .background(Color.accentColor)
             .cornerRadius(30)
     }
 
@@ -156,6 +169,9 @@ struct OmemoKeysEntry: View {
                         }
                     }
                 }
+                .onTapGesture(count: 1) {
+                    showAlert = getEntryInfoAlert()
+                }
                 .onTapGesture(count: 2) {
                     UIPasteboard.general.setValue(clipboardValue, forPasteboardType:UTType.utf8PlainText.identifier)
                     showAlert = Alert(
@@ -167,11 +183,11 @@ struct OmemoKeysEntry: View {
                 Spacer()
                 // the trust level of our own device should not be displayed
                 if(!isOwnDevice) {
-                    VStack(alignment:.center) {
+                    VStack(alignment:.trailing) {
                         Button {
                             showAlert = getEntryInfoAlert()
                         } label: {
-                            getTrustLevelIcon()
+                            getTrustLevelIcons()
                         }
                         Toggle("", isOn: trustLevelBinding).font(.footnote)
                         .labelsHidden()     //make sure we do not need more space than the actual toggle needs

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -480,21 +480,16 @@ NSString* const kStanza = @"stanza";
     BOOL retval = NO;
     //we are idle when we are not connected (and not trying to)
     //or: the catchup is done, no unacked stanzas are left in the smacks queue and receive and send queues are empty (no pending operations)
-    unsigned long unackedCount = 0;
-    @synchronized(_stateLockObject) {
-        unackedCount = (unsigned long)[self.unAckedStanzas count];
-    }
+    id unackedCount = @"unchecked";
     if(
         (
             //test if this account was permanently logged out but still has stanzas pending (this can happen if we have no connectivity for example)
             //--> we are not idle in this case because we still have pending outgoing stanzas
             _accountState<kStateReconnecting &&
-            !_reconnectInProgress &&
-            !unackedCount
+            !_reconnectInProgress
         ) || (
             //test if we are connected and idle (e.g. we're done with catchup and neither process any incoming stanzas nor trying to send anything)
             _catchupDone &&
-            !unackedCount &&
             ![_parseQueue operationCount] &&        //if something blocks the parse queue it is either an incoming stanza currently processed or waiting to be processed
             //[_receiveQueue operationCount] <= ([NSOperationQueue currentQueue]==_receiveQueue ? 1 : 0) &&
             ![_sendQueue operationCount] &&
@@ -502,12 +497,24 @@ NSString* const kStanza = @"stanza";
         )
     )
         retval = YES;
+    //only check unacked count if needed (this makes sure we don't hold the state lock unnecessarily and block the main thread)
+    if(retval)
+    {
+        @synchronized(_stateLockObject) {
+            NSUInteger unacked = [self.unAckedStanzas count];
+            if(unacked)
+            {
+                retval = NO;
+                unackedCount = @(unacked);
+            }
+        }
+    }
     _lastIdleState = retval;
     DDLogVerbose(@("%@ --> Idle check:\n"
             "\t_accountState < kStateReconnecting = %@\n"
             "\t_reconnectInProgress = %@\n"
             "\t_catchupDone = %@\n"
-            "\t[self.unAckedStanzas count] = %lu\n"
+            "\t[self.unAckedStanzas count] = %@\n"
             "\t[_parseQueue operationCount] = %lu\n"
             //"\t[_receiveQueue operationCount] = %lu\n"
             "\t[_sendQueue operationCount] = %lu\n"

--- a/Monal/Monal-iOS/Launch Screen.storyboard
+++ b/Monal/Monal-iOS/Launch Screen.storyboard
@@ -19,7 +19,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2025 monal-im.org. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2026 monal-im.org. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
                                 <rect key="frame" x="20" y="771" width="335" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>

--- a/Monal/Monal-iOS/Quicksy Launch Screen.storyboard
+++ b/Monal/Monal-iOS/Quicksy Launch Screen.storyboard
@@ -19,7 +19,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="812"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2025 monal-im.org. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
+                            <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright © 2026 monal-im.org. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="obG-Y5-kRd">
                                 <rect key="frame" x="20" y="771" width="335" height="21"/>
                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                 <nil key="textColor"/>

--- a/Monal/Podfile
+++ b/Monal/Podfile
@@ -32,7 +32,7 @@ def monalxmpp
   pod 'sqlite3/perf-threadsafe', inhibit_warnings: true
   pod 'ASN1Decoder'
   #later versions of the webrtc lib trigger the following app review error:
-  pod 'WebRTC-lib'
+  pod 'WebRTC-lib', '~> 139.0'
   #pod 'GoogleWebRTC'
   pod 'KSCrash', subspecs:['Recording', 'Reporting/Filters/Sets', 'Reporting/Filters/Tools', 'Reporting/Tools', 'Core']
   signalDeps

--- a/Monal/localization/Base.lproj/Main.storyboard
+++ b/Monal/localization/Base.lproj/Main.storyboard
@@ -1358,11 +1358,12 @@
                                             <subviews>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" ambiguous="YES" text="A Status message would go here. That is correct, a status message. " textAlignment="center" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15o-hp-DgI">
                                                     <rect key="frame" x="10" y="9" width="1004" height="34"/>
+                                                    <color key="backgroundColor" systemColor="systemYellowColor"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" constant="33.670000000000002" id="0ag-YG-RGy"/>
                                                     </constraints>
                                                     <fontDescription key="fontDescription" type="system" weight="semibold" pointSize="14"/>
-                                                    <color key="textColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                    <color key="textColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                     <nil key="highlightedColor"/>
                                                     <attributedString key="userComments">
                                                         <fragment content="#bc-ignore!"/>

--- a/Monal/opensource.html
+++ b/Monal/opensource.html
@@ -1,7 +1,7 @@
 <html>
     <head></head>
     <body>
-        Monal<br><br> Copyright (c) 2009-2025, The Monal Developers<br><br>
+        Monal<br><br> Copyright (c) 2009-2026, The Monal Developers<br><br>
         All rights reserved.<br><br>
         
         Redistribution and use in source and binary forms, with or without

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3,23 +3,10 @@
 version = 4
 
 [[package]]
-name = "ahash"
-version = "0.8.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
-dependencies = [
- "cfg-if",
- "getrandom",
- "once_cell",
- "version_check",
- "zerocopy",
-]
-
-[[package]]
 name = "anstream"
-version = "0.6.18"
+version = "0.6.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -32,67 +19,56 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.10"
+version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.6"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.2"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
  "windows-sys",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.6"
+version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
+ "once_cell_polyfill",
  "windows-sys",
 ]
 
 [[package]]
-name = "autocfg"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
-
-[[package]]
 name = "bitflags"
-version = "2.6.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-
-[[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 
 [[package]]
 name = "cfg-if"
-version = "1.0.0"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "clap"
-version = "4.5.23"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3135e7ec2ef7b10c6ed8950f0f792ed96ee093fa088608f1c76e569722700c84"
+checksum = "c6e6ff9dcd79cff5cd969a17a545d79e84ab086e444102a591e288a8aa3ce394"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -100,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.23"
+version = "4.5.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30582fc632330df2bd26877bde0c1f4470d57c582bbc070376afcd04d8cb4838"
+checksum = "fa42cf4d2b7a41bc8f663a7cab4031ebafa1bf3875705bfaf8466dc60ab52c00"
 dependencies = [
  "anstream",
  "anstyle",
@@ -112,38 +88,38 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.18"
+version = "4.5.49"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ac6a0c7b1a9e9a5186361f67dfa1b88213572f427fb9ab038efb2bd8c582dab"
+checksum = "2a0b5487afeab2deb2ff4e03a807ad1a03ac532ff5a2cee5d86884440c7f7671"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.4"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "cssparser"
-version = "0.31.2"
+version = "0.36.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b3df4f93e5fbbe73ec01ec8d3f68bba73107993a5b1e7519273c32db9b0d5be"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
 dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf 0.11.2",
+ "phf",
  "smallvec",
 ]
 
@@ -154,18 +130,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "derive_more"
-version = "0.99.18"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "rustc_version",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -176,14 +162,14 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "dtoa"
-version = "1.0.9"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbb2bf8e87535c23f7a8a321e364ce21462d0ff10cb6407820e8e96dfff6653"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
 
 [[package]]
 name = "dtoa-short"
@@ -196,15 +182,15 @@ dependencies = [
 
 [[package]]
 name = "ego-tree"
-version = "0.6.3"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12a0bb14ac04a9fcf170d0bbbef949b44cc492f4452bd20c095636956f653642"
+checksum = "b2972feb8dffe7bc8c5463b1dacda1b0dfbed3710e50f977d965429692d74cd8"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys",
@@ -218,9 +204,9 @@ checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
@@ -236,32 +222,24 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "getopts"
-version = "0.2.21"
+version = "0.2.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14dbbfd5c71d70241ecf9e6f13737f7b5ce823821063188d7e46c41d371eebd5"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
 dependencies = [
  "unicode-width",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "r-efi",
+ "wasip2",
 ]
 
 [[package]]
@@ -272,35 +250,32 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "html5ever"
-version = "0.27.0"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c13771afe0e6e846f1e67d038d4cb29998a6779f93c809212e4e9c32efd244d4"
+checksum = "6452c4751a24e1b99c3260d505eaeee76a050573e61f30ac2c924ddc7236f01e"
 dependencies = [
  "log",
- "mac",
  "markup5ever",
- "proc-macro2",
- "quote",
- "syn 2.0.93",
 ]
 
 [[package]]
 name = "icu_collections"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
+ "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locid"
-version = "1.5.0"
+name = "icu_locale_core"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -310,103 +285,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_locid_transform"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
-dependencies = [
- "displaydoc",
- "icu_locid",
- "icu_locid_transform_data",
- "icu_provider",
- "tinystr",
- "zerovec",
-]
-
-[[package]]
-name = "icu_locid_transform_data"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
-
-[[package]]
 name = "icu_normalizer"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
- "utf16_iter",
- "utf8_iter",
- "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "1.5.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
 dependencies = [
- "displaydoc",
  "icu_collections",
- "icu_locid_transform",
+ "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "tinystr",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "1.5.0"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
 
 [[package]]
 name = "icu_provider"
-version = "1.5.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
- "icu_locid",
- "icu_provider_macros",
- "stable_deref_trait",
- "tinystr",
+ "icu_locale_core",
  "writeable",
  "yoke",
  "zerofrom",
+ "zerotrie",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_provider_macros"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
-
-[[package]]
 name = "idna"
-version = "1.0.3"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -415,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -425,49 +362,48 @@ dependencies = [
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.4.14"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
-version = "0.4.12"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
 dependencies = [
- "autocfg",
  "scopeguard",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "mac"
@@ -477,23 +413,20 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "markup5ever"
-version = "0.12.1"
+version = "0.36.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16ce3abbeba692c8b8441d036ef91aea6df8da2c6b6e21c7e14d3c18e526be45"
+checksum = "6c3294c4d74d0742910f8c7b466f44dda9eb2d5742c1e430138df290a1e8451c"
 dependencies = [
  "log",
- "phf 0.11.2",
- "phf_codegen 0.11.2",
- "string_cache",
- "string_cache_codegen",
  "tendril",
+ "web_atoms",
 ]
 
 [[package]]
 name = "memchr"
-version = "2.7.4"
+version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "monal-html-parser"
@@ -526,15 +459,21 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.3"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -542,120 +481,83 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.10"
+version = "0.9.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.1"
+version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "phf"
-version = "0.10.1"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fabbf1ead8a5bcbc20f5f8b939ee3f5b0f6f281b6ad3468b84656b658b455259"
-dependencies = [
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared 0.11.2",
+ "phf_shared",
+ "serde",
 ]
 
 [[package]]
 name = "phf_codegen"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb1c3a8bc4dd4e5cfce29b44ffc14bedd2ee294559a294e2a4d4c9e9a6a13cd"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d39688d359e6b34654d328e262234662d16cc0f60ec8dcbe5e718709342a5a"
-dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
+ "phf_generator",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_generator"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5285893bb5eb82e6aaf5d59ee909a06a16737a8970984dd7746ba9283498d6"
+checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
- "phf_shared 0.10.0",
- "rand",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e4cc64c2ad9ebe670cb8fd69dd50ae301650392e81c05f9bfcb2d5bdbc24b0"
-dependencies = [
- "phf_shared 0.11.2",
- "rand",
+ "fastrand",
+ "phf_shared",
 ]
 
 [[package]]
 name = "phf_macros"
-version = "0.11.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3444646e286606587e49f3bcf1679b8cef1dc2c5ecc29ddacaffc305180d464b"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator 0.11.2",
- "phf_shared 0.11.2",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "phf_shared"
-version = "0.10.0"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6796ad771acdc0123d2a88dc428b5e38ef24456743ddb1744ed628f9815c096"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
 dependencies = [
  "siphasher",
 ]
 
 [[package]]
-name = "phf_shared"
-version = "0.11.2"
+name = "potential_utf"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90fcb95eef784c2ac79119d1dd819e162b5da872ce6f3c3abe1e8ca1c082f72b"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "ppv-lite86"
-version = "0.2.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
-dependencies = [
- "zerocopy",
+ "zerovec",
 ]
 
 [[package]]
@@ -666,18 +568,18 @@ checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.92"
+version = "1.0.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
+checksum = "535d180e0ecab6268a3e718bb9fd44db66bbbc256257165fc699dadf70d16fe7"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quick-xml"
-version = "0.36.2"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7649a7b4df05aed9ea7ec6f628c67c9953a43869b8bc50929569b2999d443fe"
+checksum = "f2e3bf4aa9d243beeb01a7b3bc30b77cfe2c44e24ec02d751a7104a53c2c49a1"
 dependencies = [
  "memchr",
  "serde",
@@ -685,57 +587,48 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "dc74d9a594b72ae6656596548f56f667211f8a97b3d4c3d467150794690dc40a"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
-name = "rand"
-version = "0.8.5"
+name = "r-efi"
+version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom",
-]
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.8"
+version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
+checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
  "bitflags",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.42"
+name = "rustc-hash"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f93dc38ecbab2eb790ff964bb77fa94faf256fd3e73285fd7ba0903b76bedb85"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
  "bitflags",
  "errno",
@@ -752,16 +645,15 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scraper"
-version = "0.20.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b90460b31bfe1fc07be8262e42c665ad97118d4585869de9345a84d501a9eaf0"
+checksum = "93cecd86d6259499c844440546d02f55f3e17bd286e529e48d1f9f67e92315cb"
 dependencies = [
- "ahash",
  "cssparser",
  "ego-tree",
  "getopts",
  "html5ever",
- "once_cell",
+ "precomputed-hash",
  "selectors",
  "tendril",
 ]
@@ -778,92 +670,105 @@ dependencies = [
 
 [[package]]
 name = "selectors"
-version = "0.25.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4eb30575f3638fc8f6815f448d50cb1a2e255b0897985c8c59f4d37b72a07b06"
+checksum = "feef350c36147532e1b79ea5c1f3791373e61cbd9a6a2615413b3807bb164fb7"
 dependencies = [
  "bitflags",
  "cssparser",
  "derive_more",
- "fxhash",
  "log",
  "new_debug_unreachable",
- "phf 0.10.1",
- "phf_codegen 0.10.0",
+ "phf",
+ "phf_codegen",
  "precomputed-hash",
+ "rustc-hash",
  "servo_arc",
  "smallvec",
 ]
 
 [[package]]
-name = "serde"
-version = "1.0.217"
+name = "semver"
+version = "1.0.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+
+[[package]]
+name = "serde"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "serde_core"
+version = "1.0.228"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "servo_arc"
-version = "0.3.0"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d036d71a959e00c77a63538b90a6c2390969f9772b096ea837205c6bd0491a44"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
 dependencies = [
  "stable_deref_trait",
 ]
 
 [[package]]
 name = "siphasher"
-version = "0.3.11"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
 
 [[package]]
 name = "smallvec"
-version = "1.13.2"
+version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c5e1a9a646d36c3599cd173a41282daf47c44583ad367b8e6837255952e5c67"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
 name = "string_cache"
-version = "0.8.7"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91138e76242f575eb1d3b38b4f1362f10d3a43f47d182a5b359af488a02293b"
+checksum = "a18596f8c785a729f2819c0f6a7eae6ebeebdfffbfe4214ae6b087f690e31901"
 dependencies = [
  "new_debug_unreachable",
- "once_cell",
  "parking_lot",
- "phf_shared 0.10.0",
+ "phf_shared",
  "precomputed-hash",
- "serde",
 ]
 
 [[package]]
 name = "string_cache_codegen"
-version = "0.5.2"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bb30289b722be4ff74a408c3cc27edeaad656e06cb1fe8fa9231fa59c728988"
+checksum = "585635e46db231059f76c5849798146164652513eb9e8ab2685939dd90f29b69"
 dependencies = [
- "phf_generator 0.10.0",
- "phf_shared 0.10.0",
+ "phf_generator",
+ "phf_shared",
  "proc-macro2",
  "quote",
 ]
@@ -876,9 +781,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "swift-bridge"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca240710850bfee64549b2f86cd2c6fbbb3de64ce5f3da764cb1ecec5c6cc37"
+checksum = "384ed39ea10f1cefabb197b7d8e67f0034b15a94ccbb1038b8e020da59bfb0be"
 dependencies = [
  "swift-bridge-build",
  "swift-bridge-macro",
@@ -886,9 +791,9 @@ dependencies = [
 
 [[package]]
 name = "swift-bridge-build"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d0ea3c38460a65d975df382b71edbc0e22942d937710d63144267d6609ce738"
+checksum = "71b36df21e7f8a8b5eeb718d2e71f9cfc308477bfb705981cca705de9767dcb7"
 dependencies = [
  "proc-macro2",
  "swift-bridge-ir",
@@ -898,9 +803,9 @@ dependencies = [
 
 [[package]]
 name = "swift-bridge-ir"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5ea2dcd83a40a918fb26a1bb90187691aa0ae8f2c96e8ea5e6963207bc65676"
+checksum = "c73bd16155df50708b92306945656e57d62d321290a7db490f299f709fb31c83"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -909,9 +814,9 @@ dependencies = [
 
 [[package]]
 name = "swift-bridge-macro"
-version = "0.1.57"
+version = "0.1.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c9b93285ca24a3fd596ecd316b217c4a0fd78c629e09efb1b4990fab1478183"
+checksum = "a1a13dc0dc875d85341dec5b5344a7d713f20eb5650b71086b27d09a6ece272f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -932,9 +837,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.93"
+version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c786062daee0d6db1132800e623df74274a0a87322d8e183338e01b3d98d058"
+checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -943,23 +848,23 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.1"
+version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]
 
 [[package]]
 name = "tempfile"
-version = "3.14.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
- "cfg-if",
  "fastrand",
+ "getrandom",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -978,9 +883,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.7.6"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -988,25 +893,26 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "url"
-version = "2.5.4"
+version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
 dependencies = [
  "form_urlencoded",
  "idna",
  "percent-encoding",
+ "serde",
 ]
 
 [[package]]
@@ -1014,12 +920,6 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
-
-[[package]]
-name = "utf16_iter"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -1034,22 +934,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
-name = "version_check"
-version = "0.9.5"
+name = "wasip2"
+version = "1.0.2+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
 
 [[package]]
-name = "wasi"
-version = "0.11.0+wasi-snapshot-preview1"
+name = "web_atoms"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
+checksum = "30e588f10c7bc3465f5fc1ab087fc97877ec1064a7ec89fb685ac4ee998dac4a"
+dependencies = [
+ "phf",
+ "phf_codegen",
+ "string_cache",
+ "string_cache_codegen",
+]
 
 [[package]]
 name = "webrtc-sdp"
 version = "0.3.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a87d58624aae43577604ea137de9dcaf92793eccc4d816efad482001c2e055ca"
+source = "git+https://github.com/tmolitor-stud-tu/webrtc-sdp.git?branch=master#b722e82d60f0c36da1faa7c3e0253688970e1874"
 dependencies = [
  "log",
  "serde",
@@ -1058,97 +966,38 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-sys"
-version = "0.59.0"
+version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-targets",
+ "windows-link",
 ]
 
 [[package]]
-name = "windows-targets"
-version = "0.52.6"
+name = "wit-bindgen"
+version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "write16"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "writeable"
-version = "0.5.5"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "yoke"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -1156,63 +1005,53 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.7.5"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
-dependencies = [
- "byteorder",
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.7.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.93",
-]
-
-[[package]]
 name = "zerofrom"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
+checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
+checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
  "synstructure",
 ]
 
 [[package]]
-name = "zerovec"
-version = "0.10.4"
+name = "zerotrie"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -1221,11 +1060,11 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.10.3"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.93",
+ "syn 2.0.114",
 ]

--- a/rust/monal-html-parser/Cargo.toml
+++ b/rust/monal-html-parser/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["staticlib", "lib"]
 
 [dependencies]
 clap = {version = "4.5.20", features = ["derive"]}
-scraper = "0.20.0"
+scraper = "0.25.0"

--- a/rust/sdp-to-jingle/Cargo.toml
+++ b/rust/sdp-to-jingle/Cargo.toml
@@ -11,5 +11,5 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 serde = {version = "1.0"}
 serde_derive = {version = "1.0"}
-quick-xml = { version = "0.38", features = ["serialize", "overlapped-lists"] }
+quick-xml = { version = "0.39", features = ["serialize", "overlapped-lists"] }
 webrtc-sdp = { git = "https://github.com/tmolitor-stud-tu/webrtc-sdp.git", branch = "master", features = ["serialize"] }

--- a/rust/sdp-to-jingle/Cargo.toml
+++ b/rust/sdp-to-jingle/Cargo.toml
@@ -11,6 +11,5 @@ crate-type = ["staticlib", "lib"]
 [dependencies]
 serde = {version = "1.0"}
 serde_derive = {version = "1.0"}
-quick-xml = { version = "0.36", features = ["serialize", "overlapped-lists"] }
-
-webrtc-sdp = {version = "0.3.10", features = ["serialize"] }
+quick-xml = { version = "0.38", features = ["serialize", "overlapped-lists"] }
+webrtc-sdp = { git = "https://github.com/tmolitor-stud-tu/webrtc-sdp.git", branch = "master", features = ["serialize"] }


### PR DESCRIPTION
IOS_ONLY - Fixed broken video calls by fixing bug in Mozilla's webrtc-sdp library
- Reworked complete OMEMO trust management
- Fixed spurious "new OMEMO device found" notifications and status messages
- Introduced some new OMEMO expert settings
- Improved UI responsiveness in some rare cases
- Made sure to periodically advance the OMEMO DH-ratchet even on devices only used for receiving messages, not sending
- Made sure to remove old OMEMO devices not seen for more than 90 days from own devicelist