### PR TITLE
Bump KSCrash to 2.6.0

### DIFF
--- a/Monal/Classes/HelperTools.h
+++ b/Monal/Classes/HelperTools.h
@@ -80,7 +80,7 @@ void swizzle(Class c, SEL orig, SEL new);
 +(NSData* _Nullable) convertLogmessageToJsonData:(DDLogMessage*) logMessage counter:(uint64_t*) counter andError:(NSError** _Nullable) error;
 +(void) initSystem;
 +(void) installExceptionHandler;
-+(int) pendingCrashreportCount;
++(NSInteger) pendingCrashreportCount;
 +(void) flushLogsWithTimeout:(double) timeout;
 +(BOOL) isAppSuspended;
 +(void) signalSuspension;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -2436,7 +2436,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     DDLogVerbose(@"KSCrash installing handler with callback: %p", crash_callback);
     KSCrashConfiguration* config = [KSCrashConfiguration new];
     config.installPath = [[HelperTools getContainerURLForPathComponents:@[@"CrashReports"]] path];
-    config.monitors = KSCrashMonitorTypeProductionSafe;      //KSCrashMonitorTypeAll
+    config.monitors = KSCrashMonitorTypeProductionSafe & (~KSCrashMonitorTypeWatchdog);       // no main thread watchdog
     //don't try to debug zombies if not in debug mode
 #ifndef DEBUG
     config.monitors = config.monitors & (~KSCrashMonitorTypeZombie);
@@ -2453,8 +2453,6 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     config.enableMemoryIntrospection = YES;
     config.addConsoleLogToReport = YES;
     config.printPreviousLogOnStartup = NO;     //debug kscrash itself?
-    config.enableSigTermMonitoring = YES;
-    config.deadlockWatchdogInterval = 0;       // no main thread watchdog
     config.reportStoreConfiguration.maxReportCount = 4;
     config.reportStoreConfiguration.reportCleanupPolicy = KSCrashReportCleanupPolicyAlways;     //KSCrashReportCleanupPolicyOnSuccess;
     //don't use the bundle names to store our crash reports which are different

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -257,7 +257,7 @@ static void addFilePathWithSize(const struct KSCrashReportWriter* _Nonnull write
     writer->addIntegerElement(writer, name_size, st.st_size);
 }
 
-static void crash_callback(const struct KSCrashReportWriter* _Nonnull writer)
+static void crash_callback(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter* _Nonnull writer)
 {
     //copy current logfile
     int logfileCopyRetval = asyncSafeCopyFile(_origLogfilePath, _logfilePath);
@@ -2444,9 +2444,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         DDLogWarn(@"Not installing crash handler: debugger is active!");
         config.monitors = KSCrashMonitorTypeManual;
     }
-    config.crashNotifyCallback = ^(const struct KSCrashReportWriter* _Nonnull writer) {
-        crash_callback(writer);
-    };
+    config.isWritingReportCallback = crash_callback;
     //this can trigger crashes on macos < 13 (e.g. mac catalyst < 16) (and possibly ios < 16)
     config.enableSwapCxaThrow = YES;
     config.enableQueueNameSearch = NO;      //this is not async safe and can crash :(

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -27,12 +27,6 @@
 #import <CommonCrypto/CommonHMAC.h>
 #import <MapKit/MapKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
-#import <KSCrash.h>
-#import <KSCrashConfiguration.h>
-#import <KSCrashC.h>
-//can not be imported, use extern declaration instead
-//#import <KSCrashReportStoreC+Private.h>
-extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 #import <monalxmpp/monalxmpp-Swift.h>
 #import <monalxmpp/hsluv.h>
 #import <monalxmpp/HelperTools.h>
@@ -72,6 +66,10 @@ extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 @import UniformTypeIdentifiers;
 @import QuickLookThumbnailing;
 @import SVGKit;
+//can not be imported, use extern declaration instead
+//from KSCrashReportStoreC+Private.h
+extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
+@import KSCrashRecording;
 
 @interface KSCrash()
 @property(nonatomic,readwrite,retain) NSString* basePath;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -259,6 +259,8 @@ static void addFilePathWithSize(const struct KSCrashReportWriter* _Nonnull write
 
 static void crash_callback(const KSCrash_ExceptionHandlingPlan *const _Nonnull plan, const struct KSCrashReportWriter* _Nonnull writer)
 {
+    if(plan->crashedDuringExceptionHandling)
+        return;
     //copy current logfile
     int logfileCopyRetval = asyncSafeCopyFile(_origLogfilePath, _logfilePath);
     int errnoLogfileCopy = errno;

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -2468,7 +2468,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         @"bundleName": nilWrapper([[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"]),
         @"appVersion": [self appBuildVersionInfoFor:MLVersionTypeLog],
     };
-    
+
     if([KSCrash.sharedInstance installWithConfiguration:config error:&error] == NO)
     {
         DDLogError(@"Failed to install KSCrash monitors, crash reporting is disabled now!");

--- a/Monal/Classes/HelperTools.m
+++ b/Monal/Classes/HelperTools.m
@@ -28,9 +28,10 @@
 #import <MapKit/MapKit.h>
 #import <MobileCoreServices/MobileCoreServices.h>
 #import <KSCrash.h>
+#import <KSCrashConfiguration.h>
 #import <KSCrashC.h>
 //can not be imported, use extern declaration instead
-//#import <KSCrash/Recording/KSCrashReportStore.h>
+//#import <KSCrashReportStoreC+Private.h>
 extern int64_t kscrs_getNextCrashReport(char* crashReportPathBuffer);
 #import <monalxmpp/monalxmpp-Swift.h>
 #import <monalxmpp/hsluv.h>
@@ -244,7 +245,7 @@ out_error:
     return -1;
 }
 
-static void addFilePathWithSize(const KSCrashReportWriter* writer, char* name, char* filePath)
+static void addFilePathWithSize(const struct KSCrashReportWriter* _Nonnull writer, char* name, char* filePath)
 {
     struct stat st;
     char name_size[64];
@@ -258,7 +259,7 @@ static void addFilePathWithSize(const KSCrashReportWriter* writer, char* name, c
     writer->addIntegerElement(writer, name_size, st.st_size);
 }
 
-static void crash_callback(const KSCrashReportWriter* writer)
+static void crash_callback(const struct KSCrashReportWriter* _Nonnull writer)
 {
     //copy current logfile
     int logfileCopyRetval = asyncSafeCopyFile(_origLogfilePath, _logfilePath);
@@ -683,10 +684,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     {
         [self configureLogging];
         //don't install KSCrash if the debugger is active
-        if(!isDebugerActive())
-            [self installCrashHandler];
-        else
-            DDLogWarn(@"Not installing crash handler: debugger is active!");
+        [self installCrashHandlerWithRecording:!isDebugerActive()];
         [self installExceptionHandler];
     }
     else
@@ -2384,17 +2382,21 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
         DDLogVerbose(@"File %@/%@", containerUrl, file);
 }
 
-+(int) pendingCrashreportCount
++(NSInteger) pendingCrashreportCount
 {
     KSCrash* handler = [KSCrash sharedInstance];
-    return handler.reportCount;
+    if(handler.reportStore == nil)
+        return 0;
+    return handler.reportStore.reportCount;
 }
 
 +(void) cleanupRawlogCrashcopies
 {
     NSError* error;
     KSCrash* handler = [KSCrash sharedInstance];
-    NSSet* reportIds = [NSSet setWithArray:[handler reportIDs]];
+    if(handler.reportStore == nil)
+        return;
+    NSSet* reportIds = [NSSet setWithArray:[handler.reportStore reportIDs]];
     NSString* reportpath = [[HelperTools getContainerURLForPathComponents:@[@"CrashReports", @"Reports"]] path];
     NSArray* directoryContentsReports = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:reportpath error:&error];
     if(error != nil)
@@ -2428,42 +2430,52 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     }
 }
 
-+(void) installCrashHandler
++(void) installCrashHandlerWithRecording:(BOOL) recordCrashes
 {
-    
+    NSError* error = nil;
     DDLogVerbose(@"KSCrash installing handler with callback: %p", crash_callback);
-    KSCrash* handler = [KSCrash sharedInstance];
-    handler.basePath = [[HelperTools getContainerURLForPathComponents:@[@"CrashReports"]] path];
-    handler.monitoring = KSCrashMonitorTypeProductionSafe;      //KSCrashMonitorTypeAll
+    KSCrashConfiguration* config = [KSCrashConfiguration new];
+    config.installPath = [[HelperTools getContainerURLForPathComponents:@[@"CrashReports"]] path];
+    config.monitors = KSCrashMonitorTypeProductionSafe;      //KSCrashMonitorTypeAll
     //don't try to debug zombies if not in debug mode
 #ifndef DEBUG
-    handler.monitoring = handler.monitoring & (~KSCrashMonitorTypeZombie);
+    config.monitors = config.monitors & (~KSCrashMonitorTypeZombie);
 #endif
-    handler.onCrash = crash_callback;
+    if(!recordCrashes)
+    {
+        DDLogWarn(@"Not installing crash handler: debugger is active!");
+        config.monitors = KSCrashMonitorTypeManual;
+    }
+    config.crashNotifyCallback = ^(const struct KSCrashReportWriter* _Nonnull writer) {
+        crash_callback(writer);
+    };
     //this can trigger crashes on macos < 13 (e.g. mac catalyst < 16) (and possibly ios < 16)
-#if !TARGET_OS_MACCATALYST
-    [handler enableSwapOfCxaThrow];
-#endif
-    handler.searchQueueNames = NO;      //this is not async safe and can crash :(
-    handler.introspectMemory = YES;
-    handler.addConsoleLogToReport = YES;
-    handler.printPreviousLog = NO;     //debug kscrash itself?
-    handler.demangleLanguages = KSCrashDemangleLanguageAll;
-    handler.maxReportCount = 4;
-    handler.deadlockWatchdogInterval = 0;       // no main thread watchdog
-    handler.userInfo = @{
+    config.enableSwapCxaThrow = YES;
+    config.enableQueueNameSearch = NO;      //this is not async safe and can crash :(
+    config.enableMemoryIntrospection = YES;
+    config.addConsoleLogToReport = YES;
+    config.printPreviousLogOnStartup = NO;     //debug kscrash itself?
+    config.enableSigTermMonitoring = YES;
+    config.deadlockWatchdogInterval = 0;       // no main thread watchdog
+    config.reportStoreConfiguration.maxReportCount = 4;
+    config.reportStoreConfiguration.reportCleanupPolicy = KSCrashReportCleanupPolicyAlways;     //KSCrashReportCleanupPolicyOnSuccess;
+    //don't use the bundle names to store our crash reports which are different
+    //in appex and mainapp use the lowlevel C api with dummy bundle name "UnifiedReport" instead
+    config.reportStoreConfiguration.appName = [NSString stringWithFormat:@"%s", _crashBundleName];
+    config.userInfoJSON = @{
         @"isAppex": bool2str([self isAppExtension]),
         @"processName": [[[NSBundle mainBundle] executablePath] lastPathComponent],
         @"bundleName": nilWrapper([[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"]),
         @"appVersion": [self appBuildVersionInfoFor:MLVersionTypeLog],
     };
-    //we can not use [KSCrash install] because this uses the bundle names to store our crash reports which are different
-    //in appex and mainapp use the lowlevel C api with dummy bundle name "UnifiedReport" instead
-    handler.monitoring = kscrash_install(_crashBundleName, handler.basePath.UTF8String);
-    if(handler.monitoring == KSCrashMonitorTypeNone)
+    
+    if([KSCrash.sharedInstance installWithConfiguration:config error:&error] == NO)
+    {
         DDLogError(@"Failed to install KSCrash monitors, crash reporting is disabled now!");
+        DDLogError(@"KSCrash reported install error: %@", error);
+    }
     else
-        DDLogInfo(@"Crash monitoring active now: %d", handler.monitoring);
+        DDLogInfo(@"Crash monitoring active now...");
     
     //KSCrash increments the id by one every new crash --> the next id used by kscrash will be this one
     _nextCrashId = kscrs_getNextCrashReport(NULL) + 1;
@@ -2475,7 +2487,7 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
     strncpy(_origProfilePath, profrawFilePath.UTF8String, sizeof(_profilePath)-1);
     _origProfilePath[sizeof(_origProfilePath)-1] = '\0';
     //use the same id for our logfile copy as for the main report (allows to delete all logfile copies for which no crash report exists)
-    snprintf(_profilePath, sizeof(_profilePath)-1, "%s/Reports/%s-profile-%016llx.profraw", handler.basePath.UTF8String, _crashBundleName, _nextCrashId);
+    snprintf(_profilePath, sizeof(_profilePath)-1, "%s/Reports/%s-profile-%016llx.profraw", config.installPath.UTF8String, _crashBundleName, _nextCrashId);
     _profilePath[sizeof(_profilePath)-1] = '\0';
     DDLogVerbose(@"KSCrash: _origProfilePath=%s, _profilePath=%s", _origProfilePath, _profilePath);
     
@@ -2492,13 +2504,13 @@ static void notification_center_logging(CFNotificationCenterRef center, void* ob
 
 +(void) updateCurrentLogfilePath:(NSString*) logfilePath
 {
-    KSCrash* handler = [KSCrash sharedInstance];
+    NSString* basePath = [[HelperTools getContainerURLForPathComponents:@[@"CrashReports"]] path];
     
     //store data globally for later retrieval by our crash_callback() (_origLogfilePath and _logfilePath)
     strncpy(_origLogfilePath, logfilePath.UTF8String, sizeof(_logfilePath)-1);
     _origLogfilePath[sizeof(_origLogfilePath)-1] = '\0';
     //use the same id for our logfile copy as for the main report (allows to delete all logfile copies for which no crash report exists)
-    snprintf(_logfilePath, sizeof(_logfilePath)-1, "%s/Reports/%s-log-%016llx.rawlog", handler.basePath.UTF8String, _crashBundleName, _nextCrashId);
+    snprintf(_logfilePath, sizeof(_logfilePath)-1, "%s/Reports/%s-log-%016llx.rawlog", basePath.UTF8String, _crashBundleName, _nextCrashId);
     _logfilePath[sizeof(_logfilePath)-1] = '\0';
     DDLogVerbose(@"KSCrash: _origLogfilePath=%s, _logfilePath=%s", _origLogfilePath, _logfilePath);
 }

--- a/Monal/Classes/MLCrashReporter.m
+++ b/Monal/Classes/MLCrashReporter.m
@@ -7,23 +7,15 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <KSCrash.h>
-#import <KSNSErrorHelper.h>
-#import <KSCrashReport.h>
-#import <KSCrashReportFilterBasic.h>
-#import <KSCrashReportFilterJSON.h>
-#import <KSCrashReportFilterStringify.h>
-#import <KSCrashReportFilterAppleFmt.h>
-#import <KSCrashReportFilterGZip.h>
-#import <KSCrashReportFields.h>
-#import <KSCrashReportFilterDemangle.h>
-#import <KSCrashReportFilterDoctor.h>
-#import <KSCrashReportFilterAlert.h>
 #import <MessageUI/MessageUI.h>
 #import <monalxmpp/MLConstants.h>
 #import <monalxmpp/HelperTools.h>
 #import "MonalAppDelegate.h"
 #import "MLCrashReporter.h"
+
+@import KSCrashCore;
+@import KSCrashDemangleFilter;
+@import KSCrashFilters;
 
 #define PART_SEPARATOR_FORMAT "\n\n-------- d049d576-9bf0-47dd-839f-dee6b07c1df9 -------- %@ -------- d049d576-9bf0-47dd-839f-dee6b07c1df9 --------\n\n"
 

--- a/Monal/Classes/MLCrashReporter.m
+++ b/Monal/Classes/MLCrashReporter.m
@@ -99,7 +99,7 @@
     DDLogVerbose(@"Trying to send crash reports...");
     [KSCrash.sharedInstance.reportStore sendAllReportsWithCompletion:^(NSArray* reports, NSError* error) {
         if(error == nil)
-            DDLogWarn(@"Sent %d reports", (int)[reports count]);
+            DDLogWarn(@"Sent %lu reports", [reports count]);
         else
             DDLogError(@"Failed to send reports: %@", error);
     }];

--- a/Monal/Classes/MLCrashReporter.m
+++ b/Monal/Classes/MLCrashReporter.m
@@ -8,12 +8,17 @@
 
 #import <Foundation/Foundation.h>
 #import <KSCrash.h>
+#import <KSNSErrorHelper.h>
+#import <KSCrashReport.h>
 #import <KSCrashReportFilterBasic.h>
 #import <KSCrashReportFilterJSON.h>
+#import <KSCrashReportFilterStringify.h>
 #import <KSCrashReportFilterAppleFmt.h>
 #import <KSCrashReportFilterGZip.h>
 #import <KSCrashReportFields.h>
-#import <NSError+SimpleConstructor.h>
+#import <KSCrashReportFilterDemangle.h>
+#import <KSCrashReportFilterDoctor.h>
+#import <KSCrashReportFilterAlert.h>
 #import <MessageUI/MessageUI.h>
 #import <monalxmpp/MLConstants.h>
 #import <monalxmpp/HelperTools.h>
@@ -22,24 +27,16 @@
 
 #define PART_SEPARATOR_FORMAT "\n\n-------- d049d576-9bf0-47dd-839f-dee6b07c1df9 -------- %@ -------- d049d576-9bf0-47dd-839f-dee6b07c1df9 --------\n\n"
 
-@interface KSCrashReportFilterStartupAlert: NSObject <KSCrashReportFilter>
-+(instancetype) filter;
+@interface KSCrashReportFilterMLEmpty: NSObject <KSCrashReportFilter>
 @end
 
-@interface KSCrashReportFilterEmpty: NSObject <KSCrashReportFilter>
-+(instancetype) filter;
+@interface KSCrashReportFilterMLAddAuxInfo : NSObject <KSCrashReportFilter>
 @end
 
-@interface KSCrashReportFilterAddAuxInfo : NSObject <KSCrashReportFilter>
-+(instancetype) filter;
+@interface KSCrashReportFilterMLAddMLLogfile : NSObject <KSCrashReportFilter>
 @end
 
-@interface KSCrashReportFilterAddMLLogfile : NSObject <KSCrashReportFilter>
-+(instancetype) filter;
-@end
-
-@interface KSCrashReportFilterAddProfraw : NSObject <KSCrashReportFilter>
-+(instancetype) filter;
+@interface KSCrashReportFilterMLAddProfraw : NSObject <KSCrashReportFilter>
 @end
 
 
@@ -54,48 +51,54 @@
 +(void) reportPendingCrashes
 {
     //send out pending KSCrash reports
-    KSCrash* handler = [KSCrash sharedInstance];
-    handler.deleteBehaviorAfterSendAll = KSCDeleteAlways;       //KSCDeleteNever
-    id<KSCrashReportFilter> dummyFilter = [KSCrashReportFilterEmpty filter];
+    id<KSCrashReportFilter> alertFilter = [[KSCrashReportFilterAlert alloc]
+        initWithTitle:NSLocalizedString(@"Crash Detected", @"Crash reporting")
+        message:NSLocalizedString(@"The app crashed last time it was launched. Send a crash report? This crash report will likely contain privacy related data (messages, contacts etc.). We will only use it to debug your crash and delete it afterwards!", @"Crash reporting")
+        yesAnswer:NSLocalizedString(@"Sure, send it!", @"Crash reporting")
+        noAnswer:NSLocalizedString(@"No, thanks", @"Crash reporting")
+    ];
+    id<KSCrashReportFilter> dummyFilter = [KSCrashReportFilterMLEmpty new];
     NSString* dummyFilterName = @"dummy not printed";
-    id<KSCrashReportFilter> auxInfoFilter = [KSCrashReportFilterAddAuxInfo filter];
+    id<KSCrashReportFilter> auxInfoFilter = [KSCrashReportFilterMLAddAuxInfo new];
     NSString* auxInfoName = @"AUX Info (*.txt)";
-    id<KSCrashReportFilter> appleFilter = [KSCrashReportFilterAppleFmt filterWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide];
+    id<KSCrashReportFilter> appleFilter = [[KSCrashReportFilterAppleFmt alloc] initWithReportStyle:KSAppleReportStyleSymbolicatedSideBySide];
     NSString* appleName = @"Apple Report (*.crash)";
-    NSArray<id<KSCrashReportFilter>>* jsonFilter = @[[KSCrashReportFilterJSONEncode filterWithOptions:KSJSONEncodeOptionPretty], [KSCrashReportFilterDataToString filter]];
+    id<KSCrashReportFilter> jsonFilter = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        [[KSCrashReportFilterJSONEncode alloc] initWithOptions:KSJSONEncodeOptionSorted | KSJSONEncodeOptionPretty],
+        [KSCrashReportFilterStringify new]
+    ]];
     NSString* jsonName = @"JSON Report (*.json)";
-    id<KSCrashReportFilter> logfileFilter = [KSCrashReportFilterAddMLLogfile filter];
+    id<KSCrashReportFilter> logfileFilter = [KSCrashReportFilterMLAddMLLogfile new];
     NSString* logfileName = @"Logfile (*.rawlog.gz)";
-    id<KSCrashReportFilter> profrawFilter = [KSCrashReportFilterAddProfraw filter];
+    id<KSCrashReportFilter> profrawFilter = [KSCrashReportFilterMLAddProfraw new];
     NSString* profrawName = @"Profile (*.profraw)";
-    handler.sink = [KSCrashReportFilterPipeline filterWithFilters:
-                        [KSCrashReportFilterStartupAlert filter],
-                        [KSCrashReportFilterCombine filterWithFiltersAndKeys:
-                            dummyFilter, dummyFilterName,       //this dummy is needed to make the filter framework print the title of our aux data
-                            auxInfoFilter, auxInfoName,
-                            appleFilter, appleName,
-                            jsonFilter, jsonName,
-                            logfileFilter, logfileName,
-                            profrawFilter, profrawName,
-                            nil
-                        ],
-                        [KSCrashReportFilterConcatenate filterWithSeparatorFmt:@PART_SEPARATOR_FORMAT keys:
-                            dummyFilterName,
-                            auxInfoName,
-                            appleName,
-                            jsonName,
-                            logfileName,
-                            profrawName,
-                            nil
-                        ],
-                        [KSCrashReportFilterStringToData filter],
-                        [KSCrashReportFilterGZipCompress filterWithCompressionLevel:-1],
-                        [[self alloc] init],           //add this class as filter to send out all stuff via mail
-                        nil
-                   ];
+    KSCrash.sharedInstance.reportStore.sink = [[KSCrashReportFilterPipeline alloc] initWithFilters:@[
+        alertFilter,
+        [KSCrashReportFilterDemangle new],
+        [KSCrashReportFilterDoctor new],
+        [[KSCrashReportFilterCombine alloc] initWithFilters:@{
+            dummyFilterName: dummyFilter,       //this dummy is needed to make the filter framework print the title of our aux data
+            auxInfoName: auxInfoFilter,
+            appleName: appleFilter,
+            jsonName: jsonFilter,
+            logfileName: logfileFilter,
+            profrawName: profrawFilter,
+        }],
+        [[KSCrashReportFilterConcatenate alloc] initWithSeparatorFmt:@PART_SEPARATOR_FORMAT keys:@[
+            dummyFilterName,
+            auxInfoName,
+            appleName,
+            jsonName,
+            logfileName,
+            profrawName,
+        ]],
+        [KSCrashReportFilterStringToData new],
+        [[KSCrashReportFilterGZipCompress alloc] initWithCompressionLevel:KSCrashReportCompressionLevelDefault],
+        [self new],                             //add this class as filter to send out all stuff via mail
+    ]];
     DDLogVerbose(@"Trying to send crash reports...");
-    [handler sendAllReportsWithCompletion:^(NSArray* reports, BOOL completed, NSError* error){
-        if(completed)
+    [KSCrash.sharedInstance.reportStore sendAllReportsWithCompletion:^(NSArray* reports, NSError* error) {
+        if(error == nil)
             DDLogWarn(@"Sent %d reports", (int)[reports count]);
         else
             DDLogError(@"Failed to send reports: %@", error);
@@ -119,10 +122,7 @@
                 DDLogWarn(@"Writing report %d to file: %@", i, path);
                 [report writeToFile:path atomically:YES];
             }
-        kscrash_callCompletion(onCompletion, reports, YES,
-                                 [NSError errorWithDomain:[[self class] description]
-                                                     code:0
-                                              description:@"Crashreports written to simulator container..."]);
+        kscrash_callCompletion(onCompletion, reports, nil);
         return;
 #else
         UIAlertController* alertController = [UIAlertController alertControllerWithTitle:NSLocalizedString(@"Email Error", @"Crash report error dialog")
@@ -134,8 +134,8 @@
         [alertController addAction:okAction];
         [[(MonalAppDelegate*)[[UIApplication sharedApplication] delegate] getTopViewController] presentViewController:alertController animated:YES completion:NULL];
 
-        kscrash_callCompletion(onCompletion, reports, NO,
-                                 [NSError errorWithDomain:[[self class] description]
+        kscrash_callCompletion(onCompletion, reports,
+                                 [KSNSErrorHelper errorWithDomain:[[self class] description]
                                                      code:0
                                               description:NSLocalizedString(@"E-Mail not enabled on device", @"Crash report error dialog")]);
         return;
@@ -150,16 +150,18 @@
     mailController.mailComposeDelegate = self;
     [mailController setToRecipients:@[@"crash@monal-im.org"]];
     [mailController setSubject:@"Crash Reports"];
-    [mailController setMessageBody:@"> Please fill in your last actions that led to this crash:\n" isHTML:NO];
+    [mailController setMessageBody:@"Please fill in your last actions that led to this crash:\n" isHTML:NO];
     int i = 1;
-    for(NSData* report in reports)
-        if(![report isKindOfClass:[NSData class]])
-            DDLogError(@"Report was of unsupported data type %@", [report class]);
+    for(id<KSCrashReport> report_ in reports)
+    {
+        if(![report_ isKindOfClass:[KSCrashReportData class]])
+            DDLogError(@"Report was of unsupported data type %@", [report_ class]);
         else
         {
             DDLogVerbose(@"Adding mail attachment...");
-            [mailController addAttachmentData:report mimeType:@"binary" fileName:[NSString stringWithFormat:@"CrashReport-%d.mcrash.gz", i++]];
+            [mailController addAttachmentData:[report_ untypedValue] mimeType:@"binary" fileName:[NSString stringWithFormat:@"CrashReport-%d.mcrash.gz", i++]];
         }
+    }
     
     dispatch_async(dispatch_get_main_queue(), ^{
         DDLogVerbose(@"Presenting MFMailComposeViewController...");
@@ -182,28 +184,28 @@
         {
             case MFMailComposeResultSent:
                 DDLogInfo(@"Crash report send result: MFMailComposeResultSent");
-                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, YES, nil);
+                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, nil);
                 break;
             case MFMailComposeResultSaved:
                 DDLogInfo(@"Crash report send result: MFMailComposeResultSaved");
-                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, YES, nil);
+                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, nil);
                 break;
             case MFMailComposeResultCancelled:
                 DDLogInfo(@"Crash report send result: MFMailComposeResultCancelled");
-                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, NO,
-                                        [NSError errorWithDomain:[[self class] description]
+                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports,
+                                        [KSNSErrorHelper errorWithDomain:[[self class] description]
                                                             code:0
                                                     description:@"User cancelled"]);
                 break;
             case MFMailComposeResultFailed:
                 DDLogInfo(@"Crash report send result: MFMailComposeResultFailed");
-                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, NO, error);
+                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, error);
                 break;
             default:
             {
                 DDLogInfo(@"Crash report send result: unknown");
-                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports, NO,
-                                        [NSError errorWithDomain:[[self class] description]
+                kscrash_callCompletion(self.kscrashCompletion, self.kscrashReports,
+                                        [KSNSErrorHelper errorWithDomain:[[self class] description]
                                                             code:0
                                                     description:@"Unknown MFMailComposeResult: %d", result]);
             }
@@ -216,70 +218,29 @@
 
 @end
 
-@implementation KSCrashReportFilterStartupAlert
-
-+(instancetype) filter
-{
-    return [[self alloc] init];
-}
+@implementation KSCrashReportFilterMLEmpty
 
 -(void) filterReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    NSString* title = NSLocalizedString(@"Crash Detected", @"Crash reporting");
-    NSString* message = NSLocalizedString(@"The app crashed last time it was launched. Send a crash report? This crash report will contain privacy related data. We will only use it to debug your crash and delete it afterwards!", @"Crash reporting");
-    NSString* yesAnswer = NSLocalizedString(@"Sure, send it!", @"Crash reporting");
-    NSString* noAnswer = NSLocalizedString(@"No, thanks", @"Crash reporting");
-    
-    DDLogVerbose(@"KSCrashReportFilterStartupAlert started...");
-    dispatch_async(dispatch_get_main_queue(), ^{
-        UIAlertController* alertController = [UIAlertController alertControllerWithTitle:title message:message preferredStyle:UIAlertControllerStyleAlert];
-        UIAlertAction* yesAction = [UIAlertAction actionWithTitle:yesAnswer style:UIAlertActionStyleDefault handler:^(__unused UIAlertAction* _Nonnull action) {
-            kscrash_callCompletion(onCompletion, reports, YES, nil);
-        }];
-        UIAlertAction* noAction = [UIAlertAction actionWithTitle:noAnswer style:UIAlertActionStyleCancel handler:^(__unused UIAlertAction* _Nonnull action) {
-            kscrash_callCompletion(onCompletion, reports, NO, nil);
-        }];
-        [alertController addAction:yesAction];
-        [alertController addAction:noAction];
-        [[(MonalAppDelegate*)[[UIApplication sharedApplication] delegate] getTopViewController] presentViewController:alertController animated:YES completion:NULL];
-    });
-    DDLogVerbose(@"KSCrashReportFilterStartupAlert finished...");
-}
-
-@end
-
-@implementation KSCrashReportFilterEmpty
-
-+(instancetype) filter
-{
-    return [[self alloc] init];
-}
-
--(void) filterReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
-{
-    DDLogVerbose(@"KSCrashReportFilterEmpty started...");
+    DDLogVerbose(@"KSCrashReportFilterMLEmpty started...");
     NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
     for(NSUInteger i = 0; i < reports.count; i++)
-        [filteredReports addObject:@""];
-    DDLogVerbose(@"KSCrashReportFilterEmpty finished...");
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
+        [filteredReports addObject:[KSCrashReportString reportWithValue:@""]];
+    DDLogVerbose(@"KSCrashReportFilterMLEmpty finished...");
+    kscrash_callCompletion(onCompletion, filteredReports, nil);
 }
 
 @end
 
-@implementation KSCrashReportFilterAddAuxInfo
-
-+(instancetype) filter
-{
-    return [[self alloc] init];
-}
+@implementation KSCrashReportFilterMLAddAuxInfo
 
 -(void) filterReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    DDLogVerbose(@"KSCrashReportFilterAddAuxInfo started...");
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    DDLogVerbose(@"KSCrashReportFilterMLAddAuxInfo started...");
+    NSMutableArray<id<KSCrashReport>>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(id<KSCrashReport> report_ in reports)
     {
+        NSDictionary* report = [report_ untypedValue];
         NSMutableString* auxData = [NSMutableString new];
         
         //add version of monal reporting this crash
@@ -305,27 +266,23 @@
         if([crashInfos length] > 0)
             [auxData appendString:[NSString stringWithFormat:@"\nAvailable crash info messages:\n\n%@", crashInfos]];
         
-        [filteredReports addObject:auxData];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:auxData]];
     }
-    DDLogVerbose(@"KSCrashReportFilterAddAuxInfo finished...");
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
+    DDLogVerbose(@"KSCrashReportFilterMLAddAuxInfo finished...");
+    kscrash_callCompletion(onCompletion, filteredReports, nil);
 }
 
 @end
 
-@implementation KSCrashReportFilterAddMLLogfile
-
-+(instancetype) filter
-{
-    return [[self alloc] init];
-}
+@implementation KSCrashReportFilterMLAddMLLogfile
 
 -(void) filterReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    DDLogVerbose(@"KSCrashReportFilterAddMLLogfile started...");
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    DDLogVerbose(@"KSCrashReportFilterMLAddMLLogfile started...");
+    NSMutableArray<id<KSCrashReport>>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(id<KSCrashReport> report_ in reports)
     {
+        NSDictionary* report = [report_ untypedValue];
         NSString* logfileCopy = report[@"user"][@"logfileCopy"];
         NSData* logfileData = [NSData new];
         if(logfileCopy != nil)
@@ -341,27 +298,23 @@
                 logfileData = [NSData new];
         }
         DDLogVerbose(@"Converting logfile data to hex...");
-        [filteredReports addObject:[HelperTools hexadecimalString:logfileData]];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:[HelperTools hexadecimalString:logfileData]]];
     }
-    DDLogVerbose(@"KSCrashReportFilterAddMLLogfile finished...");
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
+    DDLogVerbose(@"KSCrashReportFilterMLAddMLLogfile finished...");
+    kscrash_callCompletion(onCompletion, filteredReports, nil);
 }
 
 @end
 
-@implementation KSCrashReportFilterAddProfraw
-
-+(instancetype) filter
-{
-    return [[self alloc] init];
-}
+@implementation KSCrashReportFilterMLAddProfraw
 
 -(void) filterReports:(NSArray*) reports onCompletion:(KSCrashReportFilterCompletion) onCompletion
 {
-    DDLogVerbose(@"KSCrashReportFilterAddProfraw started...");
-    NSMutableArray* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
-    for(NSDictionary* report in reports)
+    DDLogVerbose(@"KSCrashReportFilterMLAddProfraw started...");
+    NSMutableArray<id<KSCrashReport>>* filteredReports = [NSMutableArray arrayWithCapacity:[reports count]];
+    for(id<KSCrashReport> report_ in reports)
     {
+        NSDictionary* report = [report_ untypedValue];
         NSString* profileCopy = report[@"user"][@"profileCopy"];
         NSData* profileData = [NSData new];
         if(profileCopy != nil)
@@ -377,10 +330,10 @@
                 profileData = [NSData new];
         }
         DDLogVerbose(@"Converting profile data to hex...");
-        [filteredReports addObject:[HelperTools hexadecimalString:profileData]];
+        [filteredReports addObject:[KSCrashReportString reportWithValue:[HelperTools hexadecimalString:profileData]]];
     }
     DDLogVerbose(@"KSCrashReportFilterAddProfile finished...");
-    kscrash_callCompletion(onCompletion, filteredReports, YES, nil);
+    kscrash_callCompletion(onCompletion, filteredReports, nil);
 }
 
 @end

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -1686,19 +1686,19 @@ typedef void (^pushCompletion)(UIBackgroundFetchResult result);
     //this method is called by didFinishLaunchingWithOptions: and our ipc handler (but this is currently unused)
     //we block the reconnect while the crash reports have not been processed yet, to avoid a crash loop preventing
     //the user from sending the crash report
-    int count = [HelperTools pendingCrashreportCount];
+    NSInteger count = [HelperTools pendingCrashreportCount];
     if(count > 0 && options == nil && applicationState != UIApplicationStateBackground)
     {
         [MLXMPPManager sharedInstance].isConnectBlocked = YES;
-        DDLogWarn(@"Blocking connect of connectIfNecessary: crash reports still pending: %d, retrying in 1 second...", count);
+        DDLogWarn(@"Blocking connect of connectIfNecessary: crash reports still pending: %ld, retrying in 1 second...", (long)count);
         cancelCurrentTimer = createTimer(1.0, (^{ [self connectIfNecessaryWithOptions:options]; }));
     }
     else
     {
         [MLXMPPManager sharedInstance].isConnectBlocked = NO;
-        DDLogInfo(@"Now unblocking connect of connectIfNecessary (applicationState%@UIApplicationStateBackground, count=%d, options=%@)...",
+        DDLogInfo(@"Now unblocking connect of connectIfNecessary (applicationState%@UIApplicationStateBackground, count=%ld, options=%@)...",
                     applicationState == UIApplicationStateBackground ? @"==" : @"!=",
-                    count,
+                    (long)count,
                     options
         );
         cancelEmergencyTimer();

--- a/Monal/Classes/MonalAppDelegate.m
+++ b/Monal/Classes/MonalAppDelegate.m
@@ -1690,7 +1690,7 @@ typedef void (^pushCompletion)(UIBackgroundFetchResult result);
     if(count > 0 && options == nil && applicationState != UIApplicationStateBackground)
     {
         [MLXMPPManager sharedInstance].isConnectBlocked = YES;
-        DDLogWarn(@"Blocking connect of connectIfNecessary: crash reports still pending: %ld, retrying in 1 second...", (long)count);
+        DDLogWarn(@"Blocking connect of connectIfNecessary: crash reports still pending: %ld, retrying in 1 second...", count);
         cancelCurrentTimer = createTimer(1.0, (^{ [self connectIfNecessaryWithOptions:options]; }));
     }
     else
@@ -1698,7 +1698,7 @@ typedef void (^pushCompletion)(UIBackgroundFetchResult result);
         [MLXMPPManager sharedInstance].isConnectBlocked = NO;
         DDLogInfo(@"Now unblocking connect of connectIfNecessary (applicationState%@UIApplicationStateBackground, count=%ld, options=%@)...",
                     applicationState == UIApplicationStateBackground ? @"==" : @"!=",
-                    (long)count,
+                    count,
                     options
         );
         cancelEmergencyTimer();

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -97,13 +97,15 @@
 		3424B4EE2D232C0F009F6503 /* MLCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 848717F2295ED64500B8D288 /* MLCall.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3424B4EF2D232C14009F6503 /* HelperTools.h in Headers */ = {isa = PBXBuildFile; fileRef = C1AAC3E224B5EF4100BB15D6 /* HelperTools.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3434775E302FC074001FCAE3 /* ASN1Decoder in Frameworks */ = {isa = PBXBuildFile; productRef = 3434775D302FC074001FCAE3 /* ASN1Decoder */; };
-		344B50C03030B7B80022BD6A /* KSCrash in Frameworks */ = {isa = PBXBuildFile; productRef = 344B50BF3030B7B80022BD6A /* KSCrash */; };
 		34660BA63043057100FDA777 /* SAMKeychain in Frameworks */ = {isa = PBXBuildFile; productRef = 34660BA53043057100FDA777 /* SAMKeychain */; };
 		34745126302F641600F23210 /* NotificationBannerSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 34745125302F641600F23210 /* NotificationBannerSwift */; };
 		34A6FD66304EAEE50092A382 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26470F511835C4080069E3E0 /* Media.xcassets */; };
 		34A6FD67304EB6CC0092A382 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 26B2A4BA1B73061400272E63 /* Images.xcassets */; };
+		34942A07304C476200CA739F /* Filters in Frameworks */ = {isa = PBXBuildFile; productRef = 34942A06304C476200CA739F /* Filters */; };
+		34942A09304C478300CA739F /* DemangleFilter in Frameworks */ = {isa = PBXBuildFile; productRef = 34942A08304C478300CA739F /* DemangleFilter */; };
 		34BC08122C5E9BE30099FB85 /* ContentUnavailableShimView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34BC08112C5E9BE30099FB85 /* ContentUnavailableShimView.swift */; };
 		34C9CAA430293B5E00A87694 /* HelperToolsTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C9CAA330293B5E00A87694 /* HelperToolsTest.swift */; };
+		34E26BC2304C399F00287300 /* Recording in Frameworks */ = {isa = PBXBuildFile; productRef = 34E26BC1304C399F00287300 /* Recording */; };
 		34E58B4B2C68E7BC009A1634 /* ContactsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E58B4A2C68E7BC009A1634 /* ContactsView.swift */; };
 		34F978CF303B90CB002029CF /* CSQLite+MonalTraits in Frameworks */ = {isa = PBXBuildFile; productRef = 34F978CE303B90CB002029CF /* CSQLite+MonalTraits */; };
 		38720923251EDE07001837EB /* MLXEPSlashMeHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 38720921251EDE07001837EB /* MLXEPSlashMeHandler.m */; };
@@ -907,17 +909,19 @@
 			buildActionMask = 2147483647;
 			files = (
 				34660BA63043057100FDA777 /* SAMKeychain in Frameworks */,
+				34942A09304C478300CA739F /* DemangleFilter in Frameworks */,
 				34F978CF303B90CB002029CF /* CSQLite+MonalTraits in Frameworks */,
 				84F632F02F80AAF900A59209 /* SVGKit in Frameworks */,
 				84F632EB2F7F3EA300A59209 /* OrderedCollections in Frameworks */,
 				849ADF3F2BACF0360009BCD7 /* CocoaLumberjack in Frameworks */,
 				BE8B63D2491B1E5582965A8F /* Pods_monalxmpp.framework in Frameworks */,
+				34E26BC2304C399F00287300 /* Recording in Frameworks */,
 				84F632E72F7F3EA300A59209 /* Collections in Frameworks */,
 				3434775E302FC074001FCAE3 /* ASN1Decoder in Frameworks */,
-				344B50C03030B7B80022BD6A /* KSCrash in Frameworks */,
 				849ADF412BACF0360009BCD7 /* CocoaLumberjackSwift in Frameworks */,
 				84F632E52F7F3EA300A59209 /* BitCollections in Frameworks */,
 				84F632E92F7F3EA300A59209 /* HashTreeCollections in Frameworks */,
+				34942A07304C476200CA739F /* Filters in Frameworks */,
 				849ADF432BACF0360009BCD7 /* CocoaLumberjackSwiftLogBackend in Frameworks */,
 				8414AE002A7ABC4300EFFCCC /* LibMonalRustSwiftBridge in Frameworks */,
 			);
@@ -1765,9 +1769,11 @@
 				84F632EA2F7F3EA300A59209 /* OrderedCollections */,
 				84F632EF2F80AAF900A59209 /* SVGKit */,
 				3434775D302FC074001FCAE3 /* ASN1Decoder */,
-				344B50BF3030B7B80022BD6A /* KSCrash */,
 				34F978CE303B90CB002029CF /* CSQLite+MonalTraits */,
 				34660BA53043057100FDA777 /* SAMKeychain */,
+				34E26BC1304C399F00287300 /* Recording */,
+				34942A06304C476200CA739F /* Filters */,
+				34942A08304C478300CA739F /* DemangleFilter */,
 			);
 			productName = monalxmpp;
 			productReference = 26CC579223A0867400ABB92A /* monalxmpp.framework */;
@@ -4889,8 +4895,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kstenerud/KSCrash";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.17.7;
+				kind = exactVersion;
+				version = 2.0.0;
 			};
 		};
 		34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */ = {
@@ -4994,10 +5000,6 @@
 			package = 3434775C302FC074001FCAE3 /* XCRemoteSwiftPackageReference "ASN1Decoder" */;
 			productName = ASN1Decoder;
 		};
-		344B50BF3030B7B80022BD6A /* KSCrash */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = KSCrash;
-		};
 		34660BA53043057100FDA777 /* SAMKeychain */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */;
@@ -5007,6 +5009,21 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 34745124302F641600F23210 /* XCRemoteSwiftPackageReference "NotificationBanner" */;
 			productName = NotificationBannerSwift;
+		};
+		34942A06304C476200CA739F /* Filters */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 344A829F3030C76B009AAC5D /* XCRemoteSwiftPackageReference "KSCrash" */;
+			productName = Filters;
+		};
+		34942A08304C478300CA739F /* DemangleFilter */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 344A829F3030C76B009AAC5D /* XCRemoteSwiftPackageReference "KSCrash" */;
+			productName = DemangleFilter;
+		};
+		34E26BC1304C399F00287300 /* Recording */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 344A829F3030C76B009AAC5D /* XCRemoteSwiftPackageReference "KSCrash" */;
+			productName = Recording;
 		};
 		34F978CE303B90CB002029CF /* CSQLite+MonalTraits */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -4895,8 +4895,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kstenerud/KSCrash";
 			requirement = {
-				kind = upToNextMinorVersion;
-				minimumVersion = 2.5.0;
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.6.0;
 			};
 		};
 		34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */ = {

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -4895,8 +4895,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/kstenerud/KSCrash";
 			requirement = {
-				kind = exactVersion;
-				version = 2.0.0;
+				kind = upToNextMinorVersion;
+				minimumVersion = 2.3.0;
 			};
 		};
 		34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */ = {

--- a/Monal/Monal.xcodeproj/project.pbxproj
+++ b/Monal/Monal.xcodeproj/project.pbxproj
@@ -4896,7 +4896,7 @@
 			repositoryURL = "https://github.com/kstenerud/KSCrash";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 2.3.0;
+				minimumVersion = 2.5.0;
 			};
 		};
 		34660BA43043057100FDA777 /* XCRemoteSwiftPackageReference "SAMKeychain" */ = {

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/kstenerud/KSCrash",
         "state": {
           "branch": null,
-          "revision": "4a8b8e2155449fd2ffdb61f6b534db9f0655dbb5",
-          "version": "2.3.0"
+          "revision": "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
+          "version": "2.5.1"
         }
       },
       {

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/kstenerud/KSCrash",
         "state": {
           "branch": null,
-          "revision": "73c793d1b8efac9e0d911ca96f347c5192ec2a52",
-          "version": "1.17.7"
+          "revision": "b87a3ef5b0b84e2a34a546b9836813756cd362a9",
+          "version": "2.0.0"
         }
       },
       {

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/kstenerud/KSCrash",
         "state": {
           "branch": null,
-          "revision": "b87a3ef5b0b84e2a34a546b9836813756cd362a9",
-          "version": "2.0.0"
+          "revision": "4a8b8e2155449fd2ffdb61f6b534db9f0655dbb5",
+          "version": "2.3.0"
         }
       },
       {

--- a/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Monal/Monal.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/kstenerud/KSCrash",
         "state": {
           "branch": null,
-          "revision": "95a8895d75f3c22aa9ad9f2a15d2fbd97b0a55e2",
-          "version": "2.5.1"
+          "revision": "3f77f379c2db001e0c261c2a51b7e2b115d31f91",
+          "version": "2.6.0"
         }
       },
       {


### PR DESCRIPTION
This brings us fully up-to-date with upstream.

https://github.com/user-attachments/assets/3d6f9579-ad92-4f0c-9042-da01b9a991eb

I initially only bumped up to `2.5.1` as I thought that the crash handler was broken beyond there. It turns out this was because I was testing it wrong :)

KScrash recently updated to not trigger crash reports on `SIGINT`. When testing initially, I would run from XCode, trigger a crash, see it get suspended in XCode and then re-run from there. It turns out that this sends `SIGINT` under the hood, so in `2.6.0`, the library was deliberately ignoring these signals from XCode.

When testing without XCode, by running the compiled target directly (as in the video), I was able to observe the correct behaviour in clean exit and crash scenarios.