### PR TITLE
Bump WebRTC version

### DIFF
--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -186,7 +186,7 @@
         "repositoryURL": "https://github.com/Stasel/WebRTC",
         "state": {
           "branch": "latest",
-          "revision": "19aa8c1fc7120d50df987b7111f42d5024df3d54",
+          "revision": "1d04692697cb642bfebf6ad2dd99fe52649c3d6d",
           "version": null
         }
       }


### PR DESCRIPTION
While debugging failing builds I saw that WebRTC fails to download with a 404. For example, [see this build](https://github.com/matthewrfennell/Monal/actions/runs/33807386552/job/100820994970#step:8:140) (with `xcbeautify` disabled to see the full log).

I then discovered that WebRTC v151.0.0 (the version hashed in our Package.lock has been removed. See stasel/WebRTC#164.

Since we are not pinned to a version but a branch, bump to the latest version, v152.0.0.

I think this will help with #1703's failing build too.