### PR TITLE
Delete unused bytesToHuman

### DIFF
--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -135,7 +135,6 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSData*) resizeAvatarImage:(UIImage* _Nullable) image withCircularMask:(BOOL) circularMask toMaxBase64Size:(unsigned long) length;
 +(double) report_memory;
 +(UIColor*) generateColorFromJid:(NSString*) jid;
-+(NSString*) bytesToHuman:(int64_t) bytes;
 +(NSString*) stringFromToken:(NSData*) tokenIn;
 +(NSString* _Nullable) exportIPCDatabase;
 +(void) configureFileProtection:(NSString*) protectionLevel forFile:(NSString*) file;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1787,24 +1787,6 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     return cache[jid] = [UIColor colorWithRed:r green:g blue:b alpha:1];
 }
 
-+(NSString*) bytesToHuman:(int64_t) bytes
-{
-    NSArray* suffixes = @[@"B", @"KiB", @"MiB", @"GiB", @"TiB", @"PiB", @"EiB"];
-    NSString* prefix = @"";
-    double size = bytes;
-    if(size < 0)
-    {
-        prefix = @"-";
-        size *= -1;
-    }
-    for(NSString* suffix in suffixes)
-        if(size < 1024)
-            return [NSString stringWithFormat:@"%@%.1F %@", prefix, size, suffix];
-        else
-            size /= 1024.0;
-    return [NSString stringWithFormat:@"%lld B", bytes];
-}
-
 +(NSString*) stringFromToken:(NSData*) tokenIn
 {
     unsigned char* tokenBytes = (unsigned char*)[tokenIn bytes];


### PR DESCRIPTION
This was added in 7f96bbba7c69560f7808b92c2b4c44364b9c5663 to print user-friendly file sizes in the logs. It only ever had one caller, which was removed in 3081ada7c617341902609fe303ed8e58d522226e.

As well as being dead code, I want to delete this to remove the suspicious implicit cast when converting bytes from `int64_t` to `double`.