### PR TITLE
Update the README

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -12,7 +12,7 @@ If you want to  use the latest stable versions, search for Monal in the iOS or O
 |--------|---------------------------------------------------------------|----------------------------------------------------------|---------------------------------------------------------------------------|
 | Stable | [App Store](https://apps.apple.com/app/id317711500)           | [App Store](https://apps.apple.com/app/id1499227291)     | brew install --cask monal                                                 |
 | Beta   | [Testflight](https://testflight.apple.com/join/lLLlgHpB)      | [Testflight](https://testflight.apple.com/join/tGH2m5vf) | brew install --cask monal@beta                                            |
-| Alpha  | upon request to [info@monal-im.org](mailto:info@monal-im.org)<br>Then download from our [alpha download site](https://downloads.monal-im.org/monal-im/alpha/) |                                                          | brew tap monal-im/homebrew-monal-alpha<br>brew install --cask monal-alpha |
+| Alpha  | upon request to [info@monal-im.org](mailto:info@monal-im.org)<br>Then download from our [alpha download site](https://downloads.monal-im.org/monal-im/alpha/) |                                                          | brew tap monal-im/homebrew-monal-alpha<br>brew trust --cask monal-im/monal-alpha/monal-alpha<br>brew install --cask monal-alpha |
 
 
 ## Support Chat (MUC) and Wiki


### PR DESCRIPTION
Update the instructions to install monal-alpha from homebrew (Homebrew versions 6.0.0 and newer require explicitly trusting third-party taps)

Companion PRs: https://github.com/monal-im/homebrew-monal-alpha/pull/1 and https://github.com/monal-im/monal-im.org/pull/98