### PR TITLE
Use ByteCountFormatter instead of bytes(toHuman:)

### DIFF
--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -135,7 +135,6 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSData*) resizeAvatarImage:(UIImage* _Nullable) image withCircularMask:(BOOL) circularMask toMaxBase64Size:(unsigned long) length;
 +(double) report_memory;
 +(UIColor*) generateColorFromJid:(NSString*) jid;
-+(NSString*) bytesToHuman:(int64_t) bytes;
 +(NSString*) stringFromToken:(NSData*) tokenIn;
 +(NSString* _Nullable) exportIPCDatabase;
 +(void) configureFileProtection:(NSString*) protectionLevel forFile:(NSString*) file;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -1787,24 +1787,6 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     return cache[jid] = [UIColor colorWithRed:r green:g blue:b alpha:1];
 }
 
-+(NSString*) bytesToHuman:(int64_t) bytes
-{
-    NSArray* suffixes = @[@"B", @"KiB", @"MiB", @"GiB", @"TiB", @"PiB", @"EiB"];
-    NSString* prefix = @"";
-    double size = bytes;
-    if(size < 0)
-    {
-        prefix = @"-";
-        size *= -1;
-    }
-    for(NSString* suffix in suffixes)
-        if(size < 1024)
-            return [NSString stringWithFormat:@"%@%.1F %@", prefix, size, suffix];
-        else
-            size /= 1024.0;
-    return [NSString stringWithFormat:@"%lld B", bytes];
-}
-
 +(NSString*) stringFromToken:(NSData*) tokenIn
 {
     unsigned char* tokenBytes = (unsigned char*)[tokenIn bytes];

--- a/Monal/Classes/ServerDetails.swift
+++ b/Monal/Classes/ServerDetails.swift
@@ -112,7 +112,7 @@ struct ServerDetails: View {
     }
 
     private func getXEPEntryData(connection: MLXMPPConnection) -> [EntryData] {
-        let maxFileUploadSize = HelperTools.bytes(toHuman: Int64(connection.uploadSize))
+        let maxFileUploadSize = connection.uploadSize.formatted(.byteCount(style: .file))
         let isUsingFast = (connection.fastMethods as? [String: Bool] ?? [:]).values.reduce(false, { $0 || $1 })
         let result: [EntryData] = [
             EntryData(


### PR DESCRIPTION
`bytes(toHuman:)` converted the max file upload size in bytes to user-readable strings in KiB, MiB etc. This included an implicit conversion from `int64_t` to `double`, which triggered a `CLANG_WARN_SUSPICIOUS_IMPLICIT_CONVERSION`.

Apple provide a `ByteCountFormatter` which provides the same purpose and allows us to remove this custom code and the warning with it. This also gives us localisation of the quantities for free - for instance, in the `fr_FR` locale, 1 terabyte is displayed as `1To` instead of `1 TB`.

Choice of `ByteCountFormatStyle.Style.file`:

One of the configuration options this provides is whether to use units based on powers of 2 or 10.

There doesn't seem to be much consensus among XMPP providers which base to use for max file upload sizes. Of our one-click-registration providers, yax.im uses decimal (80 MB, a.k.a 76.3 MiB) while conversations.im uses binary (100 MiB, a.k.a 104.9 MB). Therefore, whatever we choose, some common providers will get unnatural-looking values.

Therefore, choose `ByteCountFormatStyle.Style.file`, since this use case is conceptually for file uploads, and let Apple decide whichever format it thinks makes most sense for this use case. This style should match any file sizes in Finder/the upload dialog, which should help avoid user confusion.

Here's how it looks with yax.im and conversations.im:

| conversations.im | yax.im |
|-----|-----|
| <img width="1206" height="2622" alt="conversations-file" src="https://github.com/user-attachments/assets/b08949aa-560e-414d-aab2-916527ec4ccf" /> | <img width="1206" height="2622" alt="yaxim-file" src="https://github.com/user-attachments/assets/41776849-144d-43cf-9240-3f77a4c21605" /> |
