### PR TITLE
Fix a couple of bugs

### DIFF
--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -927,7 +927,7 @@ static NSDateFormatter* dbFormatter;
 -(NSDictionary* _Nullable) getDraftMessageDictionaryForJid:(NSString*) jid onAccount:(NSNumber*) accountID
 {
     return [self.db idReadTransaction:^{
-        NSArray* results = [self.db executeReader:@"SELECT bl.messageDraft AS message, ac.lastMessageTime AS thetime, 'MessageDraft' AS messageType FROM buddylist AS bl INNER JOIN activechats AS ac ON bl.account_id = ac.account_id AND bl.buddy_name = ac.buddy_name WHERE ac.account_id=? AND ac.buddy_name=? AND messageDraft IS NOT NULL AND messageDraft != '';" andArguments:@[accountID, jid]];
+        NSArray* results = [self.db executeReader:@"SELECT bl.messageDraft AS message, ac.lastMessageTime AS thetime, 'MessageDraft' AS messageType, bl.account_id, bl.buddy_name FROM buddylist AS bl INNER JOIN activechats AS ac ON bl.account_id = ac.account_id AND bl.buddy_name = ac.buddy_name WHERE ac.account_id=? AND ac.buddy_name=? AND messageDraft IS NOT NULL AND messageDraft != '';" andArguments:@[accountID, jid]];
         if([results count])
         {
             NSMutableDictionary* message = [(NSDictionary*)results[0] mutableCopy];

--- a/Monal/Classes/MLMessage.m
+++ b/Monal/Classes/MLMessage.m
@@ -109,6 +109,8 @@ static NSMutableDictionary* _singletonCache;
         MLMessage* message = [self new];
         // Fill only the properties useful for a draft message
         // The timestamp is used when rendering MLContactCell, among other things
+        message.accountID = dic[@"account_id"];
+        message.buddyName = dic[@"buddy_name"];
         message.messageText = dic[@"message"];
         message.messageType = dic[@"messageType"];
         message.timestamp = dic[@"thetime"];

--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -469,6 +469,23 @@ static NSMutableDictionary* _typingNotifications;
         sentByOwnOmemoDevice = ((NSNumber*)[messageNode findFirst:@"{eu.siacs.conversations.axolotl}encrypted/header@sid|uint"]).unsignedIntValue == [account.omemo getDeviceId].unsignedIntValue;
 #endif
     
+    //handle fallback body of incoming reactions
+    //(only ignore the fallback body, if it covers the whole body, else ignore the reaction and show the body as normal message)
+    BOOL isReaction = [messageNode check:@"{urn:xmpp:reactions:0}reactions"];
+    if(isReaction && [messageNode check:@"{urn:xmpp:fallback:0}fallback<for=urn:xmpp:reactions:0>/body"])
+    {
+        NSString* fallbackBody = decrypted != nil ? decrypted : [messageNode findFirst:@"body#"];
+        NSNumber* start = [messageNode findFirst:@"{urn:xmpp:fallback:0}fallback<for=urn:xmpp:reactions:0>/body@start"];
+        NSNumber* end = [messageNode findFirst:@"{urn:xmpp:fallback:0}fallback<for=urn:xmpp:reactions:0>/body@end"];
+        if((start == nil || start.unsignedIntValue == 0) && (end == nil || (fallbackBody != nil && end.unsignedIntValue == [fallbackBody length])))
+            DDLogInfo(@"Ignoring fallback body on reaction...");
+        else
+        {
+            DDLogWarn(@"Ignoring reaction with fallback body! The fallback body will be handled like a normal message.");
+            isReaction = NO;
+        }
+    }
+    
     BOOL possiblyUpdatedStanzaId = NO;
     
     //handle message retraction (XEP-0424)
@@ -546,7 +563,7 @@ static NSMutableDictionary* _typingNotifications;
             DDLogWarn(@"Got faked tombstone without server supporting them, ignoring it!");
     }
     //handle incoming reactions
-    else if([messageNode check:@"{urn:xmpp:reactions:0}reactions"])
+    else if([messageNode check:@"{urn:xmpp:reactions:0}reactions"] && !([messageNode check:@"body#"] || decrypted))
     {
         NSString* reactionId = [messageNode findFirst:@"{urn:xmpp:reactions:0}reactions@id"];
         NSOrderedSet* reactions = [NSOrderedSet orderedSetWithArray:[messageNode find:@"{urn:xmpp:reactions:0}reactions<id=%@>/reaction#", reactionId]];
@@ -573,8 +590,6 @@ static NSMutableDictionary* _typingNotifications;
             DDLogWarn(@"Ignoring incoming reaction: neither participantJid nor occupant-id provided!");
         else if(reactionId == nil)
             DDLogError(@"Received reaction without id attribute, implementation error in sender!");
-        else if([messageNode check:@"body#"] || decrypted)
-            DDLogWarn(@"Ignoring reaction with fallback body! The fallback body will be handled like a normal message.");
         else
         {
             DDLogDebug(@"Searching for history ID of messageIdOrStanzaId=%@, inChat=%@", reactionId, possiblyUnknownContact);

--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -563,7 +563,7 @@ static NSMutableDictionary* _typingNotifications;
             DDLogWarn(@"Got faked tombstone without server supporting them, ignoring it!");
     }
     //handle incoming reactions
-    else if([messageNode check:@"{urn:xmpp:reactions:0}reactions"] && !([messageNode check:@"body#"] || decrypted))
+    else if(isReaction)
     {
         NSString* reactionId = [messageNode findFirst:@"{urn:xmpp:reactions:0}reactions@id"];
         NSOrderedSet* reactions = [NSOrderedSet orderedSetWithArray:[messageNode find:@"{urn:xmpp:reactions:0}reactions<id=%@>/reaction#", reactionId]];


### PR DESCRIPTION
- Set the `accountID` and `buddyName` MLMessage properties for message drafts, because some parts of the code base expect them to be not nil e.g. `MLContact createContactFromJid:andAccountID`
- Fix a mistake in the reactions fallback handling commit