### PR TITLE
Use Double instead of Integer for idle time

### DIFF
--- a/Monal/Classes/DataLayer.m
+++ b/Monal/Classes/DataLayer.m
@@ -2422,9 +2422,9 @@ static NSDateFormatter* dbFormatter;
         {
             if(globalIdle == nil)
                 return (NSDate*)nil;
-            return [NSDate dateWithTimeIntervalSince1970:[globalIdle integerValue]];
+            return [NSDate dateWithTimeIntervalSince1970:[globalIdle doubleValue]];
         }
-        return [NSDate dateWithTimeIntervalSince1970:[idle integerValue]];
+        return [NSDate dateWithTimeIntervalSince1970:[idle doubleValue]];
     }];
 }
 
@@ -2438,7 +2438,7 @@ static NSDateFormatter* dbFormatter;
         DDLogDebug(@"LastInteraction of %@/%@ lastInteraction=%@", jid, resource, lastInteraction);
         if(lastInteraction == nil)
             return (NSDate*)nil;
-        return [NSDate dateWithTimeIntervalSince1970:[lastInteraction integerValue]];
+        return [NSDate dateWithTimeIntervalSince1970:[lastInteraction doubleValue]];
     }];
 }
 


### PR DESCRIPTION
Another small `CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION` compile-error fix.

In this case, `dateWithTimeIntervalSince1970` accepts an `NSTimeInterval` - a `Double`, while we pass an `Integer` courtesy of `integerValue`. So, it gets implicitly casted. Since these variables are `NSNumber`s, it can easily be fixed by asking for `doubleValue` instead of `integerValue`.

I tested this with two Monal instances, watching for a `kMonalLastInteractionUpdatedNotice`. All sends of these that contain a `lastInteraction` field go via these functions. When I put one Monal instance to the background, I saw this notification on the other instance:

```
Queueing notification: kMonalLastInteractionUpdatedNotice, object = 1[4123173c]: user2@..., userInfo = {
    accountID = 1;
    isTyping = 0;
    jid = "user1@...";
    lastInteraction = "2026-08-10 22:29:59 +0000";
    resource = "Monal-iOS~...";
}
```

Where `lastInteraction` matched the time it went to the background.