### PR TITLE
Fix voice note playback asset creation fallback

### DIFF
--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1151,13 +1151,9 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         return completion(nil);
     }
     
-    //create the AVURLAsset and invoke the callback using it
-    completion([AVURLAsset URLAssetWithURL:fileUrl options:@{}]);
-    
-    //remove file afterwards and just log errors if removal of symlink fails
-    [[NSFileManager defaultManager] removeItemAtURL:symlinkUrl error:&error];
-    if(error != nil)
-        DDLogError(@"Could not clean up symlink file '%@' pointing to '%@': %@", symlinkUrl, fileUrl, error);
+    //create the AVURLAsset and invoke the callback using the symlink URL carrying the desired extension.
+    //Do not delete the symlink here: AVAsset loading is often asynchronous and may still need it afterwards.
+    completion([AVURLAsset URLAssetWithURL:symlinkUrl options:@{}]);
 }
 
 +(AnyPromise*) computeMediaDurationFromFile:(NSString*) file havingMimeType:(NSString*) mimeType andFileExtension:(NSString* _Nullable) fileExtension

--- a/Monal/Classes/MLFileTransferVideoCell.m
+++ b/Monal/Classes/MLFileTransferVideoCell.m
@@ -65,7 +65,8 @@ AVPlayer *avplayer;
     
     __block AVURLAsset* videoAsset = nil;
     //the completion is calles synchronously
-    [HelperTools createAVURLAssetFromFile:fileUrlStr havingMimeType:mimeType andFileExtension:nil withCompletionHandler:^(AVURLAsset* asset) {
+    NSString* fileExtension = [fileName pathExtension];
+    [HelperTools createAVURLAssetFromFile:fileUrlStr havingMimeType:mimeType andFileExtension:(fileExtension.length > 0 ? fileExtension : nil) withCompletionHandler:^(AVURLAsset* asset) {
         videoAsset = asset;
     }];
     if(videoAsset == nil)


### PR DESCRIPTION
### ✅ Description

## Summary
Fix voice-note/file-transfer playback issues in the legacy chat media cell path by correcting AVURLAsset creation for iOS < 17.

## Changes
- `HelperTools.createAVURLAssetFromFile(...)`
  - Use the generated symlink URL (with extension) when creating AVURLAsset in the fallback path.
  - Do not delete the symlink immediately, because AVAsset loading is asynchronous.
- `MLFileTransferVideoCell.avplayerConfigWithUrlStr(...)`
  - Pass `fileName.pathExtension` into AVURLAsset helper instead of always `nil`.

## Why
Playback preview bubbles were rendered, but tap-to-play could fail when MIME/extension hints were not effectively applied to AVAsset creation.

## Scope
- Legacy UIKit file-transfer audio/video preview path (`chatViewController` -> `MLFileTransferVideoCell`).
- No behavior change for iOS 17+ path using `AVURLAssetOverrideMIMETypeKey`.

## Testing
- Not run in this environment (no app runtime/device available).


Fixes # (issue)

### 🧪 Type of Change

Please delete options that are not relevant.

- [ x] Bug fix
- [ ] New feature
- [ ] Refactoring
- [ ] Documentation update
- [ ] Other (please describe):

---

### 📸 Visual Demonstration

Please attach a short **screencast or image** showing the new feature or UI change in action. This helps reviewers quickly understand your update.

> **Note**: You can drag and drop images or screencast video files directly below.

**Screenshot / Screencast**:

<!-- Upload or paste your media here -->

---

### 🤖 AI Usage Disclosure (Required)

To maintain code authenticity and ensure quality:

> ❗ Please confirm that **no AI-generated code or content** was used in this pull request.
-> This was done by Codex exclusively. If needed I can verify on Testdrive. Please take this as a pointer to what might be the issue, not as the fix in itself. (Although who knows, if it's correct, it might be good)

- [ ] I confirm that **no AI-generated code or content** was used in creating this PR.

(If any part was AI-assisted, please clearly describe which parts and provide rationale.)

---

### 📄 Checklist

- [ ] I have **tested my code** locally
- [ ] I have attached visuals of the new feature (if applicable)
- [ ] I have confirmed no AI-generated content is used (or disclosed it clearly)
- [ ] My code follows the [style and contribution guidelines](https://github.com/monal-im/Monal/wiki/coding-style) of this project
- [ x] I have added necessary documentation or comments

---

Thank you for your contribution!
 
