### PR TITLE
Fix a regression

### DIFF
--- a/Monal/Classes/SwiftuiHelpers.swift
+++ b/Monal/Classes/SwiftuiHelpers.swift
@@ -784,10 +784,23 @@ public extension UIViewController {
 // Interfaces between ObjectiveC/Storyboards and SwiftUI
 @objc
 class SwiftuiInterface : NSObject {
+    let activeChats = (UIApplication.shared.delegate as! MonalAppDelegate).activeChats!
+
     @objc
     func makeChatView(for contact: MLContact) -> UIViewController {
         let host = UIHostingController(rootView:AnyView(EmptyView()))
-        host.rootView = AnyView(UIKitWorkaround(ChatView(contact:ObservableKVOWrapper<MLContact>(contact))))
+        let isCompact = UIUserInterfaceSizeClass(rawValue: activeChats.sizeClass.horizontal.rawValue) == .compact
+        @ViewBuilder
+        var chatView: some View {
+            if isCompact {
+                ChatView(contact:ObservableKVOWrapper<MLContact>(contact))
+            } else {
+                NavigationStack {
+                    ChatView(contact:ObservableKVOWrapper<MLContact>(contact))
+                }
+            }
+        }
+        host.rootView = AnyView(chatView)
         // Clip to bounds to avoid the overflowing of the chat background during the chat opening animation
         // (due to the use of .scaledToFill() on the background image)
         host.view.clipsToBounds = true;


### PR DESCRIPTION
A recent commit of mine introduced a regression causing the toolbar of the chatview on macOS to no longer be displayed.

Revert that commit, and simplify things a bit by removing the @StateObject, as we can't have a @StateObject in a class.

Tested on big iPhone, on iPad and mac.
 
