### PR TITLE
Add support for downloading, opening and uploading files in the new ChatView

### DIFF
--- a/Monal/Classes/ChatView.swift
+++ b/Monal/Classes/ChatView.swift
@@ -410,7 +410,7 @@ struct ChatView: View {
 
     var body: some View {
         ExyteChatView(messages: messages, chatType: .conversation, replyMode: .quote) { draft in
-            if !draft.medias.isEmpty || draft.recording != nil {
+            if !draft.medias.isEmpty || draft.recording != nil || !draft.files.isEmpty {
                 Task {
                     if draft.recording != nil {
                         await uploadAndSendFile(draft.recording!.url)
@@ -418,6 +418,9 @@ struct ChatView: View {
                     for media in draft.medias {
                         let localFileURL = await media.getURL()
                         await uploadAndSendFile(localFileURL)
+                    }
+                    for file in draft.files {
+                        await uploadAndSendFile(file.localURL)
                     }
                 }
             }
@@ -565,6 +568,12 @@ struct ChatView: View {
         })
         .showUsername(contact.isMuc)
         .linkPreviewsEnabled(false) //disabled for now due to https://github.com/exyte/Chat/issues/208
+        .checkFileSizeClosure { file in
+            MLFiletransfer.checkMimeTypeAndSize(forHistoryID: Int(file.id)! as NSNumber)
+        }
+        .downloadFileClosure { file in
+            MLFiletransfer.downloadFile(forHistoryID: Int(file.id)! as NSNumber)
+        }
         .enableLoadMore(offset: 10) {
             loadHistory()
         }
@@ -885,32 +894,8 @@ class ChatViewMessage: ExyteChat.Message {
     let fileInfo: ObservableKVOWrapper<MLFiletransferInfo>?
     private var subscriptions: Set<AnyCancellable> = Set()
     var text: String {
-        if innerMessage.messageType == kMessageTypeFiletransfer, let fileInfo = fileInfo {
-            switch(fileInfo.downloadState as DownloadState.RawValue) {
-                case DownloadState.complete.rawValue:
-                    let mimeType = fileInfo.mimeType as String
-                    if mimeType.starts(with: "audio/") || mimeType.starts(with: "image/") || mimeType.starts(with: "video/") {
-                        return ""
-                    } else {
-                        return """
-                            [File transfer with a file type that's not yet supported for displaying]
-                            \(innerMessage.obj.encrypted ? "" : "Link: \(innerMessage.messageText as String)")
-                        """
-                    }
-                case DownloadState.headers.rawValue:
-                    let humanReadableSize = (fileInfo.size as NSNumber).int64Value.formatted(.byteCount(style: .file))
-                    return """
-                    [File transfer; auto-downloading if the settings allow it...]
-                    Size: \(humanReadableSize)
-                    MimeType: \(fileInfo.mimeType as String)
-                    \(innerMessage.encrypted ? "" : "Link: \(fileInfo.downloadURL as String)")
-                    """
-                case DownloadState.none.rawValue:
-                    return "[File transfer; checking the size...]"
-                default:
-                    // .invalid case
-                    unreachable()
-            }
+        if innerMessage.messageType == kMessageTypeFiletransfer && fileInfo != nil {
+            return ""
         }
         return innerMessage.retracted ? NSLocalizedString("This message got retracted", comment: "") : innerMessage.messageText
     }
@@ -935,7 +920,7 @@ class ChatViewMessage: ExyteChat.Message {
             let isError = errorType != nil && !errorType!.isEmpty
             switch(innerMessage) {
                 case let message where isError && !message.hasBeenReceived:
-                    return .error(DraftMessage(id: id, text: text, medias: [], recording: recording, replyMessage: replyMessage, createdAt: createdAt))
+                    return .error(DraftMessage(id: id, text: text, medias: [], files: [], recording: recording, replyMessage: replyMessage, createdAt: createdAt))
                 case let message where message.hasBeenDisplayed:
                     return .read
                 case let message where message.hasBeenReceived:
@@ -973,48 +958,66 @@ class ChatViewMessage: ExyteChat.Message {
         }
         set {}
     }
-    override var attachments: [Attachment] {
+    override var files: [File] {
         get {
             guard innerMessage.messageType == kMessageTypeFiletransfer, let fileInfo = fileInfo else {
                 return []
             }
 
-            guard (fileInfo.downloadState as DownloadState.RawValue) == DownloadState.complete.rawValue else {
-                // TODO: show a proper button for mime type checks instead of doing this automatically
-                MLFiletransfer.checkMimeTypeAndSize(forHistoryID: innerMessage.messageDBId)
+            let downloadState = fileInfo.downloadState as DownloadState.RawValue
+            let fileID = innerMessage.obj.messageDBId.stringValue
+            let isBeingDownloaded = MLFiletransfer.isFileForHistoryId(inTransfer: innerMessage.messageDBId)
+            if downloadState == DownloadState.none.rawValue {
+                let file = File(id: fileID, localURL: nil, name: fileInfo.filename, downloadState: .none, isBeingDownloaded: isBeingDownloaded)
+                return [file]
+            } else if downloadState == DownloadState.headers.rawValue {
+                let file = File(id: fileID, localURL: nil, name: fileInfo.filename, downloadState: .headers,  isBeingDownloaded: isBeingDownloaded, mimeType: fileInfo.mimeType, size: (fileInfo.size as NSNumber).intValue)
+                return [file]
+            } else {
+                if fileInfo.isImage || fileInfo.isVideo || fileInfo.isAudio {
+                    // In these cases the file is included in the `attachments` or `recording` properties
+                    return []
+                }
+                let file = File(id: fileID, localURL: fileInfo.fileURL, name: fileInfo.filename, downloadState: .complete, mimeType: fileInfo.mimeType, size: (fileInfo.size as NSNumber).intValue)
+                return [file]
+            }
+        }
+        set {}
+    }
+
+    override var attachments: [Attachment] {
+        get {
+            guard innerMessage.messageType == kMessageTypeFiletransfer,
+                let fileInfo = fileInfo,
+                (fileInfo.downloadState as DownloadState.RawValue) == DownloadState.complete.rawValue,
+                fileInfo.isImage || fileInfo.isVideo else {
+                // images and videos with .none and .headers download state are included in the `files` property
                 return []
             }
-            let fileURL = fileInfo.fileURL as URL
-            let cacheId = fileInfo.cacheId as String
-            let attachmentUUID = HelperTools.stringToUUID(cacheId).uuidString
-            switch fileInfo.mimeType as String {
-                case let mimeType where mimeType.starts(with: "image/"):
-                    let attachment = Attachment(id: attachmentUUID, url: fileURL, type: .image)
-                    return [attachment]
-                case let mimeType where mimeType.starts(with: "video/"):
-                    let thumbnail = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
-                    let attachment = Attachment(id: attachmentUUID, thumbnail: thumbnail, full: fileURL, type: .video, mimeType: mimeType)
-                    return [attachment]
-                default:
-                    return []
+
+            let attachmentID = innerMessage.obj.messageDBId.stringValue
+            if fileInfo.isImage {
+                let attachment = Attachment(id: attachmentID, url: fileInfo.fileURL, type: .image, mimeType: fileInfo.mimeType)
+                return [attachment]
+            } else {
+                let thumbnail = fileInfo.thumbnailURL as URL? ?? URL(string: "about:blank")!
+                let attachment = Attachment(id: attachmentID, thumbnail: thumbnail, full: fileInfo.fileURL, type: .video, mimeType: fileInfo.mimeType)
+                return [attachment]
             }
         }
         set {}
     }
     override var recording: Recording? {
         get {
-            guard innerMessage.messageType == kMessageTypeFiletransfer, let fileInfo = fileInfo else {
+            guard innerMessage.messageType == kMessageTypeFiletransfer,
+                let fileInfo = fileInfo,
+                (fileInfo.downloadState as DownloadState.RawValue) == DownloadState.complete.rawValue,
+                fileInfo.isAudio else {
+                // audio files with .none and .headers download state are included in the `files` property
                 return nil
             }
 
-            guard (fileInfo.downloadState as DownloadState.RawValue) == DownloadState.complete.rawValue else {
-                return nil
-            }
-            guard (fileInfo.mimeType as String).starts(with: "audio/") else {
-                return nil
-            }
-            let fileURL = fileInfo.fileURL as URL
-            return Recording(duration: fileInfo.mediaDuration, url: fileURL, mimeType: fileInfo.mimeType)
+            return Recording(duration: fileInfo.mediaDuration, url: fileInfo.fileURL, mimeType: fileInfo.mimeType)
         }
         set {}
     }

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -4831,7 +4831,7 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/monal-im/ExyteChat";
 			requirement = {
-				branch = main;
+				branch = files;
 				kind = branch;
 			};
 		};

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -23,8 +23,8 @@
         "package": "Chat",
         "repositoryURL": "https://github.com/monal-im/ExyteChat",
         "state": {
-          "branch": "main",
-          "revision": "babacaf8bc09c02cfbf74872f49f5dc8d6d14f80",
+          "branch": "files",
+          "revision": "efa9aa749510b1cdbf17320c23b448715abd6c74",
           "version": null
         }
       },


### PR DESCRIPTION
Depends on https://github.com/monal-im/ExyteChat/pull/2

It adds a "Check File Size" button for `.none` downloadState, a "Download File" button for `.headers` downloadState, and a "Open File" button for `.complete` download state (but only for files that can't be displayed inline)

**A few implementation notes:**
- When opening files, the Apple framework relies on the file extension to determine the file type. Since our cached files have a hash as file extension, this unfortunately means that we have to make a temporary copy of a file when opening it.
The old chatView also does this same workaround: https://github.com/monal-im/Monal/blob/8cc133bd2a337818bdb99975fac40244eb2db81f/Monal/Classes/MLFileTransferFileViewController.m#L70-L71
- When a file is in `.none` and `.headers` downloadState, I want to show an icon representing the file. The QuickLookThumbnailing framework allows us to do so. But it requires a file URL. And since the file type detection happens entirely using the file extension (see the previous point), I decided to create empty files having the real file extension.
(I also do the same for .complete files that can't be displayed inline. We could generate a proper thumbnail for those. But except for the case of PDFs, the icon looks better than a thumbnail)

**Note**: Since I'm displaying an icon representing the file before even doing a mimeType check, we may want to update MLContactCell of Active Chats so it wouldn't display a generic "📁 A File" when the file extension is that of an image, video or audio.

**Potential improvements: (in the ExyteChat fork)**
- Maybe consider making the message bubbles that display files wider. Currently I use the same width as messages that contain a single image / video. The width can be changed from here: https://github.com/monal-im/ExyteChat/blob/10038d8b3239a1c1c4cc3a61527694e63de568cd/Sources/ExyteChat/Views/MessageView/MessageView.swift#L369-L372
- Maybe consider changing the way the checking / downloading `ProgressView()` is displayed in the FileView: by using an `if` instead of changing the opacity, the button would be perfectly centered by default, and would slide to the left to leave space for the ProgressView() when that's to be displayed. (currently there's reserved space for the progress view, so the "Check File Size" / "Download File" button is not perfectly centered)
- When improving the accessibility, we can create a UTType from the file extension or mimeType, and use the localized description for voice over: [UTType.localizedDescription](https://developer.apple.com/documentation/uniformtypeidentifiers/uttype-swift.struct/localizeddescription)

