### PR TITLE
Fix a few crashes

### DIFF
--- a/Monal/Classes/DataLayerMigrations.m
+++ b/Monal/Classes/DataLayerMigrations.m
@@ -1055,7 +1055,7 @@
         
         //make sure all muc messages in our history db have an occupant id
         [self updateDB:db withDataLayer:dataLayer toVersion:7.006 withBlock:^{
-            NSArray<NSNumber*>* missingOccupantIds = [db executeScalarReader:@"SELECT message_history_id FROM message_history AS M WHERE (occupant_id = NULL OR occupant_id = '') AND EXISTS(SELECT 1 FROM buddylist AS B WHERE M.account_id = B.account_id AND M.buddy_name = B.buddy_name AND B.Muc);"];
+            NSArray<NSNumber*>* missingOccupantIds = [db executeScalarReader:@"SELECT message_history_id FROM message_history WHERE (occupant_id IS NULL OR occupant_id = '') AND buddy_name IN (SELECT buddy_name FROM buddylist WHERE Muc=1);"];
             DDLogWarn(@"History IDs of messages with missing occupant IDs during DB migration: %@", missingOccupantIds);
             for(NSNumber* historyId in missingOccupantIds)
                 [db executeNonQuery:@"UPDATE message_history SET occupant_id=? WHERE message_history_id=?;" andArguments:@[[[NSUUID UUID] UUIDString], historyId]];

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1047,6 +1047,8 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         [NSDictionary class],
         [NSMutableSet class],
         [NSSet class],
+        [NSMutableOrderedSet class],
+        [NSOrderedSet class],
         [NSMutableArray class],
         [NSArray class],
         [NSNumber class],

--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -840,10 +840,13 @@ static NSMutableDictionary* _typingNotifications;
                     @"showAlert": @(NO),
                     @"contact": possiblyUnknownContact,
                     @"LMCReplaced": @NO,
-                    @"stanzaId": stanzaid,
+                    @"stanzaId": nilWrapper(stanzaid),
                     @"reactionsUpdate": @NO,
                 }];
-            DDLogDebug(@"Managed to update stanzaid of message (or stanzaid already known): %@", message);
+            if(stanzaid)
+                DDLogDebug(@"Managed to update stanzaid of message (or stanzaid already known): %@", message);
+            else
+                DDLogWarn(@"MUC reflection without a stanzaid! This likely means that the MUC server doesn't support stanzaids. message: %@", message);
         }
     }
     


### PR DESCRIPTION
This fixes three crashes:
- The first one is when receiving a MUC reflection that doesn't contain a stanzaID. This happens when the MUC server doesn't support stanzaIDs. For example Prosody currently has the stanzaID support in the `muc_mam` module, so if that module isn't loaded stanzaIDs aren't supported.
- The second one has the following error message and stack trace:
```
CRASH(NSError): Error Domain=NSCocoaErrorDomain Code=4864 "value for key 'NS.objects' was of unexpected class 'NSMutableOrderedSet' (0x20c80a838) [/System/Library/Frameworks/CoreFoundation.framework].
Allowed classes are: [long list of allowed classes]

Stack Trace: (
	0   CoreFoundation                      0x00000001a1d6d050 E89D821C-A544-315C-8903-39CA54D7FAF4 + 1155152
	1   libobjc.A.dylib                     0x000000019f205abc objc_exception_throw + 88
	2   monalxmpp                           0x00000001030c3b68 +[HelperTools unserializeData:] + 948
	3   monalxmpp                           0x0000000102ef04b0 -[DataLayer readStateForAccount:] + 408
	4   monalxmpp                           0x0000000102f7c368 -[xmpp realReadState] + 424
```
The crash only mentions `NSMutableOrderedSet`, but I added `NSOrderedSet` as well.
- The third one is when viewing old messages that don't have an occupantID. This was supposed to be fixed by https://github.com/monal-im/Monal/commit/a0588600b318ba5a504d0199960c1bea147d01cb but that commit has a mistake: it uses `=` for comparison with `NULL`. That doesn't work in SQL, which expects comparisons with `NULL` to use `IS`.

While at it, I took the liberty to change the SELECT query to make it faster by removing the join. It resulted in 3x time improvement for the SELECT on my database (from 110ms to 33ms)

I opted for modifying the existing migration, rather than make a new one. This means the fix will not be available for existing alpha users. But our alpha user base is very small, and the crash has a workaround: clearing the history of the crashing chat (which can be done without opening the chat, via the Contacts view)