### PR TITLE
Fix the truncation of long contact names in the toolbar

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -670,6 +670,9 @@ struct ChatView: View {
                                 }
                             }
                         }
+                        // When used in the toolbar, the default button style doesn't have any size constraints.
+                        // => use a different button style to ensure the truncation of long contact names.
+                        .buttonStyle(.borderless)
                         Spacer()
                     }
                 }


### PR DESCRIPTION
Before vs after with large font size set in accessibility settings:

<img width="200" height="432" alt="Before" src="https://github.com/user-attachments/assets/47a41480-6da3-4b5a-af5e-6dc2ba087ff8" />
<img width="200" height="432" alt="After" src="https://github.com/user-attachments/assets/a63d35a8-e9ca-4674-9d8d-0fbf56f85310" />

(the default style and the borderless style have the same color while the button is being clicked)