### PR TITLE
Bump SwiftPM dependencies

### DIFF
--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -24,7 +24,7 @@
         "repositoryURL": "https://github.com/monal-im/ExyteChat",
         "state": {
           "branch": "main",
-          "revision": "2e59c4ce424e32fba5e3dac68727469df455cb80",
+          "revision": "6f732ebd0c128267f0c5d88b8ff60373cf24f436",
           "version": null
         }
       },


### PR DESCRIPTION
https://github.com/monal-im/Monal/pull/1642 and https://github.com/monal-im/Monal/pull/1647 didn't fix the regression, so I'm reverting the third suspected commit.

Also, I added commit https://github.com/monal-im/ExyteChat/commit/6f732ebd0c128267f0c5d88b8ff60373cf24f436 which fixes the poor performance when typing while in low-power mode. (I profiled monal alpha and found that while typing, 56% of CPU time on the main thread was computing `message.attributedText` during `MessageRow` comparisons. So I removed `message.attributedText` from the `MessageRow` equality check)

The proper solution would be to persist `attributedText` in the db and make it an `MLMessage` property, so we don't have to make the (expensive) computation each time `ChatViewMessage.attributedText` is accessed.
We will have to do that anyway if / when we implement XEP-0394: Message Markup.