### PR TITLE
Improve message type detection

### DIFF
--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -680,8 +680,8 @@ static NSMutableDictionary* _typingNotifications;
         NSString* lowercaseBody = [body lowercaseString];
         if(body && [body isEqualToString:[messageNode findFirst:@"{jabber:x:oob}x/url#"]] && [lowercaseBody hasPrefix:@"https://"])
             messageType = kMessageTypeFiletransfer;
-        //messages without spaces are potentially special ones
-        else if([body rangeOfString:@" "].location == NSNotFound)
+        //messages without whitespace are potentially special ones
+        else if([body rangeOfCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].location == NSNotFound)
         {
             if([lowercaseBody hasPrefix:@"geo:"])
                 messageType = kMessageTypeGeo;

--- a/Monal/Classes/chatViewController.m
+++ b/Monal/Classes/chatViewController.m
@@ -1215,7 +1215,7 @@ enum msgSentState {
         {
             // Send trimmed message
             NSString* lowercaseCleanString = [cleanString lowercaseString];
-            if([lowercaseCleanString rangeOfString:@" "].location == NSNotFound && [lowercaseCleanString hasPrefix:@"https://"])
+            if([lowercaseCleanString rangeOfCharacterFromSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]].location == NSNotFound && [lowercaseCleanString hasPrefix:@"https://"])
                 [self sendMessage:cleanString withType:kMessageTypeUrl];
             else
                 [self sendMessage:cleanString withType:kMessageTypeText];


### PR DESCRIPTION
Special messages must not include any whitespace character.

This prevents messages containing multiple links separated by newlines from having a type of kMessageTypeUrl, which resulted in the hiding of the message and the displaying of a URL preview for only the first link while using the UIKit chat view.
