### PR TITLE
Make remaining suspicious implicit casts explicit

### DIFF
--- a/Monal/Classes/MLDNSLookup.m
+++ b/Monal/Classes/MLDNSLookup.m
@@ -111,7 +111,7 @@ static NSMutableDictionary* _RRCache;
 
             struct timeval tv;
             tv.tv_sec  = (time_t)remainingTime;
-            tv.tv_usec = (int32_t)((remainingTime - tv.tv_sec) * 1000000);
+            tv.tv_usec = (int32_t)((remainingTime - (double)tv.tv_sec) * 1000000);
 
             int result = select(FD_SETSIZE, &set, NULL, NULL, &tv);
             DDLogVerbose(@"DNS select() returned %d", result);

--- a/Monal/Classes/snprintf.m
+++ b/Monal/Classes/snprintf.m
@@ -1243,7 +1243,7 @@ again:
 	 * We "cheat" by converting the fractional part to integer by
 	 * multiplying by a factor of ten.
 	 */
-	if ((fracpart = myround(mask * (ufvalue - intpart))) >= mask) {
+	if ((fracpart = myround((long double)mask * (ufvalue - (long double)intpart))) >= mask) {
 		/*
 		 * For example, ufvalue = 2.99962, intpart = 2, and mask = 1000
 		 * (because precision = 3).  Now, myround(1000 * 0.99962) will
@@ -1487,7 +1487,7 @@ cast(LDOUBLE value)
 	 * comparison (cf. C99: 6.3.1.4, 2).  It might then equal the LDOUBLE
 	 * value although converting the latter to UINTMAX_T would overflow.
 	 */
-	if (value >= UINTMAX_MAX)
+	if (value >= (long double)UINTMAX_MAX)
 		return UINTMAX_MAX;
 
 	result = value;
@@ -1496,7 +1496,7 @@ cast(LDOUBLE value)
 	 * an integer type converts e.g. 1.9 to 2 instead of 1 (which violates
 	 * the standard).  Sigh.
 	 */
-	return (result <= value) ? result : result - 1;
+	return ((long double)result <= value) ? result : result - 1;
 }
 
 static UINTMAX_T
@@ -1507,7 +1507,7 @@ myround(LDOUBLE value)
 	if (intpart == UINTMAX_MAX)
 		return UINTMAX_MAX;
 	
-	return ((value - intpart) < 0.5) ? intpart : intpart + 1;
+	return ((value - (long double)intpart) < 0.5) ? intpart : intpart + 1;
 }
 
 static LDOUBLE

--- a/Monal/Classes/xmpp.m
+++ b/Monal/Classes/xmpp.m
@@ -1424,7 +1424,7 @@ static NSRegularExpression* fastTokenRemovalRegex;
                 //use a much smaller limit while in appex because memory there is limited to ~32MiB
                 unsigned long operationCount = [self->_parseQueue operationCount];
                 double usedMemory = [HelperTools report_memory];
-                if(!(operationCount > 256 || (appex && usedMemory > (0.5*availableMemory) && operationCount > MAX(2, (0.75*availableMemory) - usedMemory))))
+                if(!(operationCount > 256 || (appex && usedMemory > (0.5*availableMemory) && (double)operationCount > MAX(2, (0.75*availableMemory) - usedMemory))))
                     break;
                 
                 double waittime = (double)[self->_parseQueue operationCount] / 256.0;
@@ -1607,7 +1607,7 @@ static NSRegularExpression* fastTokenRemovalRegex;
                 DDLogWarn(@"Ping already delayed, ignoring additional ping...");
             else
             {
-                NSUInteger delayBy = min((NSUInteger)timeout, [self->_parseQueue operationCount]);
+                double delayBy = min(timeout, (double)[self->_parseQueue operationCount]);
                 DDLogWarn(@"parseQueue overflow, delaying ping by 4 seconds.");
                 self->_pingDelayTimer = createTimer(delayBy, (^{
                     [self removeTimerToCancelOnDisconnect:self->_pingDelayTimer];


### PR DESCRIPTION
I ideally wanted to remove the need for these completely, but these are the more difficult remaining ones which I don't have a good solution to.

For instance, `(double)operationCount` to do calculations is a common pattern, and not a problem at the depths we see on the `parseQueue`. Converting through `NSNumber*` could remove the casts, but I'm not convinced that's actually any safer, and would lead to unnecessarily verbose code.