### PR TITLE
Generate image thumbnails and use thumbnails in the media gallery

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -862,8 +862,7 @@ class ChatViewMessage: ExyteChat.Message {
             if innerMessage.messageType == kMessageTypeFiletransfer, let fileInfo = fileInfo {
                 switch(fileInfo.downloadState as DownloadState.RawValue) {
                     case DownloadState.complete.rawValue:
-                        let mimeType = fileInfo.mimeType as String
-                        if mimeType.starts(with: "audio/") || mimeType.starts(with: "image/") || mimeType.starts(with: "video/") {
+                        if fileInfo.isAudio || fileInfo.isImage || fileInfo.isVideo {
                             return ""
                         } else {
                             return """
@@ -949,19 +948,13 @@ class ChatViewMessage: ExyteChat.Message {
                 MLFiletransfer.checkMimeTypeAndSize(forHistoryID: innerMessage.messageDBId)
                 return []
             }
-            let fileURL = fileInfo.fileURL as URL
-            let cacheId = fileInfo.cacheId as String
-            let attachmentUUID = HelperTools.stringToUUID(cacheId).uuidString
-            switch fileInfo.mimeType as String {
-                case let mimeType where mimeType.starts(with: "image/"):
-                    let attachment = Attachment(id: attachmentUUID, url: fileURL, type: .image)
-                    return [attachment]
-                case let mimeType where mimeType.starts(with: "video/"):
-                    let thumbnail = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
-                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: fileURL, type: .video, mimeType: mimeType)
-                    return [attachment]
-                default:
-                    return []
+            if fileInfo.isImage || fileInfo.isVideo {
+                let attachmentType: AttachmentType = fileInfo.isImage ? .image : .video
+                let thumbnailURL = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
+                let attachment = Attachment(id: fileInfo.cacheId, thumbnail: thumbnailURL, full: fileInfo.fileURL, type: attachmentType, mimeType: fileInfo.mimeType)
+                return [attachment]
+            } else {
+                return []
             }
         }
         set {}
@@ -975,11 +968,10 @@ class ChatViewMessage: ExyteChat.Message {
             guard (fileInfo.downloadState as DownloadState.RawValue) == DownloadState.complete.rawValue else {
                 return nil
             }
-            guard (fileInfo.mimeType as String).starts(with: "audio/") else {
+            guard fileInfo.isAudio else {
                 return nil
             }
-            let fileURL = fileInfo.fileURL as URL
-            return Recording(duration: fileInfo.mediaDuration, url: fileURL, mimeType: fileInfo.mimeType)
+            return Recording(duration: fileInfo.mediaDuration, url: fileInfo.fileURL, mimeType: fileInfo.mimeType)
         }
         set {}
     }

--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -34,6 +34,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class MLXMLNode;
 @class xmpp;
 @class XMPPStanza;
+@class MLFiletransferInfo;
 @class UNNotificationRequest;
 @class DDLogMessage;
 @class DDFileLogger;
@@ -123,7 +124,7 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSError* _Nullable) postUserNotificationRequest:(UNNotificationRequest*) request;
 +(void) createAVURLAssetFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension withCompletionHandler:(void(^)(AVURLAsset* _Nullable)) completion;
 +(AnyPromise*) computeMediaDurationFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension;
-+(AnyPromise*) generateVideoThumbnailFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension;
++(AnyPromise*) generateThumbnailFromFile:(MLFiletransferInfo*) fileInfo;
 +(AnyPromise*) addUploadItemPreviewForItem:(NSURL* _Nullable) url provider:(NSItemProvider* _Nullable) provider andPayload:(NSMutableDictionary*) payload;
 +(AnyPromise*) handleUploadItemProvider:(NSItemProvider*) provider;
 +(UIImage* _Nullable) rotateImage:(UIImage* _Nullable) image byRadians:(CGFloat) rotation;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -51,6 +51,7 @@ extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 #import <monalxmpp/MLContact.h>
 #import <monalxmpp/MLMessage.h>
 #import <monalxmpp/MLFileTransfer.h>
+#import <monalxmpp/MLFiletransferInfo.h>
 #import <monalxmpp/DataLayer.h>
 #import <monalxmpp/OmemoState.h>
 #import <monalxmpp/MLUDPLogger.h>
@@ -1169,7 +1170,55 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     }];
 }
 
-+(AnyPromise*) generateVideoThumbnailFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension
++(AnyPromise*) generateThumbnailFromFile:(MLFiletransferInfo*) fileInfo
+{
+    if(fileInfo.isImage)
+        return [HelperTools generateThumbnailFromImageFile:fileInfo];
+    else if(fileInfo.isVideo)
+        return [HelperTools generateThumbnailFromVideoFile:fileInfo.cacheFilePath havingMimeType:fileInfo.mimeType andFileExtension:fileInfo.fileExtension];
+    else
+        unreachable(@"Trying to generate a thumbnail for a file that is neither an image nor a video");
+}
+
++(AnyPromise*) generateThumbnailFromImageFile:(MLFiletransferInfo*) fileInfo
+{
+    return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
+        AnyPromise* imagePromise = nil;
+        if(fileInfo.isSVGImage)
+            imagePromise = [HelperTools renderUIImageFromSVGURL:fileInfo.fileURL];
+        else
+            imagePromise = [AnyPromise promiseWithValue:[[UIImage alloc] initWithContentsOfFile:fileInfo.cacheFilePath]];
+        imagePromise.then(^(UIImage* image) {
+             if(image == nil && fileInfo.isSVGImage)
+                return resolve([NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Could not load SVG image to generate its thumbnail."}]);
+
+            // The size passed to prepareThumbnailOfSize: is the maximum dimensions, because the method
+            // preserves the original aspect ratio.
+            // For example, if we pass it 200x200 size and a 2:1 image, the output will be a 200x100 thumbnail
+            // So, we calculate the size that should be passed to the method, such that its output has 200x200 as
+            // a minimum size. i.e. in the previous example that would be 400x200
+            // That ensures that the thumbnail will look as good as possible in the ChatView
+            // (which currently crops the thumbnail to 204x200, and in some cases (using SFS) 204x100 or 100x100)
+            CGFloat scale = [UIScreen mainScreen].scale;
+            CGFloat minSize = 200 * scale; // minimum width and height are both 200
+            CGFloat aspectRatio = image.size.width / image.size.height;
+            CGSize targetSize;
+            if(aspectRatio > 1.0)
+                targetSize = CGSizeMake(minSize * aspectRatio, minSize);
+            else
+                targetSize = CGSizeMake(minSize, minSize / aspectRatio);
+
+            [image prepareThumbnailOfSize:targetSize completionHandler:^(UIImage* thumbnail) {
+                if(thumbnail == nil)
+                    return resolve([NSError errorWithDomain:@"Monal" code:0 userInfo:@{NSLocalizedDescriptionKey: @"Could not generate thumbnail of image file"}]);
+                else
+                    return resolve(thumbnail);
+            }];
+        });
+    }];
+}
+
++(AnyPromise*) generateThumbnailFromVideoFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension;
 {
     return [AnyPromise promiseWithResolverBlock:^(PMKResolver resolve) {
         [self createAVURLAssetFromFile:file havingMimeType:mimeType andFileExtension:fileExtension withCompletionHandler:^(AVURLAsset* asset) {
@@ -1272,7 +1321,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
             NSString* mimeType = [UTType typeWithFilenameExtension:url.pathExtension].preferredMIMEType;
             if(!mimeType)
                 mimeType = @"application/octet-stream";
-            [self generateVideoThumbnailFromFile:url.path havingMimeType:mimeType andFileExtension:url.pathExtension].then(^(UIImage* image) {
+            [self generateThumbnailFromVideoFile:url.path havingMimeType:mimeType andFileExtension:url.pathExtension].then(^(UIImage* image) {
                 payload[@"preview"] = image;
                 DDLogVerbose(@"Managed to generate thumbnail for url=%@ using generateVideoThumbnailFromFile: %@", url, image);
                 [url stopAccessingSecurityScopedResource];

--- a/Monal/Classes/MLChatImageCell.m
+++ b/Monal/Classes/MLChatImageCell.m
@@ -87,12 +87,12 @@
             [self.thumbnailImage addSubview:_animatedImageView];
             self.thumbnailImage.contentMode = UIViewContentModeScaleAspectFit;
         }
-        else if([info.mimeType hasPrefix:@"image/"])
+        else if(info.isImage)
         {
             self.link = msg.messageText;
             AnyPromise* imagePromise = nil;
             // this code already runs in the main queue --> we can't use PMKHang
-            if([info.mimeType hasPrefix:@"image/svg"])
+            if(info.isSVGImage)
                 imagePromise = [HelperTools renderUIImageFromSVGURL:[NSURL fileURLWithPath:info.cacheFilePath]];
             else
                 imagePromise = [AnyPromise promiseWithValue:[[UIImage alloc] initWithContentsOfFile:info.cacheFilePath]];

--- a/Monal/Classes/MLFiletransfer.m
+++ b/Monal/Classes/MLFiletransfer.m
@@ -504,9 +504,9 @@ $$
     MLFiletransferInfo* info = msg.fileInfo;
     DDLogDebug(@"Deleting file in cache: %@", info.cacheFilePath);
     [_fileManager removeItemAtPath:info.cacheFilePath error:nil];
-    if([info.mimeType hasPrefix:@"video/"])
+    if(info.isVideo || info.isImage)
     {
-        DDLogVerbose(@"Deleting video thumbnail stored at %@", msg.fileInfo.thumbnailURL.path);
+        DDLogVerbose(@"Deleting attachment thumbnail stored at %@", msg.fileInfo.thumbnailURL.path);
         [_fileManager removeItemAtPath:msg.fileInfo.thumbnailURL.path error:nil];
     }
 }

--- a/Monal/Classes/MLFiletransferInfo.h
+++ b/Monal/Classes/MLFiletransferInfo.h
@@ -36,6 +36,7 @@ typedef NS_ENUM(NSUInteger, DownloadState) {
 @property (nonatomic, readonly) UTType* _Nullable utType;
 
 @property (nonatomic, readonly) BOOL isImage;
+@property (nonatomic, readonly) BOOL isSVGImage;
 @property (nonatomic, readonly) BOOL isAudio;
 @property (nonatomic, readonly) BOOL isVideo;
 @property (nonatomic, readonly) BOOL isPDF;

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -162,6 +162,9 @@ static NSMutableDictionary* _singletonCache;
 }
 
 -(NSURL*) thumbnailURL {
+    if(!self.isImage && !self.isVideo)
+        return nil;
+
     // return thumbnail cached in memory.
     if(_thumbnailURL != nil)
         return _thumbnailURL;
@@ -180,14 +183,20 @@ static NSMutableDictionary* _singletonCache;
     if(!self.isGeneratingThumbnail)
     {
         self.isGeneratingThumbnail = YES;
-        [HelperTools generateVideoThumbnailFromFile:self.cacheFilePath havingMimeType:self.mimeType andFileExtension:self.fileExtension]
+        [HelperTools generateThumbnailFromFile:self]
         .then(^(UIImage* image) {
-            NSData* imageData = UIImagePNGRepresentation(image);
+            NSData* imageData;
+            // Use HEIC for better compression, if it's available
+            if(@available(iOS 17.0, *))
+                imageData = UIImageHEICRepresentation(image);
+            else
+                imageData = UIImageJPEGRepresentation(image, 0.8);
+
             // The following instruction triggers a ChatView update
             self.thumbnailURL = [[MLImageManager sharedInstance] setThumbnailOfMessage:self.message withData:imageData];
             self.isGeneratingThumbnail = NO;
         }).catch(^(NSError* error) {
-            DDLogError(@"Could not create video thumbnail: %@", error);
+            DDLogError(@"Could not create attachment thumbnail: %@", error);
         });
     }
 

--- a/Monal/Classes/MLFiletransferInfo.m
+++ b/Monal/Classes/MLFiletransferInfo.m
@@ -281,6 +281,16 @@ static NSMutableDictionary* _singletonCache;
     return [NSSet setWithObjects:@"mimeType", nil];
 }
 
+-(BOOL) isSVGImage
+{
+    return [self.mimeType hasPrefix:@"image/svg"];
+}
+
++(NSSet*) keyPathsForValuesAffectingIsSVGImage
+{
+    return [NSSet setWithObjects:@"mimeType", nil];
+}
+
 -(BOOL) isAudio
 {
     return [self.mimeType hasPrefix:@"audio/"];

--- a/Monal/Classes/MLImageManager.m
+++ b/Monal/Classes/MLImageManager.m
@@ -226,7 +226,7 @@
 
 -(NSString*) fileNameforThumbnailOfMessage:(MLMessage*) message
 {
-    return [NSString stringWithFormat:@"%@.png", message.messageDBId.stringValue];
+    return [NSString stringWithFormat:@"%@.heic", message.messageDBId.stringValue];
 }
 
 -(NSURL*) setThumbnailOfMessage:(MLMessage*) message withData:(NSData* _Nullable) data

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -901,7 +901,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if([typeHint conformsToType:UTTypeAudio])
         notificationAttachment = [notificationAttachment stringByAppendingPathComponent:[attachmentBasename stringByAppendingPathExtension:info.fileExtension]];
     UIImage* image = nil;
-    if([info.mimeType hasPrefix:@"image/svg"])
+    if(info.isSVGImage)
     {
         NSString* pngAttachment = [attachmentDir stringByAppendingPathComponent:[attachmentBasename stringByAppendingPathExtensionForType:UTTypePNG]];
         DDLogVerbose(@"Preparing for notification attachment(%@): converting downloaded file from svg at '%@' to png at '%@'...", typeHint, info.cacheFilePath, pngAttachment);

--- a/Monal/Classes/MediaGallery.swift
+++ b/Monal/Classes/MediaGallery.swift
@@ -45,86 +45,27 @@ struct MediaGalleryView: View {
     }
 }
 
-class MediaItem: Identifiable, ObservableObject {
-    let id = UUID()
-    let fileInfo: MLFiletransferInfo
-    @Published var thumbnail: UIImage?
-
-    init(fileInfo: MLFiletransferInfo) {
-        self.fileInfo = fileInfo
-        self.thumbnail = nil
-        Task { @MainActor in
-            await generateThumbnail()
-        }
-    }
-
-    @MainActor
-    func generateThumbnail() async {
-        guard let cacheFilePath = fileInfo.cacheFilePath else {
-            DDLogError("Failed to get cacheFilePath for: \(fileInfo)")
-            self.thumbnail = UIImage(systemName: "exclamationmark.triangle")
-            return
-        }
-
-        if fileInfo.isImage {
-            if let image = UIImage(contentsOfFile: cacheFilePath) {
-                self.thumbnail = image
-            } else {
-                DDLogError("Failed to generate image thumbnail for: \(fileInfo)")
-                self.thumbnail = UIImage(systemName: "photo")
-            }
-            return
-        } else if fileInfo.isVideo {
-            if let thumbnail = await videoPreview(for:fileInfo) {
-                self.thumbnail = thumbnail
-            } else {
-                DDLogError("Failed to generate video thumbnail for: \(fileInfo)")
-                self.thumbnail = UIImage(systemName: "video")
-            }
-            return
-        }
-
-        DDLogError("Unsupported mime type: \(fileInfo.mimeType ?? "(unknown)")")
-        self.thumbnail = UIImage(systemName: "doc")
-    }
-
-    @MainActor
-    func videoPreview(for fileInfo: MLFiletransferInfo) async -> UIImage? {
-        let moviePath = URL(fileURLWithPath: fileInfo.cacheFilePath!)
-        DDLogInfo("Trying to generate video thumbnail for: \(String(describing:fileInfo))")
-        
-        let payload: NSDictionary? = try? await HelperTools.addUploadItemPreview(
-            forItem:moviePath,
-            provider:nil,
-            andPayload:[:]
-        ).toTypedPromise().asyncOnMainActor()
-        guard let image = payload?["preview"] as? UIImage else {
-            return try? await HelperTools.generateVideoThumbnail(
-                fromFile:fileInfo.cacheFilePath!,
-                havingMimeType:fileInfo.mimeType! ,
-                andFileExtension:fileInfo.fileExtension
-            ).toTypedPromise().asyncOnMainActor()
-        }
-        return image
-    }
-}
-
 struct MediaItemView: View {
-    @StateObject private var item: MediaItem
+    @StateObject private var fileInfo: ObservableKVOWrapper<MLFiletransferInfo>
 
     init(fileInfo: MLFiletransferInfo) {
-        _item = StateObject(wrappedValue: MediaItem(fileInfo: fileInfo))
+        _fileInfo = StateObject(wrappedValue: ObservableKVOWrapper(fileInfo))
     }
 
     var body: some View {
         ZStack {
             Group {
-                if let thumbnail = item.thumbnail {
-                    Image(uiImage: thumbnail)
-                        .resizable()
-                        //.scaledToFit()        //leaves empty room around image if not having a square format
-                        .scaledToFill()         //this is what the ios gallery app uses (will crop the edges of that preview)
-                } else {
+                if (fileInfo.thumbnailURL as URL?) != nil {
+                    AsyncImage(url: fileInfo.thumbnailURL) { image in
+                        image
+                            .resizable()
+                            //.scaledToFit()        //leaves empty room around image if not having a square format
+                            .scaledToFill()         //this is what the ios gallery app uses (will crop the edges of that preview)
+                    } placeholder: { //placeholder while the thumbnail is being loaded from disk
+                        ProgressView()
+                            .progressViewStyle(CircularProgressViewStyle())
+                    }
+                } else { //placeholder if the thumbnailURL is nil, for example while the thumbnail is being generated
                     ProgressView()
                         .progressViewStyle(CircularProgressViewStyle())
                 }
@@ -134,7 +75,7 @@ struct MediaItemView: View {
             .overlay(RoundedRectangle(cornerRadius: 10).stroke(Color.gray, lineWidth: 1))
             
             // Add play icon overlay for video files
-            if item.fileInfo.isVideo {
+            if fileInfo.isVideo {
                 Image(systemName: "play.circle.fill")
                     .resizable()
                     .frame(width: 30, height: 30)
@@ -147,15 +88,15 @@ struct MediaItemView: View {
 }
 
 struct MediaItemDetailView: View {
-    @StateObject private var item: MediaItem
+    @StateObject private var fileInfo: ObservableKVOWrapper<MLFiletransferInfo>
     @StateObject private var dismisser = SheetDismisserProtocol()
     
     init(fileInfo: MLFiletransferInfo) {
-        _item = StateObject(wrappedValue: MediaItem(fileInfo: fileInfo))
+        _fileInfo = StateObject(wrappedValue: ObservableKVOWrapper(fileInfo))
     }
 
     var body: some View {
-        ImageViewerWrapper(info: item.fileInfo as MLFiletransferInfo, dismisser: dismisser)
+        ImageViewerWrapper(info: fileInfo, dismisser: dismisser)
             .onAppear {
                 let appDelegate = UIApplication.shared.delegate as! MonalAppDelegate
                 if let hostingController = appDelegate.getTopViewController() as? UIHostingController<AnyView> {
@@ -199,12 +140,12 @@ struct MediaItemSwipeView: View {
 }
 
 struct ImageViewerWrapper: View {
-    let info: MLFiletransferInfo
+    @ObservedObject var info: ObservableKVOWrapper<MLFiletransferInfo>
     let dismisser: SheetDismisserProtocol
     
     var body: some View {
         Group {
-            if info.downloadState == DownloadState.complete {
+            if info.downloadState as DownloadState.RawValue == DownloadState.complete.rawValue {
                 try? ImageViewer(delegate: dismisser, info: info)
             } else {
                 Text("Invalid file data")
@@ -212,5 +153,3 @@ struct ImageViewerWrapper: View {
         }
     }
 }
-
-

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -65,13 +65,13 @@ struct ImageViewer: View {
             Color.background
                 .ignoresSafeArea()
             
-            if info.mimeType!.hasPrefix("image/svg") {
+            if info.isSVGImage {
                 VStack {
                     ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
                         SVGView(contentsOf: info.fileURL!)
                     }
                 }
-            } else if info.mimeType!.hasPrefix("image/") {
+            } else if info.isImage {
                 if let image = UIImage(contentsOfFile:info.cacheFilePath!) {
                     VStack {
                         ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
@@ -115,9 +115,9 @@ struct ImageViewer: View {
     }
     
     private func loadPreviewAndConfigurePlayer() async {
-        if info.mimeType!.hasPrefix("image/svg") {
+        if info.isSVGImage {
             previewImage = await HelperTools.renderUIImage(fromSVGURL: info.fileURL!).toTypedGuarantee().asyncOnMainActor()
-        } else if info.mimeType!.hasPrefix("image/") {
+        } else if info.isImage {
             previewImage = UIImage(contentsOfFile:info.cacheFilePath!)
         } else if info.isVideo {
             if let filePath = info.cacheFilePath, let mimeType = info.mimeType {
@@ -197,7 +197,7 @@ struct ControlsOverlay: View {
                         Spacer()
                         
                         if let image = previewImage {
-                            if info.mimeType!.hasPrefix("image/svg") {
+                            if info.isSVGImage {
                                 ShareLink(
                                     item: SVGRepresentation(getData: {
                                         try! NSData(contentsOfFile: info.cacheFilePath!) as Data

--- a/Monal/Classes/MediaViewer.swift
+++ b/Monal/Classes/MediaViewer.swift
@@ -48,13 +48,13 @@ struct SVGRepresentation: Transferable {
 
 struct ImageViewer: View {
     var delegate: SheetDismisserProtocol
-    let info: MLFiletransferInfo
+    @ObservedObject var info: ObservableKVOWrapper<MLFiletransferInfo>
     @State private var previewImage: UIImage?
     @State private var controlsVisible = false
     @StateObject private var customPlayer = CustomAVPlayer()
     @State private var isPlayerReady = false
 
-    init(delegate: SheetDismisserProtocol, info: MLFiletransferInfo) throws {
+    init(delegate: SheetDismisserProtocol, info: ObservableKVOWrapper<MLFiletransferInfo>) throws {
         self.delegate = delegate
         self.info = info
         DDLogDebug("Loading image for info: \(String(describing:self.info))")
@@ -68,15 +68,15 @@ struct ImageViewer: View {
             if info.isSVGImage {
                 VStack {
                     ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
-                        SVGView(contentsOf: info.fileURL!)
+                        SVGView(contentsOf: info.fileURL as URL)
                     }
                 }
             } else if info.isImage {
-                if let image = UIImage(contentsOfFile:info.cacheFilePath!) {
+                if let image = UIImage(contentsOfFile:info.cacheFilePath as String) {
                     VStack {
                         ZoomableContainer(maxScale:8.0, doubleTapScale:4.0) {
-                            if info.mimeType!.hasPrefix("image/gif") {
-                                GIFViewer(data:Binding(get: { try! NSData(contentsOfFile:info.cacheFilePath!) as Data }, set: { _ in }))
+                            if (info.mimeType as String).hasPrefix("image/gif") {
+                                GIFViewer(data:Binding(get: { try! NSData(contentsOfFile:info.cacheFilePath as String) as Data }, set: { _ in }))
                                     .scaledToFit()
                             } else {
                                 Image(uiImage: image)
@@ -116,11 +116,11 @@ struct ImageViewer: View {
     
     private func loadPreviewAndConfigurePlayer() async {
         if info.isSVGImage {
-            previewImage = await HelperTools.renderUIImage(fromSVGURL: info.fileURL!).toTypedGuarantee().asyncOnMainActor()
+            previewImage = await HelperTools.renderUIImage(fromSVGURL: info.fileURL as URL).toTypedGuarantee().asyncOnMainActor()
         } else if info.isImage {
-            previewImage = UIImage(contentsOfFile:info.cacheFilePath!)
+            previewImage = UIImage(contentsOfFile:info.cacheFilePath as String)
         } else if info.isVideo {
-            if let filePath = info.cacheFilePath, let mimeType = info.mimeType {
+            if let filePath = info.cacheFilePath as String?, let mimeType = info.mimeType as String? {
                 customPlayer.configurePlayer(filePath: filePath, mimeType: mimeType)
                 isPlayerReady = true
             }
@@ -182,10 +182,16 @@ struct InvalidFileView: View {
 }
 
 struct ControlsOverlay: View {
-    let info: MLFiletransferInfo
+    @ObservedObject var info: ObservableKVOWrapper<MLFiletransferInfo>
     @Binding var previewImage: UIImage?
     let dismiss: () -> Void
-    
+
+    init(info: ObservableKVOWrapper<MLFiletransferInfo>, previewImage: Binding<UIImage?>, dismiss: @escaping () -> Void) {
+        self.info = info
+        _previewImage = previewImage
+        self.dismiss = dismiss
+    }
+
     var body: some View {
         VStack {
             Color.background
@@ -193,37 +199,46 @@ struct ControlsOverlay: View {
                 .overlay(
                     HStack {
                         Spacer().frame(width: 20)
-                        Text(info.filename).foregroundColor(.primary)
+                        Text(info.filename as String).foregroundColor(.primary)
                         Spacer()
-                        
+
                         if let image = previewImage {
                             if info.isSVGImage {
                                 ShareLink(
                                     item: SVGRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath as String) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)
                                 .foregroundColor(.primary)
-                            } else if info.mimeType!.hasPrefix("image/gif") {
+                            } else if (info.mimeType as String).hasPrefix("image/gif") {
                                 ShareLink(
                                     item: GifRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath as String) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)
                                 .foregroundColor(.primary)
                             } else if info.isVideo {
-                                if let fileURL = info.fileURL {
-                                    let mediaItem = MediaItem(fileInfo: info)
-                                    ShareLink(item: fileURL, preview: SharePreview("Share video", image: Image(uiImage: mediaItem.thumbnail ?? UIImage(systemName: "video")!)))
-                                        .labelStyle(.iconOnly)
-                                        .foregroundColor(.primary)
+                                if let fileURL = info.fileURL as URL? {
+                                    ShareLink(
+                                        item: fileURL,
+                                        preview: SharePreview(
+                                            "Share video",
+                                            image: Image(
+                                                uiImage: info.thumbnailURL
+                                                    ? UIImage(contentsOfFile: (info.thumbnailURL as URL).path)!
+                                                    : UIImage(systemName: "video")!
+                                            )
+                                        )
+                                    )
+                                    .labelStyle(.iconOnly)
+                                    .foregroundColor(.primary)
                                 }
                             } else {
                                 ShareLink(
                                     item: JpegRepresentation(getData: {
-                                        try! NSData(contentsOfFile: info.cacheFilePath!) as Data
+                                        try! NSData(contentsOfFile: info.cacheFilePath as String) as Data
                                     }), preview: SharePreview("Share image", image: Image(uiImage: image))
                                 )
                                 .labelStyle(.iconOnly)
@@ -231,7 +246,7 @@ struct ControlsOverlay: View {
                             }
                             Spacer().frame(width: 20)
                         }
-                        
+
                         Button(action: dismiss, label: {
                             Image(systemName: "xmark")
                                 .foregroundColor(.primary)

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/monal-im/ExyteChat",
         "state": {
           "branch": "main",
-          "revision": "9852f899cea836194c67597fe5e2a1d9e72797c7",
+          "revision": "17c3e387c131005fb0efe7265dc148e3542765ec",
           "version": null
         }
       },
@@ -35,15 +35,6 @@
           "branch": null,
           "revision": "0fccfdc93a01c8555cec86bf2c64caee30c23704",
           "version": "0.9.11"
-        }
-      },
-      {
-        "package": "Kingfisher",
-        "repositoryURL": "https://github.com/onevcat/Kingfisher",
-        "state": {
-          "branch": null,
-          "revision": "d30a5fad881137e2267f96a8e3fc35c58999bb94",
-          "version": "8.6.2"
         }
       },
       {

--- a/Monal/opensource.html
+++ b/Monal/opensource.html
@@ -244,38 +244,6 @@
         </details>
 
         <hr>
-        <!--DEPENDENCY-->
-        Kingfisher: A lightweight, pure-Swift library for downloading and caching images from the web.<br>
-        <a href="https://github.com/onevcat/Kingfisher">https://github.com/onevcat/Kingfisher</a><br>
-        <br>
-        <details>
-        <summary>
-        The MIT License (MIT)<br>
-        <br>
-        Copyright (c) 2019 Wei Wang<br>
-        <br>
-        </summary>
-        Permission is hereby granted, free of charge, to any person obtaining a copy
-        of this software and associated documentation files (the "Software"), to deal
-        in the Software without restriction, including without limitation the rights
-        to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-        copies of the Software, and to permit persons to whom the Software is
-        furnished to do so, subject to the following conditions:<br>
-        <br>
-        The above copyright notice and this permission notice shall be included in all
-        copies or substantial portions of the Software.<br>
-        <br>
-        THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-        IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-        FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-        AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-        LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-        OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-        SOFTWARE.<br>
-        <br>
-        </details>
-
-        <hr>
         FLAnimatedImage: Performant animated GIF engine for iOS<br>
         <a href="https://github.com/Flipboard/FLAnimatedImage">https://github.com/Flipboard/FLAnimatedImage</a><br>
         <br>


### PR DESCRIPTION
- Generate thumbnails for image attachments, including for SVGs
- Use the image thumbnails in the ChatView. This should make the loading of images much faster. I also used HEIC or JPEG instead of PNG for the thumbnails, to make the size smaller and reduce the loading times even more.
- Use the generated thumbnails of videos and images in the media gallery. This has a noticeable improvement on the loading time, and also fixes some pre-existing issues (like thumbnails for videos and for SVGs which previously didn't work)

A few notes:
- ExyteChat doesn't already have support displaying SVGs, so we don't have to use their SVG library (the original argument for using it being that it's already in our dependency tree.)
We may want to consider this as the Exyte library has poor SVG support. In fact doesn't even render the recently added Monal SVG logos correctly.
- GIFs (and other animated image formats like WebP I presume) are displayed as still images.
The removed Giphy library isn't useful in this context, as I'd imagine it works by just sending an image link from one phone to another, and the receiving end would download the image from the Giphy server. i.e. it wouldn't handle animated images sent from a non-giphy client like Gajim.
Therefore, if we want to display animated images as animated we'll have to patch our exyteChat fork and add another library. Note that FLAnimatedImage (used in the old chatView for GIF displaying) doesn't support WebP.
(Animated image support is out of scope of this PR, as it needs to be done in the exytechat fork anyway. I just wanted to discuss it.)