### PR TITLE
Avoid message duplication when getting MAM backscrolling results for 1-1 chats

### DIFF
--- a/Monal/Classes/ChannelMemberList.swift
+++ b/Monal/Classes/ChannelMemberList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2024 monal-im.org. All rights reserved.
 //
 
-import OrderedCollections
-
 struct ChannelMemberList: View {
     private let account: xmpp
     @State private var ownAffiliation: String;

--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -351,7 +351,10 @@ struct ChatView: View {
                     }
                 } else {
                     DDLogVerbose("Got backscrolling mam response: \(returnedMessages.count) messages: \(String(describing:returnedMessages))")
-                    self.messages.insert(contentsOf: returnedMessages.map {ChatViewMessage($0)}, at: 0)
+                    // When backscrolling in 1-1 chats, the oldest stanzaId may not correspond to the earliest
+                    // message we have, because messages we send don't have a stanzaId => There's a risk of
+                    // getting duplicate messages in the messages array => we need to deduplicate.
+                    self.messages = OrderedSet(returnedMessages.map {ChatViewMessage($0)} + self.messages).elements
                 }
             }
             .catch { error in

--- a/Monal/Classes/ContactPicker.swift
+++ b/Monal/Classes/ContactPicker.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 monal-im.org. All rights reserved.
 //
 
-import OrderedCollections
-
 struct ContactPickerEntry: View {
     let contact : ObservableKVOWrapper<MLContact>
     let isPicked: Bool

--- a/Monal/Classes/ContactResources.swift
+++ b/Monal/Classes/ContactResources.swift
@@ -5,7 +5,6 @@
 //  Created by Friedrich Altheide on 24.12.21.
 //  Copyright © 2021 Monal.im. All rights reserved.
 //
-import OrderedCollections
 
 @ViewBuilder
 func resourceRowElement(_ k: String, _ v: some View, space: CGFloat = 5) -> some View {

--- a/Monal/Classes/CreateGroupMenu.swift
+++ b/Monal/Classes/CreateGroupMenu.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 monal-im.org. All rights reserved.
 //
 
-import OrderedCollections
-
 struct CreateGroupMenu: View {
     private var appDelegate: MonalAppDelegate
     private var delegate: SheetDismisserProtocol

--- a/Monal/Classes/MemberList.swift
+++ b/Monal/Classes/MemberList.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Monal.im. All rights reserved.
 //
 
-import OrderedCollections
-
 struct ActionSheetPrompt {
     var title: Text = Text("")
     var message: Text = Text("")

--- a/Monal/Classes/NotificationDebugging.swift
+++ b/Monal/Classes/NotificationDebugging.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Monal.im. All rights reserved.
 //
 
-import OrderedCollections
-
 class NotificationDebuggingDefaultsDB: ObservableObject {
     @defaultsDB("lastAppexStart")
     var lastAppexStart: Date?

--- a/Monal/Classes/OmemoKeysView.swift
+++ b/Monal/Classes/OmemoKeysView.swift
@@ -6,8 +6,6 @@
 //  Copyright © 2022 Monal.im. All rights reserved.
 //
 
-import OrderedCollections
-
 struct OmemoKeysEntryView: View {
     private let contactJid: String
     

--- a/Monal/Classes/SwiftHelpers.swift
+++ b/Monal/Classes/SwiftHelpers.swift
@@ -11,6 +11,7 @@
 @_exported import CocoaLumberjackSwift
 @_exported import Logging
 @_exported import PromiseKit
+@_exported import OrderedCollections
 import CocoaLumberjackSwiftLogBackend
 import LibMonalRustSwiftBridge
 import Combine

--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -16,7 +16,6 @@
 @_exported import Combine
 import PhotosUI
 import FLAnimatedImage
-import OrderedCollections
 import CropViewController
 import SafariServices
 import WebKit


### PR DESCRIPTION
This fixes the following fatalError: `Messages can not have duplicate ids, please make sure every message gets a unique id`

Duplicate ids can happen when backscrolling in a 1-1 chat because the oldestStanzaId doesn't necessarily correspond to the earliest message we have. This is because messages we send don't have a stanzaId.
This means the results of backscrolling in a 1-1 chat risk having messages that are already displayed in the ChatView, which triggers the crash.
=> we need to deduplicate the results in the case of 1-1 chats.

###### Note:
Rather than storing the messages in an OrderedSet, I kept them in an array, and used the OrderedSet only for deduplication.
I didn't benchmark, but doing this should be a little bit faster than storing in an OrderedSet, especially as the user loads more messages in the ChatView.