### PR TITLE
Persist the "System Sound" notification sound setting properly

### DIFF
--- a/Monal/Classes/MLConstants.h
+++ b/Monal/Classes/MLConstants.h
@@ -213,6 +213,8 @@ static inline NSString* _Nonnull LocalizationNotNeeded(NSString* _Nonnull s)
 #define kMucActionShowProfile @"profile"
 #define kMucActionReinvite @"reinvite"
 
+#define kSystemSound @"SystemSound"
+
 // max count of char's in a single message (both: sending and receiving)
 #define kMonalChatMaxAllowedTextLen 2048
 

--- a/Monal/Classes/MLNotificationManager.m
+++ b/Monal/Classes/MLNotificationManager.m
@@ -493,7 +493,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if(sound && [[HelperTools defaultsDB] boolForKey:@"Sound"])
     {
         NSString* filename = [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"];
-        if(filename)
+        if(filename && ![filename isEqualToString:kSystemSound])
         {
             content.sound = [UNNotificationSound soundNamed:[NSString stringWithFormat:@"AlertSounds/%@.aif", filename]];
             DDLogDebug(@"Using user configured alert sound: %@", content.sound);
@@ -522,7 +522,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if([[HelperTools defaultsDB] boolForKey:@"Sound"])
     {
         NSString* filename = [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"];
-        if(filename)
+        if(filename && ![filename isEqualToString:kSystemSound])
         {
             content.sound = [UNNotificationSound soundNamed:[NSString stringWithFormat:@"AlertSounds/%@.aif", filename]];
             DDLogDebug(@"Using user configured alert sound: %@", content.sound);
@@ -617,7 +617,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if(sound && [[HelperTools defaultsDB] boolForKey:@"Sound"])
     {
         NSString* filename = [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"];
-        if(filename)
+        if(filename && ![filename isEqualToString:kSystemSound])
         {
             content.sound = [UNNotificationSound soundNamed:[NSString stringWithFormat:@"AlertSounds/%@.aif", filename]];
             DDLogDebug(@"Using user configured alert sound: %@", content.sound);
@@ -677,7 +677,7 @@ typedef NS_ENUM(NSUInteger, MLNotificationState) {
     if(sound && [[HelperTools defaultsDB] boolForKey:@"Sound"])
     {
         NSString* filename = [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"];
-        if(filename)
+        if(filename && ![filename isEqualToString:kSystemSound])
         {
             content.sound = [UNNotificationSound soundNamed:[NSString stringWithFormat:@"AlertSounds/%@.aif", filename]];
             DDLogDebug(@"Using user configured alert sound: %@", content.sound);

--- a/Monal/Classes/MLSoundsTableViewController.m
+++ b/Monal/Classes/MLSoundsTableViewController.m
@@ -91,9 +91,10 @@
         UITableViewCell* cell = [tableView dequeueReusableCellWithIdentifier:@"soundCell"];
         cell.textLabel.text = self.soundList[(NSUInteger)indexPath.row];
         NSString* filename = [NSString stringWithFormat:@"alert%ld", (long)indexPath.row];
+        NSString* selectedSoundFile = [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"];
         if(
-            (indexPath.row == 0 && [[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"] == nil) ||
-            [filename isEqualToString:[[HelperTools defaultsDB] objectForKey:@"AlertSoundFile"]]
+            (indexPath.row == 0 && [selectedSoundFile isEqualToString:kSystemSound]) ||
+            [selectedSoundFile isEqualToString:filename]
         )
         {
             cell.accessoryType = UITableViewCellAccessoryCheckmark;
@@ -130,7 +131,7 @@
         [[HelperTools defaultsDB] setObject:filename forKey:@"AlertSoundFile"];
     }
     else
-        [[HelperTools defaultsDB] removeObjectForKey:@"AlertSoundFile"];
+        [[HelperTools defaultsDB] setObject:kSystemSound forKey:@"AlertSoundFile"];
     NSIndexPath* old = [NSIndexPath indexPathForRow:self.selectedIndex inSection:1];
     self.selectedIndex = indexPath.row;
     NSArray* rows = @[old, indexPath];


### PR DESCRIPTION
The previous approach used nil to represent "System Sound"
However, since this setting is stored in defaultsDB, on next Monal startup it is given the default value (in `MLXMPPManager defaultSettings`)

Fixes #1691