### PR TITLE
Retrieve autodeleteInterval as a double

### DIFF
--- a/Monal/Classes/MLMessageProcessor.m
+++ b/Monal/Classes/MLMessageProcessor.m
@@ -132,7 +132,7 @@ static NSMutableDictionary* _typingNotifications;
     //(history backscrolling ones AND normal ones, both would otherwise disappear again immediately afterwards)
     //do this before handling the message stanza: only non-MLhistory pubsub messages and error-type stanzas should be processed
     //regardless of their age (but pubsub messages only if they aren't MLhistory ones)
-    NSInteger autodeleteInterval = [[HelperTools defaultsDB] integerForKey:@"AutodeleteInterval"];
+    double autodeleteInterval = [[HelperTools defaultsDB] doubleForKey:@"AutodeleteInterval"];
     if(autodeleteInterval > 0)
     {
         NSDate* pastDate = [NSDate dateWithTimeIntervalSinceNow:-autodeleteInterval];


### PR DESCRIPTION
Fix a suspicious implicit conversion: `autodeleteInterval` was retrieved into an `NSInteger`, but only used in `dateWithTimeIntervalSinceNow:`, which expects a `double`.

To test, I set the autodelete interval in the security settings to 30s, then 3 months, and printed `pastDate` both times. The values were as expected (30s before, 3 months before) both times.