### PR TITLE
Move SAMKeychain to SwiftPM

### DIFF
--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -98,6 +98,7 @@
 		3424B4EF2D232C14009F6503 /* HelperTools.h in Headers */ = {isa = PBXBuildFile; fileRef = C1AAC3E224B5EF4100BB15D6 /* HelperTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3434775E302FC074001FCAE3 /* ASN1Decoder in Frameworks */ = {isa = PBXBuildFile; productRef = 3434775D302FC074001FCAE3 /* ASN1Decoder */; };
 		344B50C03030B7B80022BD6A /* KSCrash in Frameworks */ = {isa = PBXBuildFile; productRef = 344B50BF3030B7B80022BD6A /* KSCrash */; };
+		34660BA63043057100FDA777 /* SAMKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 34660BA53043057100FDA777 /* SAMKeychain */; };
 		34745126302F641600F23210 /* NotificationBannerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 34745125302F641600F23210 /* NotificationBannerSwift */; };
 		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
 		34C9CAA430293B5E00A87694 /* HelperToolsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C9CAA330293B5E00A87694 /* HelperToolsTest.swift */; };
@@ -903,6 +904,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34660BA63043057100FDA777 /* SAMKeychain in Frameworks */,
 				34F978CF303B90CB002029CF /* CSQLite+MonalTraits in Frameworks */,
 				84F632F02F80AAF900A59209 /* SVGKit in Frameworks */,
 				84F632EB2F7F3EA300A59209 /* OrderedCollections in Frameworks */,
@@ -1763,6 +1765,7 @@
 				3434775D302FC074001FCAE3 /* ASN1Decoder */,
 				344B50BF3030B7B80022BD6A /* KSCrash */,
 				34F978CE303B90CB002029CF /* CSQLite+MonalTraits */,
+				34660BA53043057100FDA777 /* SAMKeychain */,
 			);
 			productName = monalxmpp;
 			productReference = 26CC579223A0867400ABB92A /* monalxmpp.framework */;
@@ -1925,6 +1928,7 @@
 				3434775C302FC074001FCAE3 /* XCRemoteSwiftPackageReference "ASN1Decoder" */,
 				344A829F3030C76B009AAC5D /* XCRemoteSwiftPackageReference "KSCrash" */,
 				34F978CD303B90CB002029CF /* XCRemoteSwiftPackageReference "sqlite3-package" */,
+				34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */,
 			);
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -4879,6 +4883,14 @@
 				minimumVersion = 1.17.7;
 			};
 		};
+		34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/meganz/SAMKeychain";
+			requirement = {
+				branch = master;
+				kind = branch;
+			};
+		};
 		34745124302F641600F23210 /* XCRemoteSwiftPackageReference "NotificationBanner" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/Daltron/NotificationBanner";
@@ -4975,6 +4987,11 @@
 		344B50BF3030B7B80022BD6A /* KSCrash */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = KSCrash;
+		};
+		34660BA53043057100FDA777 /* SAMKeychain */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */;
+			productName = SAMKeychain;
 		};
 		34745125302F641600F23210 /* NotificationBannerSwift */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -101,6 +101,15 @@
         }
       },
       {
+        "package": "SAMKeychain",
+        "repositoryURL": "https://github.com/meganz/SAMKeychain",
+        "state": {
+          "branch": "master",
+          "revision": "19f05f16b30eed2ed398df30353ec52844e329e5",
+          "version": null
+        }
+      },
+      {
         "package": "SnapKit",
         "repositoryURL": "https://github.com/SnapKit/SnapKit",
         "state": {

--- a/Monal/Podfile
+++ b/Monal/Podfile
@@ -25,7 +25,6 @@ def monalxmpp
   # Uncomment the next line if you're using Swift or would like to use dynamic frameworks
   use_frameworks!
   inhibit_all_warnings!
-  pod 'SAMKeychain'
   signalDeps
   pod "PromiseKit"
 end

--- a/Monal/Podfile.lock
+++ b/Monal/Podfile.lock
@@ -10,7 +10,6 @@ PODS:
     - PromiseKit/CorePromise
   - PromiseKit/UIKit (8.2.0):
     - PromiseKit/CorePromise
-  - SAMKeychain (1.5.3)
   - SDWebImage (5.21.3):
     - SDWebImage/Core (= 5.21.3)
   - SDWebImage/Core (5.21.3)
@@ -22,7 +21,6 @@ DEPENDENCIES:
   - DZNEmptyDataSet
   - MBProgressHUD (~> 1.2.0)
   - PromiseKit
-  - SAMKeychain
   - SDWebImage
   - SignalProtocolC (from `https://github.com/monal-im/libsignal-protocol-c`, branch `master`)
   - SignalProtocolObjC (from `https://github.com/monal-im/SignalProtocol-ObjC.git`, branch `master`)
@@ -32,7 +30,6 @@ SPEC REPOS:
     - DZNEmptyDataSet
     - MBProgressHUD
     - PromiseKit
-    - SAMKeychain
     - SDWebImage
 
 EXTERNAL SOURCES:
@@ -55,11 +52,10 @@ SPEC CHECKSUMS:
   DZNEmptyDataSet: 9525833b9e68ac21c30253e1d3d7076cc828eaa7
   MBProgressHUD: 3ee5efcc380f6a79a7cc9b363dd669c5e1ae7406
   PromiseKit: 74e6ab5894856b4762fef547055c809bca91d440
-  SAMKeychain: 483e1c9f32984d50ca961e26818a534283b4cd5c
   SDWebImage: 16309af6d214ba3f77a7c6f6fdda888cb313a50a
   SignalProtocolC: 8092866e45b663a6bc3e45a8d13bad2571dbf236
   SignalProtocolObjC: 1beb46b1d35733e7ab96a919f88bac20ec771c73
 
-PODFILE CHECKSUM: 1fcff053f140694a6b147950c102bb824103420a
+PODFILE CHECKSUM: ffd8a73cd97539ec1a0750ddd646b0eeba71a125
 
 COCOAPODS: 1.17.0


### PR DESCRIPTION
Mostly a drop-in replacement, except that SAMKeychain's error messages live in a bundle which isn't found by default even though the bundle is included in Package.swift.

So, switch to a fork that handled this.


https://github.com/user-attachments/assets/1183fba7-56af-4e20-b677-a2c2fa27a20a

Continues #1685
