### PR TITLE
Account settings: Allow all languages in the Display Name field

### DIFF
--- a/Monal/Classes/XMPPEdit.m
+++ b/Monal/Classes/XMPPEdit.m
@@ -632,7 +632,6 @@ enum DummySettingsRows {
             case SettingsDisplayNameRow: {
                 [thecell initCell:NSLocalizedString(@"Display Name", @"") withTextField:self.rosterName andPlaceholder:@"" andTag:1];
                 thecell.cellLabel.text = NSLocalizedString(@"Display Name", @"");
-                thecell.textInputField.keyboardType = UIKeyboardTypeAlphabet;
                 break;
             }
             case SettingsStatusMessageRow: {


### PR DESCRIPTION
`UIKeyboardTypeAlphabet` restricts the virtual keyboard to languages that use the Latin script.

Fixes #1628
